### PR TITLE
Adding instrumented allocators to util

### DIFF
--- a/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
+++ b/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
@@ -469,6 +469,7 @@ typedef CID*                PCID;
 #define STATUS_DETACH_THREAD_FAILED                 STATUS_BASE + 0x0000001b
 #define STATUS_THREAD_ATTR_INIT_FAILED              STATUS_BASE + 0x0000001c
 #define STATUS_THREAD_ATTR_SET_STACK_SIZE_FAILED    STATUS_BASE + 0x0000001d
+#define STATUS_MEMORY_NOT_FREED                     STATUS_BASE + 0x0000001e
 
 #include <stdlib.h>
 #include <string.h>
@@ -1158,6 +1159,18 @@ typedef UINT64 HANDLE;
             DLOGE("operation returned status code: 0x%08x", __status); \
         } \
     } while (FALSE)
+
+/**
+* Macro that logs one of the status codes if the operation does not return STATUS_SUCCESS
+*/
+#define CHK_LOG_ERR_NV(condition) \
+    do { \
+        STATUS __status = condition; \
+        if (STATUS_FAILED(__status)) { \
+            DLOGE("operation returned status code: 0x%08x", __status); \
+        } \
+    } while (FALSE)
+
 
 #ifdef  __cplusplus
 }

--- a/src/utils/include/com/amazonaws/kinesis/video/utils/Include.h
+++ b/src/utils/include/com/amazonaws/kinesis/video/utils/Include.h
@@ -1309,6 +1309,42 @@ PUBLIC_API STATUS semaphoreUnlock(SEMAPHORE_HANDLE);
  */
 PUBLIC_API STATUS semaphoreWaitUntilClear(SEMAPHORE_HANDLE, UINT64);
 
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+// Instrumented memory allocators functionality
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Sets the global allocators to the instrumented ones.
+ *
+ * @return - STATUS code of the execution
+ */
+PUBLIC_API STATUS setInstrumentedAllocators();
+
+/**
+ * Resets the global allocators to the original ones.
+ *
+ * NOTE: Any attempt to free allocations which were allocated after set call
+ * past this API call will result in memory corruption.
+ *
+ * @return - STATUS code of the execution
+ */
+PUBLIC_API STATUS resetInstrumentedAllocators();
+
+/**
+ * Returns the current total allocation size.
+ *
+ * @return - Total allocation size
+ */
+PUBLIC_API SIZE_T getInstrumentedTotalAllocationSize();
+
+#ifdef INSTRUMENTED_ALLOCATORS
+#define SET_INSTRUMENTED_ALLOCATORS()               setInstrumentedAllocators()
+#define RESET_INSTRUMENTED_ALLOCATORS()             resetInstrumentedAllocators()
+#else
+#define SET_INSTRUMENTED_ALLOCATORS()               do { if (0) setInstrumentedAllocators(); } while (0)
+#define RESET_INSTRUMENTED_ALLOCATORS()             do { if (0) resetInstrumentedAllocators(); } while (0)
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/utils/src/Allocators.c
+++ b/src/utils/src/Allocators.c
@@ -65,6 +65,9 @@ VOID dumpMemoryHex(PVOID pMem, UINT32 size)
     DLOGS("++++++++++++++++++++++++++++++++++++++++++++");
     DLOGS("Dumping memory done!");
     DLOGS("============================================");
+#else
+    UNUSED_PARAM(pMem);
+    UNUSED_PARAM(size);
 #endif
 }
 

--- a/src/utils/src/Include_i.h
+++ b/src/utils/src/Include_i.h
@@ -213,6 +213,15 @@ STATUS semaphoreReleaseInternal(PSemaphore);
 STATUS semaphoreSetLockInternal(PSemaphore, BOOL);
 STATUS semaphoreWaitUntilClearInternal(PSemaphore, UINT64);
 
+//////////////////////////////////////////////////////////////////////////////////////////////
+// Instrumented allocators functionality
+//////////////////////////////////////////////////////////////////////////////////////////////
+PVOID instrumentedAllocatorsMemAlloc(SIZE_T);
+PVOID instrumentedAllocatorsMemAlignAlloc(SIZE_T, SIZE_T);
+PVOID instrumentedAllocatorsMemCalloc(SIZE_T, SIZE_T);
+PVOID instrumentedAllocatorsMemRealloc(PVOID, SIZE_T);
+VOID instrumentedAllocatorsMemFree(PVOID);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/utils/src/InstrumentedAllocators.c
+++ b/src/utils/src/InstrumentedAllocators.c
@@ -1,0 +1,148 @@
+#include "Include_i.h"
+
+volatile SIZE_T gInstrumentedAllocatorsTotalAllocationSize = 0;
+
+memAlloc gInstrumentedAllocatorsStoredMemAlloc;
+memAlignAlloc gInstrumentedAllocatorsStoredMemAlignAlloc;
+memCalloc gInstrumentedAllocatorsStoredMemCalloc;
+memFree gInstrumentedAllocatorsStoredMemFree;
+memRealloc gInstrumentedAllocatorsStoredMemRealloc;
+
+STATUS setInstrumentedAllocators()
+{
+    // Store the existing function pointers
+    gInstrumentedAllocatorsStoredMemAlloc = globalMemAlloc;
+    gInstrumentedAllocatorsStoredMemAlignAlloc = globalMemAlignAlloc;
+    gInstrumentedAllocatorsStoredMemCalloc = globalMemCalloc;
+    gInstrumentedAllocatorsStoredMemFree = globalMemFree;
+    gInstrumentedAllocatorsStoredMemRealloc = globalMemRealloc;
+
+    // Overwrite with the instrumented ones
+    globalMemAlloc = instrumentedAllocatorsMemAlloc;
+    globalMemAlignAlloc = instrumentedAllocatorsMemAlignAlloc;
+    globalMemCalloc = instrumentedAllocatorsMemCalloc;
+    globalMemFree = instrumentedAllocatorsMemFree;
+    globalMemRealloc = instrumentedAllocatorsMemRealloc;
+
+    return STATUS_SUCCESS;
+}
+
+STATUS resetInstrumentedAllocators()
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    SIZE_T totalRemainingSize = ATOMIC_LOAD(&gInstrumentedAllocatorsTotalAllocationSize);
+
+    // Reset the global allocators with the stored ones
+    globalMemAlloc = gInstrumentedAllocatorsStoredMemAlloc;
+    globalMemAlignAlloc = gInstrumentedAllocatorsStoredMemAlignAlloc;
+    globalMemCalloc = gInstrumentedAllocatorsStoredMemCalloc;
+    globalMemFree = gInstrumentedAllocatorsStoredMemFree;
+    globalMemRealloc = gInstrumentedAllocatorsStoredMemRealloc;
+
+    // Check the final total value
+    CHK_WARN(totalRemainingSize == 0, STATUS_MEMORY_NOT_FREED,
+            "Possible memory leak of size %" PRIu64, totalRemainingSize);
+
+CleanUp:
+
+    CHK_LOG_ERR_NV(retStatus);
+    return retStatus;
+}
+
+SIZE_T getInstrumentedTotalAllocationSize()
+{
+    SIZE_T totalRemainingSize = ATOMIC_LOAD(&gInstrumentedAllocatorsTotalAllocationSize);
+    return totalRemainingSize;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Internal functionality
+////////////////////////////////////////////////////////////////////////////////
+
+PVOID instrumentedAllocatorsMemAlloc(SIZE_T size)
+{
+    DLOGS("Instrumented mem alloc %" PRIu64 " bytes", (UINT64) size);
+    PSIZE_T pAlloc = (PSIZE_T) gInstrumentedAllocatorsStoredMemAlloc(size + SIZEOF(SIZE_T));
+
+    if (pAlloc == NULL) {
+        return NULL;
+    }
+
+    // Store the allocation size - should be aligned
+    *pAlloc = size;
+
+    // Add to the total book keeping
+    ATOMIC_ADD(&gInstrumentedAllocatorsTotalAllocationSize, size);
+
+    return pAlloc + 1;
+}
+
+PVOID instrumentedAllocatorsMemAlignAlloc(SIZE_T size, SIZE_T alignment)
+{
+    // Doing the same as alloc
+    DLOGS("Instrumented mem alignalloc %" PRIu64 " bytes", (UINT64) size);
+    UNUSED_PARAM(alignment);
+    return instrumentedAllocatorsMemAlloc(size);
+}
+
+PVOID instrumentedAllocatorsMemCalloc(SIZE_T num, SIZE_T size)
+{
+    SIZE_T overallSize = num * size;
+    DLOGS("Instrumented mem calloc %" PRIu64 " bytes", (UINT64) overallSize);
+
+    // Allocate extra size_t to store the size of the allocation
+    PSIZE_T pAlloc = (PSIZE_T) gInstrumentedAllocatorsStoredMemCalloc(1, overallSize + SIZEOF(SIZE_T));
+    if (pAlloc == NULL) {
+        return NULL;
+    }
+
+    *pAlloc = overallSize;
+
+    ATOMIC_ADD(&gInstrumentedAllocatorsTotalAllocationSize, overallSize);
+
+    return pAlloc + 1;
+}
+
+PVOID instrumentedAllocatorsMemRealloc(PVOID ptr, SIZE_T size)
+{
+    if (ptr == NULL) {
+        return NULL;
+    }
+
+    PSIZE_T pAlloc = (PSIZE_T) ptr - 1;
+    SIZE_T existingSize = *pAlloc;
+
+    DLOGS("Instrumented mem realloc of %" PRIu64 " bytes to %" PRIu64 " bytes", (UINT64) existingSize, (UINT64) size);
+
+    if (existingSize == size) {
+        return ptr;
+    }
+
+    PSIZE_T pNewAlloc = (PSIZE_T) gInstrumentedAllocatorsStoredMemRealloc(pAlloc, size + SIZEOF(SIZE_T));
+    if (pNewAlloc == NULL) {
+        return NULL;
+    }
+
+    if (existingSize > size) {
+        ATOMIC_SUBTRACT(&gInstrumentedAllocatorsTotalAllocationSize, existingSize - size);
+    } else {
+        ATOMIC_ADD(&gInstrumentedAllocatorsTotalAllocationSize, size - existingSize);
+    }
+
+    return pNewAlloc + 1;
+}
+
+VOID instrumentedAllocatorsMemFree(PVOID ptr)
+{
+    if (ptr == NULL) {
+        return;
+    }
+
+    PSIZE_T pAlloc = (PSIZE_T) ptr - 1;
+    SIZE_T size = *pAlloc;
+    DLOGS("Instrumented mem free %" PRIu64 " bytes", (UINT64) size);
+
+    ATOMIC_SUBTRACT(&gInstrumentedAllocatorsTotalAllocationSize, size);
+
+    gInstrumentedAllocatorsStoredMemFree(pAlloc);
+}

--- a/src/utils/tst/InstrumentedAllocators.cpp
+++ b/src/utils/tst/InstrumentedAllocators.cpp
@@ -1,0 +1,172 @@
+#include "UtilTestFixture.h"
+
+class InstrumentedAllocatorsTest : public UtilTestBase {
+protected:
+    InstrumentedAllocatorsTest() : UtilTestBase(FALSE) {}
+    const int TestAllocSize = 1000;
+};
+
+TEST_F(InstrumentedAllocatorsTest, set_reset_basic_test)
+{
+    memAlloc storedMemAlloc = globalMemAlloc;
+    memAlignAlloc storedMemAlignAlloc = globalMemAlignAlloc;
+    memCalloc storedMemCalloc = globalMemCalloc;
+    memFree storedMemFree = globalMemFree;
+    memRealloc storedMemRealloc = globalMemRealloc;
+    SIZE_T totalAllocSize = getInstrumentedTotalAllocationSize();
+
+#ifndef INSTRUMENTED_ALLOCATORS
+    SET_INSTRUMENTED_ALLOCATORS();
+
+    // Check that we have not set anything actually
+    EXPECT_EQ(storedMemAlloc, globalMemAlloc);
+    EXPECT_EQ(storedMemAlignAlloc, globalMemAlignAlloc);
+    EXPECT_EQ(storedMemCalloc, globalMemCalloc);
+    EXPECT_EQ(storedMemFree, globalMemFree);
+    EXPECT_EQ(storedMemRealloc, globalMemRealloc);
+
+    RESET_INSTRUMENTED_ALLOCATORS();
+
+    EXPECT_EQ(storedMemAlloc, globalMemAlloc);
+    EXPECT_EQ(storedMemAlignAlloc, globalMemAlignAlloc);
+    EXPECT_EQ(storedMemCalloc, globalMemCalloc);
+    EXPECT_EQ(storedMemFree, globalMemFree);
+    EXPECT_EQ(storedMemRealloc, globalMemRealloc);
+#else
+    SET_INSTRUMENTED_ALLOCATORS();
+
+    // Check that the allocators have changed
+    EXPECT_NE(storedMemAlloc, globalMemAlloc);
+    EXPECT_NE(storedMemAlignAlloc, globalMemAlignAlloc);
+    EXPECT_NE(storedMemCalloc, globalMemCalloc);
+    EXPECT_NE(storedMemFree, globalMemFree);
+    EXPECT_NE(storedMemRealloc, globalMemRealloc);
+
+    RESET_INSTRUMENTED_ALLOCATORS();
+
+    // Reset back to the stored ones
+    EXPECT_EQ(storedMemAlloc, globalMemAlloc);
+    EXPECT_EQ(storedMemAlignAlloc, globalMemAlignAlloc);
+    EXPECT_EQ(storedMemCalloc, globalMemCalloc);
+    EXPECT_EQ(storedMemFree, globalMemFree);
+    EXPECT_EQ(storedMemRealloc, globalMemRealloc);
+#endif
+
+    // Force setting/resetting couple of times
+
+    for (int i = 0; i < 100; i++) {
+        EXPECT_EQ(STATUS_SUCCESS, setInstrumentedAllocators());
+
+        // Check that the allocators have changed
+        EXPECT_NE(storedMemAlloc, globalMemAlloc);
+        EXPECT_NE(storedMemAlignAlloc, globalMemAlignAlloc);
+        EXPECT_NE(storedMemCalloc, globalMemCalloc);
+        EXPECT_NE(storedMemFree, globalMemFree);
+        EXPECT_NE(storedMemRealloc, globalMemRealloc);
+
+        EXPECT_EQ(STATUS_SUCCESS, resetInstrumentedAllocators());
+
+        // Reset back to the stored ones
+        EXPECT_EQ(storedMemAlloc, globalMemAlloc);
+        EXPECT_EQ(storedMemAlignAlloc, globalMemAlignAlloc);
+        EXPECT_EQ(storedMemCalloc, globalMemCalloc);
+        EXPECT_EQ(storedMemFree, globalMemFree);
+        EXPECT_EQ(storedMemRealloc, globalMemRealloc);
+    }
+
+    EXPECT_EQ(totalAllocSize, getInstrumentedTotalAllocationSize());
+}
+
+TEST_F(InstrumentedAllocatorsTest, memory_leak_check_malloc)
+{
+    EXPECT_EQ(STATUS_SUCCESS, setInstrumentedAllocators());
+    SIZE_T totalAllocSize = getInstrumentedTotalAllocationSize();
+    PVOID pAlloc = MEMALLOC(TestAllocSize);
+    MEMSET(pAlloc, 0xFF, TestAllocSize);
+    MEMCHK(pAlloc, 0xff, TestAllocSize);
+    EXPECT_EQ(STATUS_MEMORY_NOT_FREED, resetInstrumentedAllocators());
+    EXPECT_EQ(totalAllocSize + TestAllocSize, getInstrumentedTotalAllocationSize());
+}
+
+TEST_F(InstrumentedAllocatorsTest, memory_leak_check_alignalloc)
+{
+    EXPECT_EQ(STATUS_SUCCESS, setInstrumentedAllocators());
+    SIZE_T totalAllocSize = getInstrumentedTotalAllocationSize();
+    PVOID pAlloc = MEMALIGNALLOC(TestAllocSize, 16);
+    MEMSET(pAlloc, 0xFF, TestAllocSize);
+    MEMCHK(pAlloc, 0xff, TestAllocSize);
+    EXPECT_EQ(STATUS_MEMORY_NOT_FREED, resetInstrumentedAllocators());
+    EXPECT_EQ(totalAllocSize + TestAllocSize, getInstrumentedTotalAllocationSize());
+}
+
+TEST_F(InstrumentedAllocatorsTest, memory_leak_check_calloc)
+{
+    EXPECT_EQ(STATUS_SUCCESS, setInstrumentedAllocators());
+    SIZE_T totalAllocSize = getInstrumentedTotalAllocationSize();
+    PVOID pAlloc = MEMCALLOC(10, TestAllocSize);
+    MEMCHK(pAlloc, 0x00, 10 * TestAllocSize);
+    MEMSET(pAlloc, 0xFF, 10 * TestAllocSize);
+    MEMCHK(pAlloc, 0xff, 10 * TestAllocSize);
+    EXPECT_EQ(STATUS_MEMORY_NOT_FREED, resetInstrumentedAllocators());
+    EXPECT_EQ(totalAllocSize + 10 * TestAllocSize, getInstrumentedTotalAllocationSize());
+}
+
+TEST_F(InstrumentedAllocatorsTest, memory_leak_check_realloc_larger_small_diff)
+{
+    EXPECT_EQ(STATUS_SUCCESS, setInstrumentedAllocators());
+    SIZE_T totalAllocSize = getInstrumentedTotalAllocationSize();
+    PVOID pAlloc = MEMALLOC(TestAllocSize);
+    MEMSET(pAlloc, 0xFF, TestAllocSize);
+    MEMCHK(pAlloc, 0xff, TestAllocSize);
+    PVOID pRealloc = MEMREALLOC(pAlloc, TestAllocSize + 1);
+    MEMSET(pRealloc, 0xFF, TestAllocSize + 1);
+    MEMCHK(pRealloc, 0xff, TestAllocSize + 1);
+
+    EXPECT_EQ(STATUS_MEMORY_NOT_FREED, resetInstrumentedAllocators());
+    EXPECT_EQ(totalAllocSize + TestAllocSize + 1, getInstrumentedTotalAllocationSize());
+}
+
+TEST_F(InstrumentedAllocatorsTest, memory_leak_check_realloc_larger_large_diff)
+{
+    EXPECT_EQ(STATUS_SUCCESS, setInstrumentedAllocators());
+    SIZE_T totalAllocSize = getInstrumentedTotalAllocationSize();
+    PVOID pAlloc = MEMALLOC(TestAllocSize);
+    MEMSET(pAlloc, 0xFF, TestAllocSize);
+    MEMCHK(pAlloc, 0xff, TestAllocSize);
+    PVOID pRealloc = MEMREALLOC(pAlloc, 10 * TestAllocSize);
+    MEMSET(pRealloc, 0xFF, 10 * TestAllocSize);
+    MEMCHK(pRealloc, 0xff, 10 * TestAllocSize);
+
+    EXPECT_EQ(STATUS_MEMORY_NOT_FREED, resetInstrumentedAllocators());
+    EXPECT_EQ(totalAllocSize + 10 * TestAllocSize, getInstrumentedTotalAllocationSize());
+}
+
+TEST_F(InstrumentedAllocatorsTest, memory_leak_check_realloc_smaller_small_diff)
+{
+    EXPECT_EQ(STATUS_SUCCESS, setInstrumentedAllocators());
+    SIZE_T totalAllocSize = getInstrumentedTotalAllocationSize();
+    PVOID pAlloc = MEMALLOC(TestAllocSize);
+    MEMSET(pAlloc, 0xFF, TestAllocSize);
+    MEMCHK(pAlloc, 0xff, TestAllocSize);
+    PVOID pRealloc = MEMREALLOC(pAlloc, TestAllocSize - 1);
+    MEMSET(pRealloc, 0xFF, TestAllocSize - 1);
+    MEMCHK(pRealloc, 0xff, TestAllocSize - 1);
+
+    EXPECT_EQ(STATUS_MEMORY_NOT_FREED, resetInstrumentedAllocators());
+    EXPECT_EQ(totalAllocSize + TestAllocSize - 1, getInstrumentedTotalAllocationSize());
+}
+
+TEST_F(InstrumentedAllocatorsTest, memory_leak_check_realloc_smaller_large_diff)
+{
+    EXPECT_EQ(STATUS_SUCCESS, setInstrumentedAllocators());
+    SIZE_T totalAllocSize = getInstrumentedTotalAllocationSize();
+    PVOID pAlloc = MEMALLOC(TestAllocSize);
+    MEMSET(pAlloc, 0xFF, TestAllocSize);
+    MEMCHK(pAlloc, 0xff, TestAllocSize);
+    PVOID pRealloc = MEMREALLOC(pAlloc, TestAllocSize / 10);
+    MEMSET(pRealloc, 0xFF, TestAllocSize / 10);
+    MEMCHK(pRealloc, 0xff, TestAllocSize / 10);
+
+    EXPECT_EQ(STATUS_MEMORY_NOT_FREED, resetInstrumentedAllocators());
+    EXPECT_EQ(totalAllocSize + TestAllocSize / 10, getInstrumentedTotalAllocationSize());
+}

--- a/src/utils/tst/UtilTestFixture.h
+++ b/src/utils/tst/UtilTestFixture.h
@@ -67,23 +67,28 @@ extern memFree globalMemFree;
 
 class UtilTestBase : public ::testing::Test {
 public:
-    UtilTestBase()
+    UtilTestBase(BOOL setAllocators = TRUE)
     {
         // Store the function pointers
         gTotalUtilsMemoryUsage = 0;
-        storedMemAlloc = globalMemAlloc;
-        storedMemAlignAlloc = globalMemAlignAlloc;
-        storedMemCalloc = globalMemCalloc;
-        storedMemFree = globalMemFree;
 
-        // Create the mutex for the synchronization for the instrumentation
-        gUtilityMemMutex = MUTEX_CREATE(FALSE);
+        allocatorsSet = setAllocators;
 
-        // Save the instrumented ones
-        globalMemAlloc = instrumentedUtilMemAlloc;
-        globalMemAlignAlloc = instrumentedUtilMemAlignAlloc;
-        globalMemCalloc = instrumentedUtilMemCalloc;
-        globalMemFree = instrumentedUtilMemFree;
+        if (allocatorsSet) {
+            storedMemAlloc = globalMemAlloc;
+            storedMemAlignAlloc = globalMemAlignAlloc;
+            storedMemCalloc = globalMemCalloc;
+            storedMemFree = globalMemFree;
+
+            // Create the mutex for the synchronization for the instrumentation
+            gUtilityMemMutex = MUTEX_CREATE(FALSE);
+
+            // Save the instrumented ones
+            globalMemAlloc = instrumentedUtilMemAlloc;
+            globalMemAlignAlloc = instrumentedUtilMemAlignAlloc;
+            globalMemCalloc = instrumentedUtilMemCalloc;
+            globalMemFree = instrumentedUtilMemFree;
+        }
     };
 
     virtual void SetUp()
@@ -106,11 +111,14 @@ public:
         DLOGI("Final remaining allocation size is %llu\n", gTotalUtilsMemoryUsage);
 
         EXPECT_EQ((UINT64) 0, gTotalUtilsMemoryUsage);
-        globalMemAlloc = storedMemAlloc;
-        globalMemAlignAlloc = storedMemAlignAlloc;
-        globalMemCalloc = storedMemCalloc;
-        globalMemFree = storedMemFree;
-        MUTEX_FREE(gUtilityMemMutex);
+
+        if (allocatorsSet) {
+            globalMemAlloc = storedMemAlloc;
+            globalMemAlignAlloc = storedMemAlignAlloc;
+            globalMemCalloc = storedMemCalloc;
+            globalMemFree = storedMemFree;
+            MUTEX_FREE(gUtilityMemMutex);
+        }
     };
 
     PCHAR GetTestName()
@@ -125,4 +133,6 @@ protected:
     memAlignAlloc storedMemAlignAlloc;
     memCalloc storedMemCalloc;
     memFree storedMemFree;
+
+    BOOL allocatorsSet;
 };


### PR DESCRIPTION
Having an optional compile-time set/reset macros
Minor warning fixes
Unit tests


NOTE: Many of the unit tests overwrite the allocators to do final memory leak tracking. These are Client, Util, C producer, WebRTC Signaling Client unit tests. The instrumented allocator exposed publicly will be useful for the client application debugging any memory leaks. 

The main pattern is to build the application which would use the conditional compilation macros in the commit which in normal compile mode would be no-ops. In case of INSTRUMENTED_ALLOCATORS being set at compile time, the macros will evaluate to the actual calls to the APIs to set the instrumented allocators and re-set them. The pattern of usage will be - when the application starts, it calls SET_INSTRUMENTED_ALLOCATORS() before any allocations are made and on exit it will call RESET_INSTRUMENTED_ALLOCATORS() after all of the allocations are freed. The printout or the return value from the reset will indicate whether there is any memory leaks. 

Another pattern is for the canaries/long-run stress tests. The instrumented allocator not only allows for final checks for any leaks but also periodic reporting of total memory usage metric.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
