### PR TITLE
fix strnchr read over buffer when string is not null terminated

### DIFF
--- a/src/utils/src/String.c
+++ b/src/utils/src/String.c
@@ -305,7 +305,7 @@ PCHAR strnchr(PCHAR pStr, UINT32 strLen, CHAR ch)
     UINT32 i = 0;
 
     while (*pStr != ch) {
-        if (*pStr++ == '\0' || i++ == strLen) {
+        if (*pStr++ == '\0' || i++ == strLen - 1) {
             return NULL;
         }
     }

--- a/src/utils/tst/FindStringTest.cpp
+++ b/src/utils/tst/FindStringTest.cpp
@@ -6,6 +6,7 @@ class FindStringFunctionalityTest : public UtilTestBase {
 TEST_F(FindStringFunctionalityTest, Negative_Positive_Variations)
 {
     PCHAR pRet;
+    CHAR notNullTerminatedStr[] = {'a', 'b', 'c'};
 
     EXPECT_EQ(NULL, STRNCHR(NULL, 0, 'a'));
     EXPECT_EQ(NULL, STRNCHR(NULL, 10, 'a'));
@@ -23,6 +24,7 @@ TEST_F(FindStringFunctionalityTest, Negative_Positive_Variations)
 
     EXPECT_EQ(NULL, STRNCHR((PCHAR) "abc", (UINT32) STRLEN((PCHAR) "abc"), 'd'));
     EXPECT_EQ(NULL, STRNCHR((PCHAR) "abc", 100, 'd'));
+    EXPECT_EQ(NULL, STRNCHR((PCHAR) notNullTerminatedStr, 3, 'd'));
 
     pRet = STRNCHR((PCHAR) "abc", 1, 'a');
     EXPECT_EQ('a', *pRet);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
