### PR TITLE
Skipping non-key-frames at start.

### DIFF
--- a/src/client/src/Stream.c
+++ b/src/client/src/Stream.c
@@ -119,8 +119,8 @@ STATUS createStream(PKinesisVideoClient pKinesisVideoClient, PStreamInfo pStream
     // Shouldn't reset the generator on next key frame
     pKinesisVideoStream->resetGeneratorOnKeyFrame = FALSE;
 
-    // Shouldn't skip frames
-    pKinesisVideoStream->skipNonKeyFrames = FALSE;
+    // Skip non-key frames at start
+    pKinesisVideoStream->skipNonKeyFrames = TRUE;
 
     // Shouldn't reset the generator so set invalid time
     pKinesisVideoStream->resetGeneratorTime = INVALID_TIMESTAMP_VALUE;

--- a/src/client/tst/StreamPutGetTest.cpp
+++ b/src/client/tst/StreamPutGetTest.cpp
@@ -882,9 +882,10 @@ TEST_F(StreamPutGetTest, putFrame_PutGetNonKeyFrameFirstFrame)
 
     // Consume frames on the boundary and validate
 
-    for (i = 0, timestamp = 0; timestamp < TEST_BUFFER_DURATION; timestamp += TEST_LONG_FRAME_DURATION, i++) {
+    // The first cluster frames will be skipped due to no-key-frame start
+    for (i = 10, timestamp = 0; timestamp < TEST_BUFFER_DURATION; timestamp += TEST_LONG_FRAME_DURATION, i++) {
         // The first frame will have the cluster and MKV overhead
-        if (i == 0) {
+        if (i == 10) {
             offset = mkvgenGetMkvHeaderOverhead((PStreamMkvGenerator) FROM_STREAM_HANDLE(mStreamHandle)->pMkvGenerator);
         } else if (i % 10 == 0) {
             // Cluster start will have cluster overhead
@@ -897,20 +898,28 @@ TEST_F(StreamPutGetTest, putFrame_PutGetNonKeyFrameFirstFrame)
         // Set the buffer size to be the offset + frame bits size
         bufferSize = SIZEOF(tempBuffer) + offset;
 
-        EXPECT_EQ(STATUS_SUCCESS,
-                  getKinesisVideoStreamData(mStreamHandle, TEST_UPLOAD_HANDLE, getDataBuffer, bufferSize, &filledSize));
-        EXPECT_EQ(bufferSize, filledSize);
+        if (timestamp < TEST_BUFFER_DURATION - 10 * TEST_LONG_FRAME_DURATION) {
+            EXPECT_EQ(STATUS_SUCCESS,
+                      getKinesisVideoStreamData(mStreamHandle, TEST_UPLOAD_HANDLE, getDataBuffer, bufferSize,
+                                                &filledSize));
+            EXPECT_EQ(bufferSize, filledSize);
 
-        // Validate the fill pattern
-        validPattern = TRUE;
-        for (j = 0; j < SIZEOF(tempBuffer); j++) {
-            if (getDataBuffer[offset + j] != i) {
-                validPattern = FALSE;
-                break;
+            // Validate the fill pattern
+            validPattern = TRUE;
+            for (j = 0; j < SIZEOF(tempBuffer); j++) {
+                if (getDataBuffer[offset + j] != i) {
+                    validPattern = FALSE;
+                    break;
+                }
             }
-        }
 
-        EXPECT_TRUE(validPattern) << "Failed at offset: " << j << " from the beginning of frame: " << i;
+            EXPECT_TRUE(validPattern) << "Failed at offset: " << j << " from the beginning of frame: " << i;
+        } else {
+            // We should get STATUS_NO_MORE_DATA_AVAILABLE
+            EXPECT_EQ(STATUS_NO_MORE_DATA_AVAILABLE,
+                      getKinesisVideoStreamData(mStreamHandle, TEST_UPLOAD_HANDLE, getDataBuffer, bufferSize,
+                                                &filledSize));
+        }
     }
 }
 
@@ -971,9 +980,10 @@ TEST_F(StreamPutGetTest, putFrame_PutGetNonKeyFrameFirstFrameCpd1Byte)
 
     // Consume frames on the boundary and validate
 
-    for (i = 0, timestamp = 0; timestamp < TEST_BUFFER_DURATION; timestamp += TEST_LONG_FRAME_DURATION, i++) {
+    // The first cluster frames will be dropped as the frame is not marked as a key-frame at start
+    for (i = 10, timestamp = 0; timestamp < TEST_BUFFER_DURATION; timestamp += TEST_LONG_FRAME_DURATION, i++) {
         // The first frame will have the cluster and MKV overhead
-        if (i == 0) {
+        if (i == 10) {
             // CPD + CPD elem size + CPD encoded len
             offset = mkvgenGetMkvHeaderOverhead((PStreamMkvGenerator) FROM_STREAM_HANDLE(mStreamHandle)->pMkvGenerator);
         } else if (i % 10 == 0) {
@@ -987,20 +997,28 @@ TEST_F(StreamPutGetTest, putFrame_PutGetNonKeyFrameFirstFrameCpd1Byte)
         // Set the buffer size to be the offset + frame bits size
         bufferSize = SIZEOF(tempBuffer) + offset;
 
-        EXPECT_EQ(STATUS_SUCCESS,
-                  getKinesisVideoStreamData(mStreamHandle, TEST_UPLOAD_HANDLE, getDataBuffer, bufferSize, &filledSize));
-        EXPECT_EQ(bufferSize, filledSize);
+        if (timestamp < TEST_BUFFER_DURATION - 10 * TEST_LONG_FRAME_DURATION) {
+            EXPECT_EQ(STATUS_SUCCESS,
+                      getKinesisVideoStreamData(mStreamHandle, TEST_UPLOAD_HANDLE, getDataBuffer, bufferSize,
+                                                &filledSize));
+            EXPECT_EQ(bufferSize, filledSize);
 
-        // Validate the fill pattern
-        validPattern = TRUE;
-        for (j = 0; j < SIZEOF(tempBuffer); j++) {
-            if (getDataBuffer[offset + j] != i) {
-                validPattern = FALSE;
-                break;
+            // Validate the fill pattern
+            validPattern = TRUE;
+            for (j = 0; j < SIZEOF(tempBuffer); j++) {
+                if (getDataBuffer[offset + j] != i) {
+                    validPattern = FALSE;
+                    break;
+                }
             }
-        }
 
-        EXPECT_TRUE(validPattern) << "Failed at offset: " << j << " from the beginning of frame: " << i;
+            EXPECT_TRUE(validPattern) << "Failed at offset: " << j << " from the beginning of frame: " << i;
+        } else {
+            // Should be getting no more data
+            EXPECT_EQ(STATUS_NO_MORE_DATA_AVAILABLE,
+                      getKinesisVideoStreamData(mStreamHandle, TEST_UPLOAD_HANDLE, getDataBuffer, bufferSize,
+                                                &filledSize));
+        }
     }
 }
 
@@ -1061,9 +1079,10 @@ TEST_F(StreamPutGetTest, putFrame_PutGetNonKeyFrameFirstFrameCpd2Byte)
 
     // Consume frames on the boundary and validate
 
-    for (i = 0, timestamp = 0; timestamp < TEST_BUFFER_DURATION; timestamp += TEST_LONG_FRAME_DURATION, i++) {
+    // The first cluster frames will be skipped due to non-key-frame start.
+    for (i = 10, timestamp = 0; timestamp < TEST_BUFFER_DURATION; timestamp += TEST_LONG_FRAME_DURATION, i++) {
         // The first frame will have the cluster and MKV overhead
-        if (i == 0) {
+        if (i == 10) {
             // CPD + CPD elem size + CPD encoded len
             offset = mkvgenGetMkvHeaderOverhead((PStreamMkvGenerator) FROM_STREAM_HANDLE(mStreamHandle)->pMkvGenerator);
         } else if (i % 10 == 0) {
@@ -1077,20 +1096,28 @@ TEST_F(StreamPutGetTest, putFrame_PutGetNonKeyFrameFirstFrameCpd2Byte)
         // Set the buffer size to be the offset + frame bits size
         bufferSize = SIZEOF(tempBuffer) + offset;
 
-        EXPECT_EQ(STATUS_SUCCESS,
-                  getKinesisVideoStreamData(mStreamHandle, TEST_UPLOAD_HANDLE, getDataBuffer, bufferSize, &filledSize));
-        EXPECT_EQ(bufferSize, filledSize);
+        if (timestamp < TEST_BUFFER_DURATION - 10 * TEST_LONG_FRAME_DURATION) {
+            EXPECT_EQ(STATUS_SUCCESS,
+                      getKinesisVideoStreamData(mStreamHandle, TEST_UPLOAD_HANDLE, getDataBuffer, bufferSize,
+                                                &filledSize));
+            EXPECT_EQ(bufferSize, filledSize);
 
-        // Validate the fill pattern
-        validPattern = TRUE;
-        for (j = 0; j < SIZEOF(tempBuffer); j++) {
-            if (getDataBuffer[offset + j] != i) {
-                validPattern = FALSE;
-                break;
+            // Validate the fill pattern
+            validPattern = TRUE;
+            for (j = 0; j < SIZEOF(tempBuffer); j++) {
+                if (getDataBuffer[offset + j] != i) {
+                    validPattern = FALSE;
+                    break;
+                }
             }
-        }
 
-        EXPECT_TRUE(validPattern) << "Failed at offset: " << j << " from the beginning of frame: " << i;
+            EXPECT_TRUE(validPattern) << "Failed at offset: " << j << " from the beginning of frame: " << i;
+        } else {
+            // Should be getting no more data status due to skipped frames at the start
+            EXPECT_EQ(STATUS_NO_MORE_DATA_AVAILABLE,
+                      getKinesisVideoStreamData(mStreamHandle, TEST_UPLOAD_HANDLE, getDataBuffer, bufferSize,
+                                                &filledSize));
+        }
     }
 }
 
@@ -1153,9 +1180,10 @@ TEST_F(StreamPutGetTest, putFrame_PutGetNonKeyFrameFirstFrameCpd3Byte)
 
     // Consume frames on the boundary and validate
 
-    for (i = 0, timestamp = 0; timestamp < TEST_BUFFER_DURATION; timestamp += TEST_LONG_FRAME_DURATION, i++) {
+    // The first cluster frames will be skipped due to a non-key-frame start
+    for (i = 10, timestamp = 0; timestamp < TEST_BUFFER_DURATION; timestamp += TEST_LONG_FRAME_DURATION, i++) {
         // The first frame will have the cluster and MKV overhead
-        if (i == 0) {
+        if (i == 10) {
             // CPD + CPD elem size + CPD encoded len
             offset = mkvgenGetMkvHeaderOverhead((PStreamMkvGenerator) FROM_STREAM_HANDLE(mStreamHandle)->pMkvGenerator);
         } else if (i % 10 == 0) {
@@ -1169,20 +1197,28 @@ TEST_F(StreamPutGetTest, putFrame_PutGetNonKeyFrameFirstFrameCpd3Byte)
         // Set the buffer size to be the offset + frame bits size
         bufferSize = SIZEOF(tempBuffer) + offset;
 
-        EXPECT_EQ(STATUS_SUCCESS,
-                  getKinesisVideoStreamData(mStreamHandle, TEST_UPLOAD_HANDLE, getDataBuffer, bufferSize, &filledSize));
-        EXPECT_EQ(bufferSize, filledSize);
+        if (timestamp < TEST_BUFFER_DURATION - 10 * TEST_LONG_FRAME_DURATION) {
+            EXPECT_EQ(STATUS_SUCCESS,
+                      getKinesisVideoStreamData(mStreamHandle, TEST_UPLOAD_HANDLE, getDataBuffer, bufferSize,
+                                                &filledSize));
+            EXPECT_EQ(bufferSize, filledSize);
 
-        // Validate the fill pattern
-        validPattern = TRUE;
-        for (j = 0; j < SIZEOF(tempBuffer); j++) {
-            if (getDataBuffer[offset + j] != i) {
-                validPattern = FALSE;
-                break;
+            // Validate the fill pattern
+            validPattern = TRUE;
+            for (j = 0; j < SIZEOF(tempBuffer); j++) {
+                if (getDataBuffer[offset + j] != i) {
+                    validPattern = FALSE;
+                    break;
+                }
             }
-        }
 
-        EXPECT_TRUE(validPattern) << "Failed at offset: " << j << " from the beginning of frame: " << i;
+            EXPECT_TRUE(validPattern) << "Failed at offset: " << j << " from the beginning of frame: " << i;
+        } else {
+            // We should be getting no more data status as we skipped the first frames
+            EXPECT_EQ(STATUS_NO_MORE_DATA_AVAILABLE,
+                      getKinesisVideoStreamData(mStreamHandle, TEST_UPLOAD_HANDLE, getDataBuffer, bufferSize,
+                                                &filledSize));
+        }
     }
     MEMFREE(cpd);
     MEMFREE(getDataBuffer);


### PR DESCRIPTION
Issue: https://github.com/awslabs/amazon-kinesis-video-streams-pic/issues/76

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
