### PR TITLE
add H264/uLaw Content Type definition; add MKV_PCM_xxx Codec ID defin…

### DIFF
--- a/src/mkvgen/include/com/amazonaws/kinesis/video/mkvgen/Include.h
+++ b/src/mkvgen/include/com/amazonaws/kinesis/video/mkvgen/Include.h
@@ -150,6 +150,7 @@ extern "C" {
 #define MKV_AVC_CONTENT_TYPE                ((PCHAR) "video/avc")
 #define MKV_HEVC_CONTENT_TYPE               ((PCHAR) "video/hevc")
 #define MKV_H264_AAC_MULTI_CONTENT_TYPE     ((PCHAR) "video/h264,audio/aac")
+#define MKV_H264_MULAW_MULTI_CONTENT_TYPE     ((PCHAR) "video/h264,audio/mulaw")
 
 /**
  * Constant definitions for some known codec IDs
@@ -159,6 +160,9 @@ extern "C" {
 #define MKV_H265_HEVC_CODEC_ID              ((PCHAR) "V_MPEGH/ISO/HEVC")
 #define MKV_AAC_MPEG4_MAIN_CODEC_ID         ((PCHAR) "A_AAC/MPEG4/MAIN")
 #define MKV_AAC_CODEC_ID                    ((PCHAR) "A_AAC")
+#define MKV_PCM_INT_LIT_CODEC_ID            ((PCHAR) "A_PCM/INT/LIT")
+#define MKV_PCM_INT_BIG_CODEC_ID            ((PCHAR) "A_PCM/INT/BIG")
+#define MKV_PCM_FLOAT_IEEE_CODEC_ID         ((PCHAR) "A_PCM/FLOAT/IEEE")
 
 /**
  * Current versions of the public facing structures


### PR DESCRIPTION
Add video/mkvgen/Include.h definitions for the use of PCM Codec IDs and "video/h264,audio/mulaw" Content Type

These are dependencies for the addition of a new amazon-kinesis-video-producer-c sample project that uses H264 video with a single PCM u-law audio track.

This pull request goes with PIC issue 86.
https://github.com/awslabs/amazon-kinesis-video-streams-pic/issues/86

Addition of the following definitions to the appropriate video/mkvgen/Include.h sections:

#define MKV_H264_MULAW_MULTI_CONTENT_TYPE     ((PCHAR) "video/h264,audio/mulaw")

#define MKV_PCM_INT_LIT_CODEC_ID            ((PCHAR) "A_PCM/INT/LIT")
#define MKV_PCM_INT_BIG_CODEC_ID            ((PCHAR) "A_PCM/INT/BIG")
#define MKV_PCM_FLOAT_IEEE_CODEC_ID         ((PCHAR) "A_PCM/FLOAT/IEEE")


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
