### PR TITLE
Adding checks for multiple sets/resets of the instrumented allocators…

### DIFF
--- a/src/utils/include/com/amazonaws/kinesis/video/utils/Include.h
+++ b/src/utils/include/com/amazonaws/kinesis/video/utils/Include.h
@@ -1323,6 +1323,20 @@ PUBLIC_API STATUS semaphoreWaitUntilClear(SEMAPHORE_HANDLE, UINT64);
 PUBLIC_API STATUS setInstrumentedAllocators();
 
 /**
+ * No-op equivalent of the setInstrumentedAllocators.
+ *
+ * NOTE: This is needed to allow the applications to use the macro which evaluates
+ * at compile time based on the INSTRUMENTED_ALLOCATORS compiler definition.
+ * The reason for the API is due to inability to get a no-op C macro compilable
+ * across different languages and compilers with l-values.
+ *
+ * ex: CHK_STATUS(SET_INSTRUMENTED_ALLOCATORS);
+ *
+ * @return - STATUS code of the execution
+ */
+PUBLIC_API STATUS setInstrumentedAllocatorsNoop();
+
+/**
  * Resets the global allocators to the original ones.
  *
  * NOTE: Any attempt to free allocations which were allocated after set call
@@ -1331,6 +1345,20 @@ PUBLIC_API STATUS setInstrumentedAllocators();
  * @return - STATUS code of the execution
  */
 PUBLIC_API STATUS resetInstrumentedAllocators();
+
+/**
+ * No-op equivalent of the resetInstrumentedAllocators.
+ *
+ * NOTE: This is needed to allow the applications to use the macro which evaluates
+ * at compile time based on the INSTRUMENTED_ALLOCATORS compiler definition.
+ * The reason for the API is due to inability to get a no-op C macro compilable
+ * across different languages and compilers with l-values.
+ *
+ * ex: CHK_STATUS(RESET_INSTRUMENTED_ALLOCATORS);
+ *
+ * @return - STATUS code of the execution
+ */
+PUBLIC_API STATUS resetInstrumentedAllocatorsNoop();
 
 /**
  * Returns the current total allocation size.
@@ -1343,8 +1371,8 @@ PUBLIC_API SIZE_T getInstrumentedTotalAllocationSize();
 #define SET_INSTRUMENTED_ALLOCATORS()               setInstrumentedAllocators()
 #define RESET_INSTRUMENTED_ALLOCATORS()             resetInstrumentedAllocators()
 #else
-#define SET_INSTRUMENTED_ALLOCATORS()               ({STATUS __noopStatusSuccess = STATUS_SUCCESS; do { if (0) setInstrumentedAllocators(); } while (0); __noopStatusSuccess;})
-#define RESET_INSTRUMENTED_ALLOCATORS()             ({STATUS __noopStatusSuccess = STATUS_SUCCESS; do { if (0) resetInstrumentedAllocators(); } while (0); __noopStatusSuccess;})
+#define SET_INSTRUMENTED_ALLOCATORS()               setInstrumentedAllocatorsNoop()
+#define RESET_INSTRUMENTED_ALLOCATORS()             resetInstrumentedAllocatorsNoop()
 #endif
 
 #ifdef __cplusplus

--- a/src/utils/include/com/amazonaws/kinesis/video/utils/Include.h
+++ b/src/utils/include/com/amazonaws/kinesis/video/utils/Include.h
@@ -1343,8 +1343,8 @@ PUBLIC_API SIZE_T getInstrumentedTotalAllocationSize();
 #define SET_INSTRUMENTED_ALLOCATORS()               setInstrumentedAllocators()
 #define RESET_INSTRUMENTED_ALLOCATORS()             resetInstrumentedAllocators()
 #else
-#define SET_INSTRUMENTED_ALLOCATORS()               do { if (0) setInstrumentedAllocators(); } while (0)
-#define RESET_INSTRUMENTED_ALLOCATORS()             do { if (0) resetInstrumentedAllocators(); } while (0)
+#define SET_INSTRUMENTED_ALLOCATORS()               ({STATUS __noopStatusSuccess = STATUS_SUCCESS; do { if (0) setInstrumentedAllocators(); } while (0); __noopStatusSuccess;})
+#define RESET_INSTRUMENTED_ALLOCATORS()             ({STATUS __noopStatusSuccess = STATUS_SUCCESS; do { if (0) resetInstrumentedAllocators(); } while (0); __noopStatusSuccess;})
 #endif
 
 #ifdef __cplusplus

--- a/src/utils/src/InstrumentedAllocators.c
+++ b/src/utils/src/InstrumentedAllocators.c
@@ -38,6 +38,12 @@ CleanUp:
     return retStatus;
 }
 
+STATUS setInstrumentedAllocatorsNoop()
+{
+    // No-op function
+    return STATUS_SUCCESS;
+}
+
 STATUS resetInstrumentedAllocators()
 {
     STATUS retStatus = STATUS_SUCCESS;
@@ -72,6 +78,12 @@ CleanUp:
 
     CHK_LOG_ERR(retStatus);
     return retStatus;
+}
+
+STATUS resetInstrumentedAllocatorsNoop()
+{
+    // No-op function
+    return STATUS_SUCCESS;
 }
 
 SIZE_T getInstrumentedTotalAllocationSize()

--- a/src/utils/src/InstrumentedAllocators.c
+++ b/src/utils/src/InstrumentedAllocators.c
@@ -2,14 +2,22 @@
 
 volatile SIZE_T gInstrumentedAllocatorsTotalAllocationSize = 0;
 
-memAlloc gInstrumentedAllocatorsStoredMemAlloc;
-memAlignAlloc gInstrumentedAllocatorsStoredMemAlignAlloc;
-memCalloc gInstrumentedAllocatorsStoredMemCalloc;
-memFree gInstrumentedAllocatorsStoredMemFree;
-memRealloc gInstrumentedAllocatorsStoredMemRealloc;
+memAlloc gInstrumentedAllocatorsStoredMemAlloc = NULL;
+memAlignAlloc gInstrumentedAllocatorsStoredMemAlignAlloc = NULL;
+memCalloc gInstrumentedAllocatorsStoredMemCalloc = NULL;
+memFree gInstrumentedAllocatorsStoredMemFree = NULL;
+memRealloc gInstrumentedAllocatorsStoredMemRealloc = NULL;
 
 STATUS setInstrumentedAllocators()
 {
+    STATUS retStatus = STATUS_SUCCESS;
+    // Check if we are attempting to set the instrumented allocators again
+    CHK(gInstrumentedAllocatorsStoredMemAlloc == NULL &&
+        gInstrumentedAllocatorsStoredMemAlignAlloc == NULL &&
+        gInstrumentedAllocatorsStoredMemCalloc == NULL &&
+        gInstrumentedAllocatorsStoredMemFree == NULL &&
+        gInstrumentedAllocatorsStoredMemRealloc == NULL, STATUS_INVALID_OPERATION);
+
     // Store the existing function pointers
     gInstrumentedAllocatorsStoredMemAlloc = globalMemAlloc;
     gInstrumentedAllocatorsStoredMemAlignAlloc = globalMemAlignAlloc;
@@ -24,13 +32,23 @@ STATUS setInstrumentedAllocators()
     globalMemFree = instrumentedAllocatorsMemFree;
     globalMemRealloc = instrumentedAllocatorsMemRealloc;
 
-    return STATUS_SUCCESS;
+CleanUp:
+
+    CHK_LOG_ERR(retStatus);
+    return retStatus;
 }
 
 STATUS resetInstrumentedAllocators()
 {
     STATUS retStatus = STATUS_SUCCESS;
     SIZE_T totalRemainingSize = ATOMIC_LOAD(&gInstrumentedAllocatorsTotalAllocationSize);
+
+    // Check if we are attempting to reset without setting or attempting to reset again
+    CHK(globalMemAlloc == instrumentedAllocatorsMemAlloc &&
+        globalMemAlignAlloc == instrumentedAllocatorsMemAlignAlloc &&
+        globalMemCalloc == instrumentedAllocatorsMemCalloc &&
+        globalMemFree == instrumentedAllocatorsMemFree &&
+        globalMemRealloc == instrumentedAllocatorsMemRealloc, STATUS_INVALID_OPERATION);
 
     // Reset the global allocators with the stored ones
     globalMemAlloc = gInstrumentedAllocatorsStoredMemAlloc;
@@ -39,9 +57,16 @@ STATUS resetInstrumentedAllocators()
     globalMemFree = gInstrumentedAllocatorsStoredMemFree;
     globalMemRealloc = gInstrumentedAllocatorsStoredMemRealloc;
 
+    // Reset the stored allocator function pointers to ensure we are OK to set again
+    gInstrumentedAllocatorsStoredMemAlloc = NULL;
+    gInstrumentedAllocatorsStoredMemAlignAlloc = NULL;
+    gInstrumentedAllocatorsStoredMemCalloc = NULL;
+    gInstrumentedAllocatorsStoredMemFree = NULL;
+    gInstrumentedAllocatorsStoredMemRealloc = NULL;
+
     // Check the final total value
     CHK_WARN(totalRemainingSize == 0, STATUS_MEMORY_NOT_FREED,
-            "Possible memory leak of size %" PRIu64, totalRemainingSize);
+             "Possible memory leak of size %" PRIu64, totalRemainingSize);
 
 CleanUp:
 

--- a/src/utils/tst/InstrumentedAllocators.cpp
+++ b/src/utils/tst/InstrumentedAllocators.cpp
@@ -95,6 +95,25 @@ TEST_F(InstrumentedAllocatorsTest, set_reset_negative_test)
     EXPECT_EQ(STATUS_INVALID_OPERATION, resetInstrumentedAllocators());
 }
 
+TEST_F(InstrumentedAllocatorsTest, noop_allocators_test)
+{
+    EXPECT_EQ(STATUS_SUCCESS, resetInstrumentedAllocatorsNoop());
+
+    EXPECT_EQ(STATUS_SUCCESS, setInstrumentedAllocatorsNoop());
+    EXPECT_EQ(STATUS_SUCCESS, setInstrumentedAllocatorsNoop());
+
+    EXPECT_EQ(STATUS_SUCCESS, resetInstrumentedAllocatorsNoop());
+    EXPECT_EQ(STATUS_SUCCESS, resetInstrumentedAllocatorsNoop());
+
+    // Attempt with the allocators
+    EXPECT_EQ(STATUS_SUCCESS, setInstrumentedAllocators());
+    EXPECT_EQ(STATUS_SUCCESS, setInstrumentedAllocatorsNoop());
+
+    EXPECT_EQ(STATUS_SUCCESS, resetInstrumentedAllocatorsNoop());
+    EXPECT_EQ(STATUS_SUCCESS, resetInstrumentedAllocators());
+    EXPECT_EQ(STATUS_SUCCESS, resetInstrumentedAllocatorsNoop());
+}
+
 TEST_F(InstrumentedAllocatorsTest, memory_leak_check_malloc)
 {
     EXPECT_EQ(STATUS_SUCCESS, setInstrumentedAllocators());

--- a/src/utils/tst/InstrumentedAllocators.cpp
+++ b/src/utils/tst/InstrumentedAllocators.cpp
@@ -20,7 +20,7 @@ TEST_F(InstrumentedAllocatorsTest, set_reset_basic_test)
     SIZE_T totalAllocSize = getInstrumentedTotalAllocationSize();
 
 #ifndef INSTRUMENTED_ALLOCATORS
-    SET_INSTRUMENTED_ALLOCATORS();
+    EXPECT_EQ(STATUS_SUCCESS, SET_INSTRUMENTED_ALLOCATORS());
 
     // Check that we have not set anything actually
     EXPECT_EQ(storedMemAlloc, globalMemAlloc);
@@ -29,7 +29,7 @@ TEST_F(InstrumentedAllocatorsTest, set_reset_basic_test)
     EXPECT_EQ(storedMemFree, globalMemFree);
     EXPECT_EQ(storedMemRealloc, globalMemRealloc);
 
-    RESET_INSTRUMENTED_ALLOCATORS();
+    EXPECT_EQ(STATUS_SUCCESS, RESET_INSTRUMENTED_ALLOCATORS());
 
     EXPECT_EQ(storedMemAlloc, globalMemAlloc);
     EXPECT_EQ(storedMemAlignAlloc, globalMemAlignAlloc);
@@ -37,7 +37,7 @@ TEST_F(InstrumentedAllocatorsTest, set_reset_basic_test)
     EXPECT_EQ(storedMemFree, globalMemFree);
     EXPECT_EQ(storedMemRealloc, globalMemRealloc);
 #else
-    SET_INSTRUMENTED_ALLOCATORS();
+    EXPECT_EQ(STATUS_SUCCESS, SET_INSTRUMENTED_ALLOCATORS());
 
     // Check that the allocators have changed
     EXPECT_NE(storedMemAlloc, globalMemAlloc);
@@ -46,7 +46,7 @@ TEST_F(InstrumentedAllocatorsTest, set_reset_basic_test)
     EXPECT_NE(storedMemFree, globalMemFree);
     EXPECT_NE(storedMemRealloc, globalMemRealloc);
 
-    RESET_INSTRUMENTED_ALLOCATORS();
+    EXPECT_EQ(STATUS_SUCCESS, RESET_INSTRUMENTED_ALLOCATORS());
 
     // Reset back to the stored ones
     EXPECT_EQ(storedMemAlloc, globalMemAlloc);
@@ -79,6 +79,20 @@ TEST_F(InstrumentedAllocatorsTest, set_reset_basic_test)
     }
 
     EXPECT_EQ(totalAllocSize, getInstrumentedTotalAllocationSize());
+}
+
+TEST_F(InstrumentedAllocatorsTest, set_reset_negative_test)
+{
+    // Attempting to reset without setting it first
+    EXPECT_EQ(STATUS_INVALID_OPERATION, resetInstrumentedAllocators());
+
+    // Double-set
+    EXPECT_EQ(STATUS_SUCCESS, setInstrumentedAllocators());
+    EXPECT_EQ(STATUS_INVALID_OPERATION, setInstrumentedAllocators());
+
+    // Reset twice
+    EXPECT_EQ(STATUS_SUCCESS, resetInstrumentedAllocators());
+    EXPECT_EQ(STATUS_INVALID_OPERATION, resetInstrumentedAllocators());
 }
 
 TEST_F(InstrumentedAllocatorsTest, memory_leak_check_malloc)


### PR DESCRIPTION
… to avoid hard-to-debug memory crashes on double set or when resetting unset allocators. Also, ensuring that NO-OP macros work with L-values.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
