### PR TITLE
Add sscanf to the list of macro-covered standard library functions.

### DIFF
--- a/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
+++ b/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
@@ -799,6 +799,7 @@ extern PUBLIC_API atomicXor globalAtomicXor;
 #define PRINTF                     printf
 #define SPRINTF                    sprintf
 #define SNPRINTF                   snprintf
+#define SSCANF                     sscanf
 #define TRIMSTRALL                 trimstrall
 #define LTRIMSTR                   ltrimstr
 #define RTRIMSTR                   rtrimstr

--- a/src/utils/tst/StringToInteger.cpp
+++ b/src/utils/tst/StringToInteger.cpp
@@ -343,4 +343,23 @@ TEST_F(StoIFunctionalityTest, CheckLimits) {
     EXPECT_EQ(-9223372036854775807LL - 1, i64);
 }
 
+TEST_F(StoIFunctionalityTest, CheckSSCANFSupport) {
+    INT32 i32;
+    UINT32 ui32;
+    EXPECT_EQ(1, SSCANF("20", "%x", &i32));
+    EXPECT_EQ(0x20, i32);
+    EXPECT_EQ(1, SSCANF("30;", "%x", &i32));
+    EXPECT_EQ(0x30, i32);
+
+    EXPECT_EQ(1, SSCANF("20", "%d", &i32));
+    EXPECT_EQ(20, i32);
+    EXPECT_EQ(1, SSCANF("30;", "%d", &i32));
+    EXPECT_EQ(30, i32);
+
+    EXPECT_EQ(1, SSCANF("20", "%d", &ui32));
+    EXPECT_EQ(20, ui32);
+    EXPECT_EQ(1, SSCANF("30;", "%d", &ui32));
+    EXPECT_EQ(30, ui32);
+}
+
 #endif


### PR DESCRIPTION
*Issue #, if available:*

Add sscanf -> SSCANF standard library macro in support of using it in this PR:

https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/pull/952

*Description of changes:*

Add sscanf -> SSCANF standard library macro alongside other standard library functions (e.g. printf, snprintf, etc.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
