### PR TITLE
Add strnstr implementation for non-BSD

### DIFF
--- a/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
+++ b/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
@@ -803,7 +803,11 @@ extern PUBLIC_API atomicXor globalAtomicXor;
 #define LTRIMSTR                   ltrimstr
 #define RTRIMSTR                   rtrimstr
 #define STRSTR                     strstr
+#ifdef strnstr
 #define STRNSTR                    strnstr
+#else
+#define STRNSTR                    defaultStrnstr
+#endif
 #define TOLOWER                    tolower
 #define TOUPPER                    toupper
 #define TOLOWERSTR                 tolowerstr

--- a/src/utils/include/com/amazonaws/kinesis/video/utils/Include.h
+++ b/src/utils/include/com/amazonaws/kinesis/video/utils/Include.h
@@ -110,6 +110,17 @@ PUBLIC_API STATUS strtoi64(PCHAR, PCHAR, UINT32, PINT64);
 PUBLIC_API PCHAR strnchr(PCHAR, UINT32, CHAR);
 
 /**
+ * Safe variant of strstr. This is a default implementation for strnstr when not available.
+ *
+ * @param 1 - IN - Input string to process
+ * @param 3 - IN - The string to look for
+ * @param 2 - IN - String length.
+ *
+ * @return - Pointer to the first occurrence or NULL
+ */
+PUBLIC_API PCHAR defaultStrnstr(PCHAR, PCHAR, SIZE_T);
+
+/**
  * Left and right trim of the whitespace
  *
  * @param 1 - IN - Input string to process

--- a/src/utils/tst/StringSearch.cpp
+++ b/src/utils/tst/StringSearch.cpp
@@ -1,0 +1,63 @@
+#include "UtilTestFixture.h"
+
+class StringSearchFunctionalityTest : public UtilTestBase {
+};
+
+TEST_F(StringSearchFunctionalityTest, NegativeInvalidInput) {
+    CHAR str[] = "this is a test";
+    EXPECT_EQ(NULL, defaultStrnstr(NULL, NULL, 0));
+    EXPECT_EQ(str, defaultStrnstr(str, NULL, 0));
+    EXPECT_EQ(NULL, defaultStrnstr(NULL, str, 0));
+    EXPECT_EQ(NULL, defaultStrnstr(str, str, 1));
+    EXPECT_EQ(str, defaultStrnstr(str, (PCHAR) "", ARRAY_SIZE(str) - 1));
+    EXPECT_EQ(NULL, defaultStrnstr((PCHAR) "", str, 1));
+    EXPECT_EQ(NULL, defaultStrnstr(str, (PCHAR) "this is a test with extra length", ARRAY_SIZE(str) - 1));
+}
+
+TEST_F(StringSearchFunctionalityTest, ExactMatch_WithoutLen) {
+    CHAR str[] = "this is a test";
+    EXPECT_EQ(str, defaultStrnstr(str, str, ARRAY_SIZE(str) - 1));
+}
+
+TEST_F(StringSearchFunctionalityTest, ExactMatch_WithLen) {
+    CHAR str1[] = "this is a test";
+    CHAR str2[] = "this is";
+    EXPECT_EQ(str1, defaultStrnstr(str1, str2, ARRAY_SIZE(str2) - 1));
+}
+
+auto randStr = [](SIZE_T n) -> std::string {
+    std::string s;
+
+    // not ideal, but it's important to always randomize rand
+    SRAND(GETTIME());
+    for (int i = 0; i < n; i++) {
+        // 8 bits contain 255 characters + 1 null character
+        s += (CHAR)(RAND() % 255) + 1;
+    }
+
+    return s;
+};
+
+TEST_F(StringSearchFunctionalityTest, BigString_BigHaystack) {
+    std::string str1;
+    std::string str2;
+
+    str1 += randStr(10000);
+    str2 = "this is the needle";
+    str1 += str2;
+    str1 += randStr(10000);
+
+    EXPECT_EQ(STRSTR(str1.c_str(), str2.c_str()), defaultStrnstr((PCHAR) str1.c_str(), (PCHAR) str2.c_str(), str1.size()));
+}
+
+TEST_F(StringSearchFunctionalityTest, BigString_BigNeedle) {
+    std::string str1;
+    std::string str2;
+
+    str1 += randStr(10000);
+    str2 = randStr(10000);
+    str1 += str2;
+    str1 += randStr(10000);
+
+    EXPECT_EQ(STRSTR(str1.c_str(), str2.c_str()), defaultStrnstr((PCHAR) str1.c_str(), (PCHAR) str2.c_str(), str1.size()));
+}


### PR DESCRIPTION
`STRNSTR` is defined in common def. But, unfortunately, `strnstr` is only defined in BSD. So, to make `STRNSTR` available for all platforms, this PR will add a default implementation in Rabin Karp algorithm.

`STRNSTR` is also needed for this PR, https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/pull/600.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
