### PR TITLE
Fix unupdated size for instrusmented realloc

### DIFF
--- a/src/utils/src/InstrumentedAllocators.c
+++ b/src/utils/src/InstrumentedAllocators.c
@@ -170,6 +170,7 @@ PVOID instrumentedAllocatorsMemRealloc(PVOID ptr, SIZE_T size)
     } else {
         ATOMIC_ADD(&gInstrumentedAllocatorsTotalAllocationSize, size - existingSize);
     }
+    *pNewAlloc = size;
 
     return pNewAlloc + 1;
 }


### PR DESCRIPTION
Instrumented realloc doesn't keep track the memory size that was allocated originally.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
