### PR TITLE
Adding ability to set NALu adaptation flags prior starting the stream

### DIFF
--- a/src/client/include/com/amazonaws/kinesis/video/client/Include.h
+++ b/src/client/include/com/amazonaws/kinesis/video/client/Include.h
@@ -2156,7 +2156,7 @@ PUBLIC_API STATUS tagResourceResultEvent(UINT64, SERVICE_CALL_RESULT);
  * Updates the codec private data associated with the stream.
  *
  * NOTE: Many encoders provide CPD after they have been initialized.
- * This update should happen in states other than STREAMING state.
+ * IMPORTANT: This update should happen in states other than STREAMING state.
  *
  * @param 1 STREAM_HANDLE - the stream handle.
  * @param 2 UINT32 - Codec Private Data size
@@ -2166,6 +2166,22 @@ PUBLIC_API STATUS tagResourceResultEvent(UINT64, SERVICE_CALL_RESULT);
  * @return Status of the function call.
  */
 PUBLIC_API STATUS kinesisVideoStreamFormatChanged(STREAM_HANDLE, UINT32, PBYTE, UINT64);
+
+/**
+ * Updates/sets NALu adaptation flags
+ *
+ * NOTE: In some scenarios, the upstream media source format is now known until the
+ * CPD is retrieved and first frame bits can be examined. In order to avoid creation
+ * of the stream on the media thread when first frame arrives we need to have a
+ * capability of re-setting the NALu adaptation flags before streaming.
+ * IMPORTANT: This update should happen in states other than STREAMING state.
+ *
+ * @param 1 STREAM_HANDLE - the stream handle.
+ * @param 2 UINT32 - New NALu adaptation flags
+ *
+ * @return Status of the function call.
+ */
+PUBLIC_API STATUS kinesisVideoStreamSetNalAdaptionFlags(STREAM_HANDLE, UINT32);
 
 /**
  * Streaming has been terminated unexpectedly

--- a/src/client/include/com/amazonaws/kinesis/video/client/Include.h
+++ b/src/client/include/com/amazonaws/kinesis/video/client/Include.h
@@ -2181,7 +2181,7 @@ PUBLIC_API STATUS kinesisVideoStreamFormatChanged(STREAM_HANDLE, UINT32, PBYTE, 
  *
  * @return Status of the function call.
  */
-PUBLIC_API STATUS kinesisVideoStreamSetNalAdaptionFlags(STREAM_HANDLE, UINT32);
+PUBLIC_API STATUS kinesisVideoStreamSetNalAdaptationFlags(STREAM_HANDLE, UINT32);
 
 /**
  * Streaming has been terminated unexpectedly

--- a/src/client/src/Client.c
+++ b/src/client/src/Client.c
@@ -885,7 +885,7 @@ CleanUp:
  *
  * NOTE: The operation is permitted in non-streaming states
  */
-STATUS kinesisVideoStreamSetNalAdaptionFlags(STREAM_HANDLE streamHandle, UINT32 nalAdaptationFlags)
+STATUS kinesisVideoStreamSetNalAdaptationFlags(STREAM_HANDLE streamHandle, UINT32 nalAdaptationFlags)
 {
     STATUS retStatus = STATUS_SUCCESS;
     PKinesisVideoStream pKinesisVideoStream = FROM_STREAM_HANDLE(streamHandle);
@@ -903,7 +903,7 @@ STATUS kinesisVideoStreamSetNalAdaptionFlags(STREAM_HANDLE streamHandle, UINT32 
     releaseStreamSemaphore = TRUE;
 
     // Process and store the result
-    CHK_STATUS(setNalAdaptionFlags(pKinesisVideoStream, nalAdaptationFlags));
+    CHK_STATUS(setNalAdaptationFlags(pKinesisVideoStream, nalAdaptationFlags));
 
 CleanUp:
 

--- a/src/client/src/FrameOrderCoordinator.c
+++ b/src/client/src/FrameOrderCoordinator.c
@@ -132,9 +132,7 @@ STATUS audioVideoFrameTimestampComparator(PFrameOrderTrackData pFrameOrderTrackD
     // mkv timestamp as the key frame.
     // In case of the same MKV timestamps with the same track we won't do any auto-adjustment
     // and will let the call fail later with the same timestamps in the main PutFrame API call
-    if (mkvTimestamp1 == mkvTimestamp2 &&
-        pFrameOrderTrackData1->pTrackInfo->trackType != pFrameOrderTrackData2->pTrackInfo->trackType) {
-
+    if (mkvTimestamp1 == mkvTimestamp2 && pFrameOrderTrackData1->pTrackInfo->trackType != pFrameOrderTrackData2->pTrackInfo->trackType) {
         // If the first frame does not have key frame flag but the second does the we swap
         if (!CHECK_FRAME_FLAG_KEY_FRAME(pFirst->flags) && CHECK_FRAME_FLAG_KEY_FRAME(pSecond->flags)) {
             pSwap = pFirst;

--- a/src/client/src/Stream.c
+++ b/src/client/src/Stream.c
@@ -1770,7 +1770,7 @@ CleanUp:
 /**
  * Sets NALu adaptation flags.
  */
-STATUS setNalAdaptionFlags(PKinesisVideoStream pKinesisVideoStream, UINT32 nalAdaptationFlags)
+STATUS setNalAdaptationFlags(PKinesisVideoStream pKinesisVideoStream, UINT32 nalAdaptationFlags)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;

--- a/src/client/src/Stream.c
+++ b/src/client/src/Stream.c
@@ -1787,7 +1787,7 @@ STATUS setNalAdaptationFlags(PKinesisVideoStream pKinesisVideoStream, UINT32 nal
     // Ensure we are not in a streaming state
     CHK_STATUS(acceptStateMachineState(pKinesisVideoStream->base.pStateMachine,
                                        STREAM_STATE_READY | STREAM_STATE_NEW | STREAM_STATE_DESCRIBE | STREAM_STATE_CREATE |
-                                       STREAM_STATE_GET_ENDPOINT | STREAM_STATE_GET_TOKEN | STREAM_STATE_STOPPED));
+                                           STREAM_STATE_GET_ENDPOINT | STREAM_STATE_GET_TOKEN | STREAM_STATE_STOPPED));
 
     // Free and re-create the packager
     CHK_STATUS(freeMkvGenerator(pKinesisVideoStream->pMkvGenerator));

--- a/src/client/src/Stream.h
+++ b/src/client/src/Stream.h
@@ -531,7 +531,7 @@ STATUS putFrame(PKinesisVideoStream, PFrame);
 STATUS putFragmentMetadata(PKinesisVideoStream, PCHAR, PCHAR, BOOL);
 
 /**
- * Puts the frame into the stream. The stream will be started if it hasn't been yet.
+ * Sets a new CPD for the given track. The API should be called before the first frame is produced.
  *
  * @param 1 PKinesisVideoStream - Kinesis Video stream object.
  * @param 2 UINT32 - Codec private data size.
@@ -541,6 +541,16 @@ STATUS putFragmentMetadata(PKinesisVideoStream, PCHAR, PCHAR, BOOL);
  * @return Status of the function call.
  */
 STATUS streamFormatChanged(PKinesisVideoStream, UINT32, PBYTE, UINT64);
+
+/**
+ * Sets NALu adaptation flags. The API should be called before the first frame is produced.
+ *
+ * @param 1 PKinesisVideoStream - Kinesis Video stream object.
+ * @param 2 UINT32 - Nal adaptation flags.
+ *
+ * @return Status of the function call.
+ */
+STATUS setNalAdaptionFlags(PKinesisVideoStream, UINT32);
 
 /**
  * Extracts and returns the stream metrics.

--- a/src/client/src/Stream.h
+++ b/src/client/src/Stream.h
@@ -550,7 +550,7 @@ STATUS streamFormatChanged(PKinesisVideoStream, UINT32, PBYTE, UINT64);
  *
  * @return Status of the function call.
  */
-STATUS setNalAdaptionFlags(PKinesisVideoStream, UINT32);
+STATUS setNalAdaptationFlags(PKinesisVideoStream, UINT32);
 
 /**
  * Extracts and returns the stream metrics.

--- a/src/client/tst/StreamApiFunctionalityTest.cpp
+++ b/src/client/tst/StreamApiFunctionalityTest.cpp
@@ -146,7 +146,7 @@ TEST_F(StreamApiFunctionalityTest, setNalAdaptionFlags_stateCheck)
     EXPECT_EQ(MKV_NALS_ADAPT_NONE, ((PStreamMkvGenerator) pKinesisVideoStream->pMkvGenerator)->nalsAdaptation);
 
     // Ensure we can successfully set the NAL adaption flags
-    EXPECT_EQ(STATUS_SUCCESS, kinesisVideoStreamSetNalAdaptionFlags(mStreamHandle, nalFlags));
+    EXPECT_EQ(STATUS_SUCCESS, kinesisVideoStreamSetNalAdaptationFlags(mStreamHandle, nalFlags));
 
     EXPECT_EQ(nalFlags, pKinesisVideoStream->streamInfo.streamCaps.nalAdaptationFlags);
     EXPECT_EQ(MKV_NALS_ADAPT_ANNEXB, ((PStreamMkvGenerator) pKinesisVideoStream->pMkvGenerator)->nalsAdaptation);
@@ -164,21 +164,21 @@ TEST_F(StreamApiFunctionalityTest, setNalAdaptionFlags_stateCheck)
 
     // Ensure we can successfully reset the NALs again before the first frame
     nalFlags = NAL_ADAPTATION_ANNEXB_NALS;
-    EXPECT_EQ(STATUS_SUCCESS, kinesisVideoStreamSetNalAdaptionFlags(mStreamHandle, nalFlags));
+    EXPECT_EQ(STATUS_SUCCESS, kinesisVideoStreamSetNalAdaptationFlags(mStreamHandle, nalFlags));
     EXPECT_EQ(nalFlags, pKinesisVideoStream->streamInfo.streamCaps.nalAdaptationFlags);
     EXPECT_EQ(MKV_NALS_ADAPT_ANNEXB, ((PStreamMkvGenerator) pKinesisVideoStream->pMkvGenerator)->nalsAdaptation);
     EXPECT_EQ(STATUS_SUCCESS, getStreamingEndpointResultEvent(mCallContext.customData, SERVICE_CALL_RESULT_OK, TEST_STREAMING_ENDPOINT));
 
     // Ensure we can successfully set nal flags
     nalFlags = NAL_ADAPTATION_AVCC_NALS;
-    EXPECT_EQ(STATUS_SUCCESS, kinesisVideoStreamSetNalAdaptionFlags(mStreamHandle, nalFlags));
+    EXPECT_EQ(STATUS_SUCCESS, kinesisVideoStreamSetNalAdaptationFlags(mStreamHandle, nalFlags));
     EXPECT_EQ(nalFlags, pKinesisVideoStream->streamInfo.streamCaps.nalAdaptationFlags);
     EXPECT_EQ(MKV_NALS_ADAPT_AVCC, ((PStreamMkvGenerator) pKinesisVideoStream->pMkvGenerator)->nalsAdaptation);
     EXPECT_EQ(STATUS_SUCCESS, getStreamingTokenResultEvent(mCallContext.customData, SERVICE_CALL_RESULT_OK, (PBYTE) TEST_STREAMING_TOKEN, SIZEOF(TEST_STREAMING_TOKEN), TEST_AUTH_EXPIRATION));
 
     // Ensure we can successfully set the nal flags
     nalFlags = NAL_ADAPTATION_ANNEXB_CPD_NALS;
-    EXPECT_EQ(STATUS_SUCCESS, kinesisVideoStreamSetNalAdaptionFlags(mStreamHandle, nalFlags));
+    EXPECT_EQ(STATUS_SUCCESS, kinesisVideoStreamSetNalAdaptationFlags(mStreamHandle, nalFlags));
     EXPECT_EQ(nalFlags, pKinesisVideoStream->streamInfo.streamCaps.nalAdaptationFlags);
     EXPECT_EQ(MKV_NALS_ADAPT_NONE, ((PStreamMkvGenerator) pKinesisVideoStream->pMkvGenerator)->nalsAdaptation);
 
@@ -201,7 +201,7 @@ TEST_F(StreamApiFunctionalityTest, setNalAdaptionFlags_stateCheck)
         }
 
         // Setting NAL flags should fail
-        EXPECT_NE(STATUS_SUCCESS, kinesisVideoStreamSetNalAdaptionFlags(mStreamHandle, nalFlags));
+        EXPECT_NE(STATUS_SUCCESS, kinesisVideoStreamSetNalAdaptationFlags(mStreamHandle, nalFlags));
     }
 }
 

--- a/src/client/tst/StreamApiTest.cpp
+++ b/src/client/tst/StreamApiTest.cpp
@@ -564,7 +564,7 @@ TEST_F(StreamApiTest, kinesisVideoStreamSetNalAdaptionFlags_Negative)
     // Create a stream
     CreateStream();
 
-    EXPECT_NE(STATUS_SUCCESS, kinesisVideoStreamSetNalAdaptionFlags(streamHandle, nalFlags));
+    EXPECT_NE(STATUS_SUCCESS, kinesisVideoStreamSetNalAdaptationFlags(streamHandle, nalFlags));
 }
 
 PVOID streamStopNotifier(PVOID arg)

--- a/src/client/tst/StreamApiTest.cpp
+++ b/src/client/tst/StreamApiTest.cpp
@@ -556,6 +556,17 @@ TEST_F(StreamApiTest, kinesisVideoStreamFormatChanged_Multitrack_free)
     MEMFREE(pCpd);
 }
 
+TEST_F(StreamApiTest, kinesisVideoStreamSetNalAdaptionFlags_Negative)
+{
+    STREAM_HANDLE streamHandle = INVALID_STREAM_HANDLE_VALUE;
+    UINT32 nalFlags = NAL_ADAPTATION_ANNEXB_CPD_NALS | NAL_ADAPTATION_ANNEXB_NALS;
+
+    // Create a stream
+    CreateStream();
+
+    EXPECT_NE(STATUS_SUCCESS, kinesisVideoStreamSetNalAdaptionFlags(streamHandle, nalFlags));
+}
+
 PVOID streamStopNotifier(PVOID arg)
 {
     STREAM_HANDLE streamHandle = (STREAM_HANDLE) arg;


### PR DESCRIPTION
*Issue #, if available:*

This is needed in cases when a higher level application doesn't know about the upstream media source elementary stream NAL packaging format. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
