### PR TITLE
fix an edge case when view item with STREAM_STRAT flag is dropped bef…

### DIFF
--- a/src/client/src/Stream.c
+++ b/src/client/src/Stream.c
@@ -2074,6 +2074,11 @@ STATUS resetCurrentViewItemStreamStart(PKinesisVideoStream pKinesisVideoStream)
 
 CleanUp:
 
+    /* fix up retStatus if contentViewGetItemAt could not find curViewItem */
+    if (retStatus == STATUS_CONTENT_VIEW_INVALID_INDEX) {
+        retStatus = STATUS_SUCCESS;
+    }
+
     // Unmap the old mapping
     if (pFrame != NULL) {
         heapUnmap(pKinesisVideoClient->pHeap, (PVOID) pFrame);


### PR DESCRIPTION
…ore it's fully streamed, all subsequenct getStreamData fail with STATUS_CONTENT_VIEW_INVALID_INDEX

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
