### PR TITLE
change resetKinesisVideoConnection to terminate all active upload han…

### DIFF
--- a/src/client/include/com/amazonaws/kinesis/video/client/Include.h
+++ b/src/client/include/com/amazonaws/kinesis/video/client/Include.h
@@ -185,15 +185,17 @@ extern "C" {
 #define STATUS_MAX_FRAME_TIMESTAMP_DELTA_BETWEEN_TRACKS_EXCEEDED                    STATUS_CLIENT_BASE + 0x00000085
 #define STATUS_STREAM_SHUTTING_DOWN                                                 STATUS_CLIENT_BASE + 0x00000086
 #define STATUS_CLIENT_SHUTTING_DOWN                                                 STATUS_CLIENT_BASE + 0x00000087
+#define STATUS_PUTMEDIA_LAST_PERSIST_ACK_NOT_RECEIVED								STATUS_CLIENT_BASE + 0x00000088
 
-#define IS_RECOVERABLE_ERROR(error)     ((error) == STATUS_ACK_ERR_INVALID_MKV_DATA ||          \
-                                        (error) == STATUS_ACK_ERR_FRAGMENT_ARCHIVAL_ERROR ||    \
-                                        (error) == STATUS_INVALID_ACK_KEY_START ||              \
-                                        (error) == STATUS_INVALID_ACK_DUPLICATE_KEY_NAME ||     \
-                                        (error) == STATUS_INVALID_ACK_INVALID_VALUE_START ||    \
-                                        (error) == STATUS_INVALID_ACK_INVALID_VALUE_END ||      \
-                                        (error) == STATUS_ACK_TIMESTAMP_NOT_IN_VIEW_WINDOW ||   \
-                                        (error) == STATUS_ACK_ERR_FRAGMENT_DURATION_REACHED)    \
+#define IS_RECOVERABLE_ERROR(error)     ((error) == STATUS_ACK_ERR_INVALID_MKV_DATA ||          	\
+                                        (error) == STATUS_ACK_ERR_FRAGMENT_ARCHIVAL_ERROR ||    	\
+                                        (error) == STATUS_INVALID_ACK_KEY_START ||              	\
+                                        (error) == STATUS_INVALID_ACK_DUPLICATE_KEY_NAME ||     	\
+                                        (error) == STATUS_INVALID_ACK_INVALID_VALUE_START ||    	\
+                                        (error) == STATUS_INVALID_ACK_INVALID_VALUE_END ||      	\
+                                        (error) == STATUS_ACK_TIMESTAMP_NOT_IN_VIEW_WINDOW ||   	\
+                                        (error) == STATUS_PUTMEDIA_LAST_PERSIST_ACK_NOT_RECEIVED ||	\
+                                        (error) == STATUS_ACK_ERR_FRAGMENT_DURATION_REACHED)    	\
 
 #define IS_RETRIABLE_ERROR(error)       ((error) == STATUS_DESCRIBE_STREAM_CALL_FAILED ||       \
                                         (error) == STATUS_CREATE_STREAM_CALL_FAILED ||          \
@@ -2164,7 +2166,8 @@ PUBLIC_API STATUS kinesisVideoStreamGetStreamInfo(STREAM_HANDLE,
 PUBLIC_API STATUS kinesisVideoStreamResetStream(STREAM_HANDLE);
 
 /**
- * Reset connection for stream, continue sending existing data in buffer with new connection
+ * Reset connection for stream. All existing putMedia connection will be terminated first.
+ * Continue sending existing data with new connection
  *
  * @param 1 STREAM_HANDLE - The stream handle to reset
  *

--- a/src/client/src/Client.c
+++ b/src/client/src/Client.c
@@ -1031,14 +1031,14 @@ CleanUp:
 /**
  * Put stream with endless payload API call result event
  */
-STATUS putStreamResultEvent(UINT64 customData, SERVICE_CALL_RESULT callResult, UPLOAD_HANDLE streamHandle)
+STATUS putStreamResultEvent(UINT64 customData, SERVICE_CALL_RESULT callResult, UPLOAD_HANDLE uploadHandle)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     BOOL releaseClientSemaphore = FALSE, releaseStreamSemaphore = FALSE;
     PKinesisVideoStream pKinesisVideoStream = FROM_STREAM_HANDLE(customData);
 
-    DLOGI("Put stream result event.");
+    DLOGI("Put stream result event. New upload handle %" PRIu64, uploadHandle);
     CHK(pKinesisVideoStream != NULL && pKinesisVideoStream->pKinesisVideoClient != NULL, STATUS_NULL_ARG);
 
     // Shutdown sequencer
@@ -1048,7 +1048,7 @@ STATUS putStreamResultEvent(UINT64 customData, SERVICE_CALL_RESULT callResult, U
     CHK_STATUS(semaphoreAcquire(pKinesisVideoStream->base.shutdownSemaphore, INFINITE_TIME_VALUE));
     releaseStreamSemaphore = TRUE;
 
-    CHK_STATUS(putStreamResult(pKinesisVideoStream, callResult, streamHandle));
+    CHK_STATUS(putStreamResult(pKinesisVideoStream, callResult, uploadHandle));
 
 CleanUp:
 
@@ -1135,7 +1135,7 @@ STATUS kinesisVideoStreamTerminated(STREAM_HANDLE streamHandle, UPLOAD_HANDLE st
     BOOL releaseClientSemaphore = FALSE, releaseStreamSemaphore = FALSE;
     PKinesisVideoStream pKinesisVideoStream = FROM_STREAM_HANDLE(streamHandle);
 
-    DLOGI("Stream terminated event.");
+    DLOGI("Stream 0x%" PRIx64 " terminated upload handle %" PRIu64 " with service call result %u.", streamHandle, streamUploadHandle, callResult);
     CHK(pKinesisVideoStream != NULL && pKinesisVideoStream->pKinesisVideoClient != NULL, STATUS_NULL_ARG);
 
     // Shutdown sequencer

--- a/src/client/src/Stream.h
+++ b/src/client/src/Stream.h
@@ -228,14 +228,19 @@ typedef enum {
 } UPLOAD_CONNECTION_STATE;
 
 /**
+ * Whether the upload handle is in state s
+ */
+#define IS_UPLOAD_HANDLE_IN_STATE(u, s)            ((((PUploadHandleInfo)(u))->state & (s)) != UPLOAD_HANDLE_STATE_NONE)
+
+/**
  * Whether the upload handle is in sending EoS state
  */
-#define IS_UPLOAD_HANDLE_IN_SENDING_EOS_STATE(p)    ((((PUploadHandleInfo)(p))->state & UPLOAD_HANDLE_STATE_SEND_EOS) != UPLOAD_HANDLE_STATE_NONE)
+#define IS_UPLOAD_HANDLE_IN_SENDING_EOS_STATE(p)    (IS_UPLOAD_HANDLE_IN_STATE(p, UPLOAD_HANDLE_STATE_SEND_EOS))
 
 /**
  * Whether the upload handle has sent all its items, including eos.
  */
-#define IS_UPLOAD_HANDLE_READY_TO_TRIM(p)    ((((PUploadHandleInfo)(p))->state & UPLOAD_HANDLE_STATE_READY_TO_TRIM) != UPLOAD_HANDLE_STATE_NONE)
+#define IS_UPLOAD_HANDLE_READY_TO_TRIM(p)    (IS_UPLOAD_HANDLE_IN_STATE(p, UPLOAD_HANDLE_STATE_READY_TO_TRIM))
 
 /**
  * Upload handle information struct

--- a/src/client/src/StreamEvent.c
+++ b/src/client/src/StreamEvent.c
@@ -620,8 +620,10 @@ STATUS streamTerminatedEvent(PKinesisVideoStream pKinesisVideoStream, UPLOAD_HAN
     STATUS retStatus = STATUS_SUCCESS;
     PStateMachineState pState;
     PKinesisVideoClient pKinesisVideoClient = NULL;
-    PUploadHandleInfo pUploadHandleInfo;
-    BOOL locked = FALSE;
+    PUploadHandleInfo pUploadHandleInfo, pActiveUploadHandleInfo = NULL;
+    UINT32 sessionCount = 0, i = 0;
+    UINT64 item;
+    BOOL locked = FALSE, spawnNewUploadSession = TRUE, uploadHandleNotUsed = FALSE;
 
     CHK(pKinesisVideoStream != NULL && pKinesisVideoStream->pKinesisVideoClient != NULL, STATUS_NULL_ARG);
     pKinesisVideoClient = pKinesisVideoStream->pKinesisVideoClient;
@@ -632,30 +634,26 @@ STATUS streamTerminatedEvent(PKinesisVideoStream pKinesisVideoStream, UPLOAD_HAN
 
     // We should handle the in-grace termination differently by not setting the terminated state
     if (SERVICE_CALL_STREAM_AUTH_IN_GRACE_PERIOD != callResult) {
-        // Set the indicator of the retrying handle
+
+        // Set default to UPLOAD_CONNECTION_STATE_IN_USE which will trigger rollback
         pKinesisVideoStream->connectionState = UPLOAD_CONNECTION_STATE_IN_USE;
 
-        // Get the first upload handle in case of invalid handle specified
+        // If invalid upload handle is specified, terminated all uploading session, and let
+        // state machine spawn new session.
         if (!IS_VALID_UPLOAD_HANDLE(uploadHandle)) {
-            pUploadHandleInfo = getStreamUploadInfoWithState(pKinesisVideoStream, UPLOAD_HANDLE_STATE_ACTIVE);
-        } else {
-            pUploadHandleInfo = getStreamUploadInfo(pKinesisVideoStream, uploadHandle);
-        }
 
-        // If the upload handle has streamed some data, set flag to trigger rollback in the next getStreamData call.
-        // If the upload handle has not stream any data, we can safely ignore this event.
-        if (NULL != pUploadHandleInfo) {
-            if ((pUploadHandleInfo->state & UPLOAD_HANDLE_STATE_NOT_IN_USE) != UPLOAD_HANDLE_STATE_NONE) {
-                // Need to indicate to the getStreamData to rollback.
-                pKinesisVideoStream->connectionState = UPLOAD_CONNECTION_STATE_NOT_IN_USE;
-            }
+            CHK_STATUS(stackQueueGetCount(pKinesisVideoStream->pUploadInfoQueue, &sessionCount));
 
-            // Set the state to terminated
-            pUploadHandleInfo->state = UPLOAD_HANDLE_STATE_TERMINATED;
+            for (i = 0; i < sessionCount; i++) {
+                CHK_STATUS(stackQueueGetAt(pKinesisVideoStream->pUploadInfoQueue, i, &item));
+                pUploadHandleInfo = (PUploadHandleInfo) item;
+                CHK(pUploadHandleInfo != NULL, STATUS_INTERNAL_ERROR);
 
-            // In case of reset connection and error acks, need to ping the terminated upload handle so that it
-            // can unpause if paused and then call getStreamData and receive the end-of-stream status
-            if (connectionStillAlive) {
+                pUploadHandleInfo->state = UPLOAD_HANDLE_STATE_TERMINATED;
+
+                // pulse the upload handle to receive the terminated status. The assumption is that
+                // upper layer uploading session should not be dead and should call getStreamData
+                // after receiving streamDataAvailable callback.
                 CHK_STATUS(pKinesisVideoClient->clientCallbacks.streamDataAvailableFn(
                         pKinesisVideoClient->clientCallbacks.customData,
                         TO_STREAM_HANDLE(pKinesisVideoStream),
@@ -664,18 +662,84 @@ STATUS streamTerminatedEvent(PKinesisVideoStream pKinesisVideoStream, UPLOAD_HAN
                         0,
                         0));
             }
-        }
+        } else {
 
-        // If the connection that upload handle represents is already dead. Then it will not make anymore
-        // getStreamData call so it should be removed.
-        if (!connectionStillAlive) {
-            // Remove the handle info from the queue
-            deleteStreamUploadInfo(pKinesisVideoStream, pUploadHandleInfo);
-            pUploadHandleInfo = NULL;
+            pUploadHandleInfo = getStreamUploadInfo(pKinesisVideoStream, uploadHandle);
+
+            if (pUploadHandleInfo == NULL) {
+                DLOGW("streamTerminatedEvent called for unknown upload handle %" PRIu64, uploadHandle);
+            } else {
+                // If the upload handle has not streamed any data, we can safely ignore this event.
+                // else the upload handle has streamed some data, set flag to trigger rollback in the next getStreamData call.
+                uploadHandleNotUsed = IS_UPLOAD_HANDLE_IN_STATE(pUploadHandleInfo, UPLOAD_HANDLE_STATE_NOT_IN_USE);
+
+                // Set the state to terminated
+                pUploadHandleInfo->state = UPLOAD_HANDLE_STATE_TERMINATED;
+
+                if (uploadHandleNotUsed) {
+                    // Need to indicate to the getStreamData to not rollback.
+                    pKinesisVideoStream->connectionState = UPLOAD_CONNECTION_STATE_NOT_IN_USE;
+
+                } else {
+                    pActiveUploadHandleInfo = getStreamUploadInfo(pKinesisVideoStream, UPLOAD_HANDLE_STATE_ACTIVE);
+
+                    if (pActiveUploadHandleInfo != NULL) {
+                        // If the errored handle is the only handle, then rollback,
+                        // otherwise do not rollback because the rollback will corrupt other active handle.
+                        pKinesisVideoStream->connectionState = UPLOAD_CONNECTION_STATE_NOT_IN_USE;
+
+                        DLOGW("Last fragment with timestamp %" PRIu64 " for upload handle %" PRIu64 " might not be fully persisted",
+                              pUploadHandleInfo->lastFragmentTs,
+                              uploadHandle);
+
+                        if (pUploadHandleInfo->state == UPLOAD_HANDLE_STATE_AWAITING_ACK &&
+                            pKinesisVideoClient->clientCallbacks.streamErrorReportFn != NULL) {
+                            pKinesisVideoClient->clientCallbacks.streamErrorReportFn(
+                                    pKinesisVideoClient->clientCallbacks.customData,
+                                    TO_STREAM_HANDLE(pKinesisVideoStream),
+                                    uploadHandle,
+                                    pUploadHandleInfo->lastFragmentTs,
+                                    STATUS_PUTMEDIA_LAST_PERSIST_ACK_NOT_RECEIVED);
+                        }
+                    }
+                }
+
+                // In case of reset connection and error acks, need to ping the terminated upload handle so that it
+                // can unpause if paused and then call getStreamData and receive the end-of-stream status
+                if (connectionStillAlive) {
+                    pKinesisVideoClient->clientCallbacks.streamDataAvailableFn(
+                            pKinesisVideoClient->clientCallbacks.customData,
+                            TO_STREAM_HANDLE(pKinesisVideoStream),
+                            pKinesisVideoStream->streamInfo.name,
+                            pUploadHandleInfo->handle,
+                            0,
+                            0);
+                } else {
+                    // If the connection that upload handle represents is already dead. Then it will not make anymore
+                    // getStreamData call so it should be removed.
+                    deleteStreamUploadInfo(pKinesisVideoStream, pUploadHandleInfo);
+                    pUploadHandleInfo = NULL;
+                }
+
+                // signal the next active session that it can start getting stream data.
+                pActiveUploadHandleInfo = getStreamUploadInfo(pKinesisVideoStream, UPLOAD_HANDLE_STATE_ACTIVE);
+
+                if (pActiveUploadHandleInfo != NULL) {
+                    // dont spawn new session since we already have a active one
+                    spawnNewUploadSession = FALSE;
+                    pKinesisVideoClient->clientCallbacks.streamDataAvailableFn(
+                            pKinesisVideoClient->clientCallbacks.customData,
+                            TO_STREAM_HANDLE(pKinesisVideoStream),
+                            pKinesisVideoStream->streamInfo.name,
+                            pUploadHandleInfo->handle,
+                            0,
+                            0);
+                }
+            }
         }
     }
 
-    // return early if pic is already in process of traversing control plane states.
+    // return early if pic is already in process of spawning new uploading session
     CHK(!STATUS_SUCCEEDED(acceptStateMachineState(pKinesisVideoStream->base.pStateMachine,
                                                  STREAM_STATE_DESCRIBE |
                                                  STREAM_STATE_CREATE |
@@ -684,20 +748,22 @@ STATUS streamTerminatedEvent(PKinesisVideoStream pKinesisVideoStream, UPLOAD_HAN
                                                  STREAM_STATE_GET_ENDPOINT |
                                                  STREAM_STATE_READY)), retStatus);
 
-    // Stop the stream
-    pKinesisVideoStream->streamState = STREAM_STATE_STOPPED;
+    if (spawnNewUploadSession) {
+        // Stop the stream
+        pKinesisVideoStream->streamState = STREAM_STATE_STOPPED;
 
-    // Get the accepted state
-    CHK_STATUS(getStateMachineState(pKinesisVideoStream->base.pStateMachine, STREAM_STATE_STOPPED, &pState));
+        // Get the accepted state
+        CHK_STATUS(getStateMachineState(pKinesisVideoStream->base.pStateMachine, STREAM_STATE_STOPPED, &pState));
 
-    // Check for the right state
-    CHK_STATUS(acceptStateMachineState(pKinesisVideoStream->base.pStateMachine, pState->acceptStates));
+        // Check for the right state
+        CHK_STATUS(acceptStateMachineState(pKinesisVideoStream->base.pStateMachine, pState->acceptStates));
 
-    // store the result
-    pKinesisVideoStream->base.result = callResult;
+        // store the result
+        pKinesisVideoStream->base.result = callResult;
 
-    // Step the machine
-    CHK_STATUS(stepStateMachine(pKinesisVideoStream->base.pStateMachine));
+        // Step the machine
+        CHK_STATUS(stepStateMachine(pKinesisVideoStream->base.pStateMachine));
+    }
 
 CleanUp:
 

--- a/src/client/tst/StreamRecoveryFunctionalityTest.cpp
+++ b/src/client/tst/StreamRecoveryFunctionalityTest.cpp
@@ -101,6 +101,9 @@ TEST_P(StreamRecoveryFunctionalityTest, CreateStreamThenStreamResetConnectionAft
             EXPECT_EQ(STATUS_SUCCESS, kinesisVideoStreamTerminated(mStreamHandle,
                                                                    INVALID_UPLOAD_HANDLE_VALUE,
                                                                    SERVICE_CALL_RESULT_OK));
+            // restore slow speed after reset so all subsequent uploads are at normal speed
+            mMockConsumerConfig.mUploadSpeedBytesPerSecond = 1000000;
+            // restore speed for current active upload handles
             mStreamingSession.getActiveUploadHandles(currentUploadHandles);
             for (int i = 0; i < currentUploadHandles.size(); i++) {
                 UPLOAD_HANDLE uploadHandle = currentUploadHandles[i];


### PR DESCRIPTION
…… (#345)

* change resetKinesisVideoConnection to terminate all active upload handles. Add unit test simulating curl timeout. When an upload get an error, only indicate rollback if there is no other active upload handle.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
