### PR TITLE
Adding a realtime clock to be used primarily for cvars as default pla…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,5 @@
 build
 cmake-build-debug/
 cmake-build-release/
-open-source/libgtest
-open-source/local
+open-source/
 outputs

--- a/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
+++ b/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
@@ -658,6 +658,7 @@ PUBLIC_API INLINE UINT64 defaultGetTime();
 // Thread related functionality
 //
 extern getTime globalGetTime;
+extern getTime globalGetRealTime;
 
 //
 // Thread library function definitions
@@ -939,6 +940,7 @@ extern PUBLIC_API atomicXor globalAtomicXor;
 // Time functionality
 //
 #define GETTIME                     globalGetTime
+#define GETREALTIME                 globalGetRealTime
 #define STRFTIME                    strftime
 #define GMTIME                      gmtime
 

--- a/src/utils/src/Mutex.c
+++ b/src/utils/src/Mutex.c
@@ -284,7 +284,7 @@ STATUS defaultConditionVariableWait(CVAR cvar, MUTEX mutex, UINT64 timeout)
     INT32 retVal = 0;
     struct timespec timeSpec;
     pthread_mutex_t* pMutex = (pthread_mutex_t*) mutex;
-    UINT64 curTime = GETTIME();
+    UINT64 curTime = GETREALTIME();
 
     // Timeout is a duration so we need to construct an absolute time
     UINT64 time = timeout + curTime;

--- a/src/utils/src/Time.c
+++ b/src/utils/src/Time.c
@@ -1,6 +1,7 @@
 #include "Include_i.h"
 
 getTime globalGetTime = defaultGetTime;
+getTime globalGetRealTime = defaultGetTime;
 
 STATUS generateTimestampStr(UINT64 timestamp, PCHAR formatStr, PCHAR pDestBuffer, UINT32 destBufferLen,
                             PUINT32 pFormattedStrLen)


### PR DESCRIPTION
…tform implementations depend on realtime clocks and overwritten time functionality will be broken.

Issue #28 
Issue #61 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
