### PR TITLE
Bug fix: Null deref in case of stream termination with "host not aliv…

### DIFF
--- a/src/client/src/StreamEvent.c
+++ b/src/client/src/StreamEvent.c
@@ -764,7 +764,7 @@ STATUS streamTerminatedEvent(PKinesisVideoStream pKinesisVideoStream, UPLOAD_HAN
                             pKinesisVideoClient->clientCallbacks.customData,
                             TO_STREAM_HANDLE(pKinesisVideoStream),
                             pKinesisVideoStream->streamInfo.name,
-                            pUploadHandleInfo->handle,
+                            pActiveUploadHandleInfo->handle,
                             0,
                             0);
                 }


### PR DESCRIPTION
…e" service result sets the uploadhandleinfo to null which then is used by mistake instead of the active upload handle.

Issue: https://github.com/awslabs/amazon-kinesis-video-streams-producer-c/issues/141

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
