### PR TITLE
Implementing intermittent producer support in the PIC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ matrix:
       addons:
         apt:
           sources:
-            - ubuntu-toolchain-r-test
+            - sourceline: 'ppa:ubuntu-toolchain-r/test'
           packages:
             - gcc-4.4
             - gdb

--- a/src/client/src/Include_i.h
+++ b/src/client/src/Include_i.h
@@ -169,6 +169,14 @@ typedef struct __EndpointInfo* PEndpointInfo;
                                                 (r) == SERVICE_CALL_NOT_AUTHORIZED)
 
 /**
+ * Returns whether the service call result is a timeout
+ */
+#define SERVICE_CALL_RESULT_IS_A_TIMEOUT(r)     ((r) == SERVICE_CALL_REQUEST_TIMEOUT || \
+                                                (r) == SERVICE_CALL_GATEWAY_TIMEOUT || \
+                                                (r) == SERVICE_CALL_NETWORK_READ_TIMEOUT || \
+                                                (r) == SERVICE_CALL_NETWORK_CONNECTION_TIMEOUT)
+
+/**
  * The Realtime put media API name for GetDataEndpoint API call
  */
 #define GET_DATA_ENDPOINT_REAL_TIME_PUT_API_NAME            "PUT_MEDIA"

--- a/src/client/tst/ClientTestFixture.h
+++ b/src/client/tst/ClientTestFixture.h
@@ -92,6 +92,13 @@
         return;\
     }
 
+#define PASS_TEST_FOR_OFFLINE_OR_ZERO_RETENTION() \
+    if (mStreamInfo.streamCaps.streamingType == STREAMING_TYPE_OFFLINE || \
+        mStreamInfo.retention == 0 || \
+        !mStreamInfo.streamCaps.fragmentAcks) { \
+        return;\
+    }
+
 #define PASS_TEST_FOR_OFFLINE() \
     if (mStreamInfo.streamCaps.streamingType == STREAMING_TYPE_OFFLINE) { \
         return;\

--- a/src/client/tst/ClientTestFixture.h
+++ b/src/client/tst/ClientTestFixture.h
@@ -85,6 +85,9 @@
 // Offset of the MKV Segment Info UUID from the beginning of the header
 #define MKV_SEGMENT_UUID_OFFSET         54
 
+// Default producer configuration frame size
+#define TEST_DEFAULT_PRODUCER_CONFIG_FRAME_SIZE             50000
+
 #define PASS_TEST_FOR_ZERO_RETENTION_AND_OFFLINE() \
     if ((mStreamInfo.retention == 0 || !mStreamInfo.streamCaps.fragmentAcks) && \
         mStreamInfo.streamCaps.streamingType == STREAMING_TYPE_OFFLINE) { \
@@ -532,7 +535,7 @@ protected:
     void initDefaultProducer() {
         mMockProducerConfig.mFps = 20;
         mMockProducerConfig.mKeyFrameInterval = 20;
-        mMockProducerConfig.mFrameSizeByte = 50000;
+        mMockProducerConfig.mFrameSizeByte = TEST_DEFAULT_PRODUCER_CONFIG_FRAME_SIZE;
         mMockProducerConfig.mIsLive = TRUE;
         mMockProducerConfig.mSetEOFR = FALSE;
         mMockProducerConfig.mFrameTrackId = TEST_TRACKID;

--- a/src/client/tst/MockConsumer.cpp
+++ b/src/client/tst/MockConsumer.cpp
@@ -148,14 +148,15 @@ void MockConsumer::purgeAckItemWithTimestamp(UINT64 ackTimestamp)
     }
 }
 
-STATUS MockConsumer::timedGetStreamData(UINT64 currentTime, PBOOL pDidGetStreamData, PUINT32 pRetrievedSize){
+STATUS MockConsumer::timedGetStreamData(UINT64 currentTime, PBOOL pDidGetStreamData, PUINT32 pRetrievedSize) {
     STATUS retStatus = STATUS_SUCCESS;
     UINT32 actualDataSize;
     *pDidGetStreamData = FALSE;
 
     if (mDataAvailable && (currentTime >= mNextGetStreamDataTime)) {
         *pDidGetStreamData = TRUE;
-        retStatus = getKinesisVideoStreamData(mStreamHandle, mUploadHandle, mDataBuffer, mDataBufferSize, &actualDataSize);
+        retStatus = getKinesisVideoStreamData(mStreamHandle, mUploadHandle, mDataBuffer, mDataBufferSize,
+                                              &actualDataSize);
 
         // stop calling getKinesisVideoStreamData if there is no more data.
         if (retStatus == STATUS_NO_MORE_DATA_AVAILABLE || retStatus == STATUS_AWAITING_PERSISTED_ACK) {

--- a/src/client/tst/MockProducer.cpp
+++ b/src/client/tst/MockProducer.cpp
@@ -31,6 +31,9 @@ STATUS MockProducer::putFrame(BOOL isEofr) {
         mFrame.presentationTs = mTimestamp;
         mFrame.index = mIndex;
 
+        // Set the body of the frame so it's easier to track
+        MEMSET(mFrame.frameData, mFrame.index, mFrame.size);
+
         retStatus = putKinesisVideoFrame(mStreamHandle, &mFrame);
 
         mIndex++;

--- a/src/client/tst/MockProducer.cpp
+++ b/src/client/tst/MockProducer.cpp
@@ -18,10 +18,10 @@ MockProducer::MockProducer(MockProducerConfig config,
     mFrame.duration = (UINT64) 1000 / mFps * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
 }
 
-STATUS MockProducer::putFrame(BOOL eofr) {
+STATUS MockProducer::putFrame(BOOL isEofr) {
     STATUS retStatus = STATUS_SUCCESS;
 
-    if (eofr) {
+    if (isEofr) {
         Frame eofr = EOFR_FRAME_INITIALIZER;
         mIndex += (mKeyFrameInterval - (mIndex % mKeyFrameInterval)); // next frame must have key frame flag after eofr.
         retStatus = putKinesisVideoFrame(mStreamHandle, &eofr);

--- a/src/client/tst/StreamRecoveryFunctionalityTest.cpp
+++ b/src/client/tst/StreamRecoveryFunctionalityTest.cpp
@@ -706,10 +706,10 @@ TEST_P(StreamRecoveryFunctionalityTest, CreateStreamThenStreamTimeoutWithoutBuff
         mockProducer.putFrame();
         // Recovery till ready state
         EXPECT_EQ(2, mPutStreamFuncCount);
-        EXPECT_EQ(3, mDescribeStreamFuncCount);
+        EXPECT_EQ(3, mDescribeStreamFuncCount); // remains the same
         EXPECT_EQ(0, mCreateStreamFuncCount);
         EXPECT_EQ(0, mTagResourceFuncCount);
-        EXPECT_EQ(2, mGetStreamingEndpointFuncCount);
+        EXPECT_EQ(1, mGetStreamingEndpointFuncCount); // remains the same
         EXPECT_EQ(2, mStreamReadyFuncCount);
     }
 


### PR DESCRIPTION
Issue #26 

Adding logic to PIC to not auto-prime on timeout upload handle termination if we have no more data in the buffer to be streamed out.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
