### PR TITLE
Fix frame rate calc

### DIFF
--- a/src/client/include/com/amazonaws/kinesis/video/client/Include.h
+++ b/src/client/include/com/amazonaws/kinesis/video/client/Include.h
@@ -1152,8 +1152,13 @@ struct __ClientMetrics {
     // Content view allocation size
     UINT64 totalContentViewsSize;
 
-    // Overall frame rate across the streams
+    // Overall frame rate across the streams: This is an indication of the rate at which frames are produced
+    // This is calculated using the clock value
     UINT64 totalFrameRate;
+
+    // Elementary stream frame rate in realtime/offline mode: This indicates the elementary stream frame rate
+    // This is calculated using the frame PTS
+    UINT64 totalElementaryFrameRate;
 
     // Overall transfer rate across the streams
     UINT64 totalTransferRate;

--- a/src/client/include/com/amazonaws/kinesis/video/client/Include.h
+++ b/src/client/include/com/amazonaws/kinesis/video/client/Include.h
@@ -1156,12 +1156,14 @@ struct __ClientMetrics {
     // This is calculated using the clock value
     UINT64 totalFrameRate;
 
+    // Overall transfer rate across the streams
+    UINT64 totalTransferRate;
+
+    // V1 metrics following
+
     // Elementary stream frame rate in realtime/offline mode: This indicates the elementary stream frame rate
     // This is calculated using the frame PTS
     DOUBLE totalElementaryFrameRate;
-
-    // Overall transfer rate across the streams
-    UINT64 totalTransferRate;
 };
 
 typedef struct __ClientMetrics* PClientMetrics;
@@ -1190,9 +1192,6 @@ struct __StreamMetrics {
 
     // Last measured put frame rate in bytes per second
     DOUBLE currentFrameRate;
-
-    // Current stream's elementary frame rate.
-    DOUBLE elementaryFrameRate;
 
     // Last measured transfer rate in bytes per second
     UINT64 currentTransferRate;
@@ -1256,6 +1255,11 @@ struct __StreamMetrics {
 
     // Backend Data Plane API call latency which includes success and failure
     UINT64 dataApiCallLatency;
+
+    // V2 metrics following
+
+    // Current stream's elementary frame rate.
+    DOUBLE elementaryFrameRate;
 };
 
 typedef struct __StreamMetrics* PStreamMetrics;

--- a/src/client/include/com/amazonaws/kinesis/video/client/Include.h
+++ b/src/client/include/com/amazonaws/kinesis/video/client/Include.h
@@ -446,7 +446,7 @@ extern "C" {
 #define SERVICE_CALL_CONTEXT_CURRENT_VERSION 0
 #define STREAM_DESCRIPTION_CURRENT_VERSION   1
 #define FRAGMENT_ACK_CURRENT_VERSION         0
-#define STREAM_METRICS_CURRENT_VERSION       1
+#define STREAM_METRICS_CURRENT_VERSION       2
 #define CLIENT_METRICS_CURRENT_VERSION       0
 #define CLIENT_INFO_CURRENT_VERSION          2
 
@@ -1190,6 +1190,9 @@ struct __StreamMetrics {
 
     // Last measured put frame rate in bytes per second
     DOUBLE currentFrameRate;
+
+    // Current stream's elementary frame rate
+    DOUBLE elementaryFrameRate;
 
     // Last measured transfer rate in bytes per second
     UINT64 currentTransferRate;

--- a/src/client/include/com/amazonaws/kinesis/video/client/Include.h
+++ b/src/client/include/com/amazonaws/kinesis/video/client/Include.h
@@ -447,7 +447,7 @@ extern "C" {
 #define STREAM_DESCRIPTION_CURRENT_VERSION   1
 #define FRAGMENT_ACK_CURRENT_VERSION         0
 #define STREAM_METRICS_CURRENT_VERSION       2
-#define CLIENT_METRICS_CURRENT_VERSION       0
+#define CLIENT_METRICS_CURRENT_VERSION       1
 #define CLIENT_INFO_CURRENT_VERSION          2
 
 /**
@@ -1158,7 +1158,7 @@ struct __ClientMetrics {
 
     // Elementary stream frame rate in realtime/offline mode: This indicates the elementary stream frame rate
     // This is calculated using the frame PTS
-    UINT64 totalElementaryFrameRate;
+    DOUBLE totalElementaryFrameRate;
 
     // Overall transfer rate across the streams
     UINT64 totalTransferRate;
@@ -1191,7 +1191,7 @@ struct __StreamMetrics {
     // Last measured put frame rate in bytes per second
     DOUBLE currentFrameRate;
 
-    // Current stream's elementary frame rate
+    // Current stream's elementary frame rate.
     DOUBLE elementaryFrameRate;
 
     // Last measured transfer rate in bytes per second

--- a/src/client/src/Client.c
+++ b/src/client/src/Client.c
@@ -375,6 +375,7 @@ STATUS getKinesisVideoMetrics(CLIENT_HANDLE clientHandle, PClientMetrics pKinesi
     pKinesisVideoMetrics->totalContentViewsSize = 0;
     pKinesisVideoMetrics->totalTransferRate = 0;
     pKinesisVideoMetrics->totalFrameRate = 0;
+    pKinesisVideoMetrics->totalElementaryFrameRate = 0;
 
     // Lock the client streams list lock because we're iterating over
     pKinesisVideoClient->clientCallbacks.lockMutexFn(pKinesisVideoClient->clientCallbacks.customData, pKinesisVideoClient->base.streamListLock);
@@ -385,6 +386,7 @@ STATUS getKinesisVideoMetrics(CLIENT_HANDLE clientHandle, PClientMetrics pKinesi
             CHK_STATUS(contentViewGetAllocationSize(pKinesisVideoClient->streams[i]->pView, &viewAllocationSize));
             pKinesisVideoMetrics->totalContentViewsSize += viewAllocationSize;
             pKinesisVideoMetrics->totalFrameRate += (UINT64) pKinesisVideoClient->streams[i]->diagnostics.currentFrameRate;
+            pKinesisVideoMetrics->totalElementaryFrameRate += pKinesisVideoClient->streams[i]->diagnostics.elementaryFrameRate;
             pKinesisVideoMetrics->totalTransferRate += pKinesisVideoClient->streams[i]->diagnostics.currentTransferRate;
         }
     }

--- a/src/client/src/Client.c
+++ b/src/client/src/Client.c
@@ -375,7 +375,7 @@ STATUS getKinesisVideoMetrics(CLIENT_HANDLE clientHandle, PClientMetrics pKinesi
     pKinesisVideoMetrics->totalContentViewsSize = 0;
     pKinesisVideoMetrics->totalTransferRate = 0;
     pKinesisVideoMetrics->totalFrameRate = 0;
-    pKinesisVideoMetrics->totalElementaryFrameRate = 0;
+    //    pKinesisVideoMetrics->totalElementaryFrameRate = 0;
 
     // Lock the client streams list lock because we're iterating over
     pKinesisVideoClient->clientCallbacks.lockMutexFn(pKinesisVideoClient->clientCallbacks.customData, pKinesisVideoClient->base.streamListLock);
@@ -384,10 +384,18 @@ STATUS getKinesisVideoMetrics(CLIENT_HANDLE clientHandle, PClientMetrics pKinesi
     for (i = 0; i < pKinesisVideoClient->deviceInfo.streamCount; i++) {
         if (NULL != pKinesisVideoClient->streams[i]) {
             CHK_STATUS(contentViewGetAllocationSize(pKinesisVideoClient->streams[i]->pView, &viewAllocationSize));
-            pKinesisVideoMetrics->totalContentViewsSize += viewAllocationSize;
-            pKinesisVideoMetrics->totalFrameRate += (UINT64) pKinesisVideoClient->streams[i]->diagnostics.currentFrameRate;
-            pKinesisVideoMetrics->totalElementaryFrameRate += pKinesisVideoClient->streams[i]->diagnostics.elementaryFrameRate;
-            pKinesisVideoMetrics->totalTransferRate += pKinesisVideoClient->streams[i]->diagnostics.currentTransferRate;
+            switch (pKinesisVideoMetrics->version) {
+                case 1:
+                    pKinesisVideoMetrics->totalElementaryFrameRate += pKinesisVideoClient->streams[i]->diagnostics.elementaryFrameRate;
+                    // explicit fall through since V1 would include V0 metrics as well
+                case 0:
+                    pKinesisVideoMetrics->totalContentViewsSize += viewAllocationSize;
+                    pKinesisVideoMetrics->totalFrameRate += (UINT64) pKinesisVideoClient->streams[i]->diagnostics.currentFrameRate;
+                    pKinesisVideoMetrics->totalTransferRate += pKinesisVideoClient->streams[i]->diagnostics.currentTransferRate;
+                    break;
+                default:
+                    DLOGW("Invalid client struct version. Nothing to populate");
+            }
         }
     }
 

--- a/src/client/src/Stream.c
+++ b/src/client/src/Stream.c
@@ -1049,7 +1049,6 @@ STATUS putFrame(PKinesisVideoStream pKinesisVideoStream, PFrame pFrame)
             ? currentTime
             : pKinesisVideoClient->clientCallbacks.getCurrentTimeFn(pKinesisVideoClient->clientCallbacks.customData);
         if (!CHECK_ITEM_STREAM_START(itemFlags) && pTrackInfo->trackType == MKV_TRACK_INFO_TYPE_VIDEO) {
-            DLOGD("Track type: %d", pTrackInfo->trackType);
             // Calculate the delta time in seconds
             deltaInSeconds = (DOUBLE)(currentTime - pKinesisVideoStream->diagnostics.lastFrameRateTimestamp) / HUNDREDS_OF_NANOS_IN_A_SECOND;
 

--- a/src/client/src/Stream.c
+++ b/src/client/src/Stream.c
@@ -711,6 +711,8 @@ STATUS logStreamMetric(PKinesisVideoStream pKinesisVideoStream)
     DLOGD("\tAverage Control Plane API latency (ms): %" PRIu64 " ", streamMetrics.cplApiCallLatency / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
     DLOGD("\tAverage Data Plane API latency (ms): %" PRIu64 " ", streamMetrics.dataApiCallLatency / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 
+    // V2 information
+    DLOGD("\tCurrent elementary frame rate (fps): %f ", streamMetrics.elementaryFrameRate);
 CleanUp:
 
     return retStatus;
@@ -1577,6 +1579,7 @@ STATUS getStreamMetrics(PKinesisVideoStream pKinesisVideoStream, PStreamMetrics 
 
     // Store the frame rate and the transfer rate
     pStreamMetrics->currentFrameRate = pKinesisVideoStream->diagnostics.currentFrameRate;
+    pStreamMetrics->elementaryFrameRate = pKinesisVideoStream->diagnostics.elementaryFrameRate;
     pStreamMetrics->currentTransferRate = pKinesisVideoStream->diagnostics.currentTransferRate;
 
     // Bail out for V0

--- a/src/client/src/Stream.c
+++ b/src/client/src/Stream.c
@@ -1007,6 +1007,7 @@ STATUS putFrame(PKinesisVideoStream pKinesisVideoStream, PFrame pFrame)
         pKinesisVideoStream->newSessionTimestamp = encodedFrameInfo.streamStartTs;
         CHK_STATUS(contentViewGetHead(pKinesisVideoStream->pView, &pViewItem));
         pKinesisVideoStream->newSessionIndex = pViewItem->index;
+        pKinesisVideoStream->diagnostics.lastFrameRatePts = pFrame->presentationTs;
     }
 
     // We need to check for the latency pressure. If the view head is ahead of the current
@@ -1055,6 +1056,8 @@ STATUS putFrame(PKinesisVideoStream pKinesisVideoStream, PFrame pFrame)
                 pKinesisVideoStream->diagnostics.currentFrameRate =
                     EMA_ACCUMULATOR_GET_NEXT(pKinesisVideoStream->diagnostics.currentFrameRate, frameRate);
             }
+            DLOGD("Frame PTS for %d: %llu, prev PTS: %llu", pFrame->index, pFrame->presentationTs, pKinesisVideoStream->diagnostics.lastFrameRatePts);
+            pKinesisVideoStream->diagnostics.lastFrameRatePts = pFrame->presentationTs;
         }
 
         // Store the last frame timestamp

--- a/src/client/src/Stream.h
+++ b/src/client/src/Stream.h
@@ -92,8 +92,14 @@ struct __KinesisVideoStreamDiagnostics {
     // Current FPS value
     DOUBLE currentFrameRate;
 
+    // Current stream's elementary frame rate
+    DOUBLE elementaryFrameRate;
+
     // Last time we took a measurement for the frame rate
     UINT64 lastFrameRateTimestamp;
+
+    // Previous PTS for the frame
+    UINT64 lastFrameRatePts;
 
     // Current transfer bytes-per-second
     UINT64 currentTransferRate;

--- a/src/client/src/Stream.h
+++ b/src/client/src/Stream.h
@@ -99,7 +99,7 @@ struct __KinesisVideoStreamDiagnostics {
     UINT64 lastFrameRateTimestamp;
 
     // Previous PTS for the frame
-    UINT64 lastFrameRatePts;
+    UINT64 previousFrameRatePts;
 
     // Current transfer bytes-per-second
     UINT64 currentTransferRate;

--- a/src/client/tst/ClientApiTest.cpp
+++ b/src/client/tst/ClientApiTest.cpp
@@ -348,28 +348,51 @@ TEST_F(ClientApiTest, getKinesisVideoMetrics_Invalid)
     kinesisVideoClientMetrics.version = CLIENT_METRICS_CURRENT_VERSION + 1;
     EXPECT_NE(STATUS_SUCCESS, getKinesisVideoMetrics(mClientHandle, &kinesisVideoClientMetrics));
 
-    kinesisVideoClientMetrics.version = CLIENT_METRICS_CURRENT_VERSION;
-    EXPECT_EQ(STATUS_SUCCESS, getKinesisVideoMetrics(mClientHandle, &kinesisVideoClientMetrics));
+}
 
+TEST_F(ClientApiTest, getKinesisVideoMetrics_Valid)
+{
+    ClientMetrics kinesisVideoClientMetrics;
+    // Testing all versions
+    for(UINT64 i = 0; i <= CLIENT_METRICS_CURRENT_VERSION; i++) {
+        kinesisVideoClientMetrics.version = i;
+        EXPECT_EQ(STATUS_SUCCESS, getKinesisVideoMetrics(mClientHandle, &kinesisVideoClientMetrics));
+    }
 }
 
 TEST_F(ClientApiTest, getStreamMetrics_Invalid)
 {
     StreamMetrics streamMetrics;
+    STREAM_HANDLE streamHandle = INVALID_STREAM_HANDLE_VALUE;
+
+    EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoStream(mClientHandle, &mStreamInfo, &streamHandle));
 
     streamMetrics.version = STREAM_METRICS_CURRENT_VERSION;
 
     EXPECT_NE(STATUS_SUCCESS, getKinesisVideoStreamMetrics(INVALID_STREAM_HANDLE_VALUE, &streamMetrics));
-    EXPECT_NE(STATUS_SUCCESS, getKinesisVideoStreamMetrics(mStreamHandle, NULL));
+    EXPECT_NE(STATUS_SUCCESS, getKinesisVideoStreamMetrics(streamHandle, NULL));
     EXPECT_NE(STATUS_SUCCESS, getKinesisVideoStreamMetrics(INVALID_STREAM_HANDLE_VALUE, NULL));
     EXPECT_NE(STATUS_SUCCESS, getKinesisVideoStreamMetrics(INVALID_STREAM_HANDLE_VALUE, &streamMetrics));
-    // Checking V1
+    // Checking unknown version
     streamMetrics.version = STREAM_METRICS_CURRENT_VERSION + 1;
-    EXPECT_EQ(STATUS_SUCCESS, getKinesisVideoStreamMetrics(mStreamHandle, &streamMetrics));
+    EXPECT_EQ(STATUS_INVALID_STREAM_METRICS_VERSION, getKinesisVideoStreamMetrics(streamHandle, &streamMetrics));
 
-    // Checking V0
-    streamMetrics.version = 0;
-    EXPECT_EQ(STATUS_SUCCESS, getKinesisVideoStreamMetrics(mStreamHandle, &streamMetrics));
+    EXPECT_EQ(STATUS_SUCCESS, freeKinesisVideoStream(&streamHandle));
+}
+
+TEST_F(ClientApiTest, getStreamMetrics_Valid)
+{
+    StreamMetrics streamMetrics;
+    STREAM_HANDLE streamHandle = INVALID_STREAM_HANDLE_VALUE;
+
+    EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoStream(mClientHandle, &mStreamInfo, &streamHandle));
+    // Testing all versions
+    for(UINT64 i = 0; i <= STREAM_METRICS_CURRENT_VERSION; i++) {
+        streamMetrics.version = i;
+        EXPECT_EQ(STATUS_SUCCESS, getKinesisVideoStreamMetrics(streamHandle, &streamMetrics));
+    }
+
+    EXPECT_EQ(STATUS_SUCCESS, freeKinesisVideoStream(&streamHandle));
 }
 
 TEST_F(ClientApiTest, kinesisVideoClientCreateInvalidSecurityTokenExpiration)

--- a/src/client/tst/ClientApiTest.cpp
+++ b/src/client/tst/ClientApiTest.cpp
@@ -350,6 +350,26 @@ TEST_F(ClientApiTest, getKinesisVideoMetrics_Invalid)
 
     kinesisVideoClientMetrics.version = CLIENT_METRICS_CURRENT_VERSION;
     EXPECT_EQ(STATUS_SUCCESS, getKinesisVideoMetrics(mClientHandle, &kinesisVideoClientMetrics));
+
+}
+
+TEST_F(ClientApiTest, getStreamMetrics_Invalid)
+{
+    StreamMetrics streamMetrics;
+
+    streamMetrics.version = STREAM_METRICS_CURRENT_VERSION;
+
+    EXPECT_NE(STATUS_SUCCESS, getKinesisVideoStreamMetrics(INVALID_STREAM_HANDLE_VALUE, &streamMetrics));
+    EXPECT_NE(STATUS_SUCCESS, getKinesisVideoStreamMetrics(mStreamHandle, NULL));
+    EXPECT_NE(STATUS_SUCCESS, getKinesisVideoStreamMetrics(INVALID_STREAM_HANDLE_VALUE, NULL));
+    EXPECT_NE(STATUS_SUCCESS, getKinesisVideoStreamMetrics(INVALID_STREAM_HANDLE_VALUE, &streamMetrics));
+    // Checking V1
+    streamMetrics.version = STREAM_METRICS_CURRENT_VERSION + 1;
+    EXPECT_EQ(STATUS_SUCCESS, getKinesisVideoStreamMetrics(mStreamHandle, &streamMetrics));
+
+    // Checking V0
+    streamMetrics.version = 0;
+    EXPECT_EQ(STATUS_SUCCESS, getKinesisVideoStreamMetrics(mStreamHandle, &streamMetrics));
 }
 
 TEST_F(ClientApiTest, kinesisVideoClientCreateInvalidSecurityTokenExpiration)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-cpp/issues/562
*Description of changes:*
Previously, the frame rate reported used getTime() for calculation. The current frame rate truly is indicative of the observed frame rate, which means, it can give an idea of whether the encoder is stable or bursty, however, it is not truly indicative of the elementary frame rate which requires using PTS. This led to adding a new metric called `elementaryFrameRate` that indicates the original streams frame rate and not the rate at which the frames are produced. 

The PR also addresses very high FPS values being observed in multitrack scenario. We only calculate frameRate for video track.

API level unit test is added for Client and Stream metrics. 

TODO: 
Functional unit tests for metrics are missing. This is a bigger work item. We must simulate streaming in the tests and extract metrics to ensure values are appropriately calculated/reported.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
