### PR TITLE
fix state machine issue on auth failure force retry auth and reset gr…

### DIFF
--- a/src/client/include/com/amazonaws/kinesis/video/client/Include.h
+++ b/src/client/include/com/amazonaws/kinesis/video/client/Include.h
@@ -666,6 +666,9 @@ typedef enum {
     // Other errors
     SERVICE_CALL_UNKNOWN = 10006,
 
+    // Auth failure we don't know the specific reason at this layer
+    SERVICE_CALL_AUTH_FAILURE = 10007,
+
     // ACK errors
     // Error when reading the input stream
     SERVICE_CALL_RESULT_STREAM_READ_ERROR = 4000,

--- a/src/client/src/AuthIntegration.c
+++ b/src/client/src/AuthIntegration.c
@@ -60,6 +60,12 @@ STATUS getAuthInfo(PKinesisVideoClient pKinesisVideoClient)
 
 CleanUp:
 
+    if (STATUS_FAILED(retStatus)) {
+        pKinesisVideoClient->base.result = SERVICE_CALL_AUTH_FAILURE;
+    } else {
+        pKinesisVideoClient->base.result = SERVICE_CALL_RESULT_OK;
+    }
+
     LEAVES();
     return retStatus;
 }

--- a/src/client/src/Include_i.h
+++ b/src/client/src/Include_i.h
@@ -108,14 +108,14 @@ typedef STATUS (*KinesisVideoClientCallbackHookFunc)(UINT64);
 /**
  * Kinesis Video client states definitions
  */
-#define CLIENT_STATE_NONE       ((UINT64) 0)
-#define CLIENT_STATE_NEW        ((UINT64)(1 << 0))
-#define CLIENT_STATE_AUTH       ((UINT64)(1 << 1))
-#define CLIENT_STATE_PROVISION  ((UINT64)(1 << 2))
-#define CLIENT_STATE_GET_TOKEN  ((UINT64)(1 << 3))
-#define CLIENT_STATE_CREATE     ((UINT64)(1 << 4))
-#define CLIENT_STATE_TAG_CLIENT ((UINT64)(1 << 5))
-#define CLIENT_STATE_READY      ((UINT64)(1 << 6))
+#define CLIENT_STATE_NONE       ((UINT64) 0)       // 0x00
+#define CLIENT_STATE_NEW        ((UINT64)(1 << 0)) // 0x01
+#define CLIENT_STATE_AUTH       ((UINT64)(1 << 1)) // 0x02
+#define CLIENT_STATE_PROVISION  ((UINT64)(1 << 2)) // 0x04
+#define CLIENT_STATE_GET_TOKEN  ((UINT64)(1 << 3)) // 0x08
+#define CLIENT_STATE_CREATE     ((UINT64)(1 << 4)) // 0x10
+#define CLIENT_STATE_TAG_CLIENT ((UINT64)(1 << 5)) // 0x20
+#define CLIENT_STATE_READY      ((UINT64)(1 << 6)) // 0x40
 
 /**
  * Object identifier enum - these will serve as sentinel values to identify

--- a/src/client/src/Stream.c
+++ b/src/client/src/Stream.c
@@ -2715,6 +2715,7 @@ STATUS checkStreamingTokenExpiration(PKinesisVideoStream pKinesisVideoStream)
     STATUS retStatus = STATUS_SUCCESS;
     UINT64 currentTime;
 
+    DLOGD("Enter");
     // Check if we need to do anything and early exit
     // If we are already in a grace period then bail out
     CHK(!pKinesisVideoStream->gracePeriod, retStatus);
@@ -2734,14 +2735,17 @@ STATUS checkStreamingTokenExpiration(PKinesisVideoStream pKinesisVideoStream)
 
     // Set the grace period which will be reset when the new token is in place.
     pKinesisVideoStream->gracePeriod = TRUE;
+    DLOGD("Grace Period Set to TRUE");
 
     // Set the streaming mode to stopped to trigger the transitions.
     // Set the result that will move the state machinery to the get endpoint state
     // In case of failure with get endpoint (i.e. if client state machine fails at auth,
     // we will keep oscillating between STREAM_STATE_STOPPED and STREAM_STATE_GET_ENDPOINT
     // with every putFrame call
-    if(STATUS_FAILED(retStatus = streamTerminatedEvent(pKinesisVideoStream, INVALID_UPLOAD_HANDLE_VALUE, SERVICE_CALL_STREAM_AUTH_IN_GRACE_PERIOD, TRUE))) {
+    if (STATUS_FAILED(retStatus = streamTerminatedEvent(pKinesisVideoStream, INVALID_UPLOAD_HANDLE_VALUE, SERVICE_CALL_STREAM_AUTH_IN_GRACE_PERIOD, TRUE))) {
         pKinesisVideoStream->gracePeriod = FALSE;
+        DLOGD("Grace Period RESET to FALSE");
+
         CHK(FALSE, retStatus);
     }
 
@@ -2754,6 +2758,14 @@ STATUS checkStreamingTokenExpiration(PKinesisVideoStream pKinesisVideoStream)
     }
 
 CleanUp:
+
+    if (pKinesisVideoStream->gracePeriod) {
+        DLOGD("In CleanUp, gracePeriod is TRUE");
+    } else {
+        DLOGD("In CleanUp, gracePeriod is FALSE");
+    }
+
+    DLOGD("In CleanUp, retStatus: 0x%08x", retStatus);
 
     LEAVES();
     return retStatus;

--- a/src/client/src/Stream.c
+++ b/src/client/src/Stream.c
@@ -2715,7 +2715,6 @@ STATUS checkStreamingTokenExpiration(PKinesisVideoStream pKinesisVideoStream)
     STATUS retStatus = STATUS_SUCCESS;
     UINT64 currentTime;
 
-    DLOGD("Enter");
     // Check if we need to do anything and early exit
     // If we are already in a grace period then bail out
     CHK(!pKinesisVideoStream->gracePeriod, retStatus);
@@ -2735,7 +2734,6 @@ STATUS checkStreamingTokenExpiration(PKinesisVideoStream pKinesisVideoStream)
 
     // Set the grace period which will be reset when the new token is in place.
     pKinesisVideoStream->gracePeriod = TRUE;
-    DLOGD("Grace Period Set to TRUE");
 
     // Set the streaming mode to stopped to trigger the transitions.
     // Set the result that will move the state machinery to the get endpoint state
@@ -2744,8 +2742,6 @@ STATUS checkStreamingTokenExpiration(PKinesisVideoStream pKinesisVideoStream)
     // with every putFrame call
     if (STATUS_FAILED(retStatus = streamTerminatedEvent(pKinesisVideoStream, INVALID_UPLOAD_HANDLE_VALUE, SERVICE_CALL_STREAM_AUTH_IN_GRACE_PERIOD, TRUE))) {
         pKinesisVideoStream->gracePeriod = FALSE;
-        DLOGD("Grace Period RESET to FALSE");
-
         CHK(FALSE, retStatus);
     }
 
@@ -2758,14 +2754,6 @@ STATUS checkStreamingTokenExpiration(PKinesisVideoStream pKinesisVideoStream)
     }
 
 CleanUp:
-
-    if (pKinesisVideoStream->gracePeriod) {
-        DLOGD("In CleanUp, gracePeriod is TRUE");
-    } else {
-        DLOGD("In CleanUp, gracePeriod is FALSE");
-    }
-
-    DLOGD("In CleanUp, retStatus: 0x%08x", retStatus);
 
     LEAVES();
     return retStatus;

--- a/src/client/src/StreamEvent.c
+++ b/src/client/src/StreamEvent.c
@@ -741,11 +741,14 @@ STATUS streamTerminatedEvent(PKinesisVideoStream pKinesisVideoStream, UPLOAD_HAN
         }
     }
 
-    // return early if pic is already in process of spawning new uploading session
-    CHK(!STATUS_SUCCEEDED(acceptStateMachineState(pKinesisVideoStream->base.pStateMachine,
-                                                  STREAM_STATE_DESCRIBE | STREAM_STATE_CREATE | STREAM_STATE_TAG_STREAM | STREAM_STATE_GET_TOKEN |
-                                                      STREAM_STATE_GET_ENDPOINT | STREAM_STATE_READY)),
-        retStatus);
+    // if we had an auth failure then we will not exit early we need to retry auth
+    if (pKinesisVideoClient->base.result != SERVICE_CALL_AUTH_FAILURE) {
+        // return early if pic is already in process of spawning new uploading session
+        CHK(!STATUS_SUCCEEDED(acceptStateMachineState(pKinesisVideoStream->base.pStateMachine,
+                                                      STREAM_STATE_DESCRIBE | STREAM_STATE_CREATE | STREAM_STATE_TAG_STREAM | STREAM_STATE_GET_TOKEN |
+                                                          STREAM_STATE_GET_ENDPOINT | STREAM_STATE_READY)),
+            retStatus);
+    }
 
     if (spawnNewUploadSession) {
         // Stop the stream

--- a/src/client/src/StreamEvent.c
+++ b/src/client/src/StreamEvent.c
@@ -375,7 +375,7 @@ STATUS getStreamingTokenResult(PKinesisVideoStream pKinesisVideoStream, SERVICE_
     // Reset the status
     retStatus = STATUS_SUCCESS;
 
-    // NOTE: We won't calculate the latency for this API as most implementations will integreate
+    // NOTE: We won't calculate the latency for this API as most implementations will integrate
     // with the credential provider which might not evaluate into a service call and return
     // a pre-cached result resulting in skewed numbers for the overall control plane API latency.
 

--- a/src/client/src/StreamState.c
+++ b/src/client/src/StreamState.c
@@ -477,7 +477,7 @@ STATUS executeGetEndpointStreamState(UINT64 customData, UINT64 time)
     STATUS retStatus = STATUS_SUCCESS;
     PKinesisVideoStream pKinesisVideoStream = STREAM_FROM_CUSTOM_DATA(customData);
     PKinesisVideoClient pKinesisVideoClient = NULL;
-    PStateMachineState pState;
+    PStateMachineState pState = NULL;
 
 
     CHK(pKinesisVideoStream != NULL, STATUS_NULL_ARG);
@@ -485,9 +485,8 @@ STATUS executeGetEndpointStreamState(UINT64 customData, UINT64 time)
     pKinesisVideoClient = pKinesisVideoStream->pKinesisVideoClient;
 
     // Step the client state machine first
-    //CHK_STATUS(stepClientStateMachine(pKinesisVideoClient));
+    if (STATUS_FAILED(retStatus = stepClientStateMachine(pKinesisVideoClient))) {
 
-    if(STATUS_FAILED(retStatus = stepClientStateMachine(pKinesisVideoClient))) {
         if(retStatus == STATUS_CLIENT_AUTH_CALL_FAILED) {
             // reset client state machine to READY state
 

--- a/src/client/src/StreamState.c
+++ b/src/client/src/StreamState.c
@@ -477,13 +477,32 @@ STATUS executeGetEndpointStreamState(UINT64 customData, UINT64 time)
     STATUS retStatus = STATUS_SUCCESS;
     PKinesisVideoStream pKinesisVideoStream = STREAM_FROM_CUSTOM_DATA(customData);
     PKinesisVideoClient pKinesisVideoClient = NULL;
+    PStateMachineState pState;
+
 
     CHK(pKinesisVideoStream != NULL, STATUS_NULL_ARG);
 
     pKinesisVideoClient = pKinesisVideoStream->pKinesisVideoClient;
 
     // Step the client state machine first
-    CHK_STATUS(stepClientStateMachine(pKinesisVideoClient));
+    //CHK_STATUS(stepClientStateMachine(pKinesisVideoClient));
+
+    if(STATUS_FAILED(retStatus = stepClientStateMachine(pKinesisVideoClient))) {
+        if(retStatus == STATUS_CLIENT_AUTH_CALL_FAILED) {
+            // reset client state machine to READY state
+
+            // Get the accepted state
+            CHK_STATUS(getStateMachineState(pKinesisVideoClient->base.pStateMachine, CLIENT_STATE_READY, &pState));
+
+            // Check if we are in the correct state
+            CHK_STATUS(acceptStateMachineState(pKinesisVideoClient->base.pStateMachine, pState->acceptStates));
+
+            // Step the machine
+            CHK_STATUS(stepStateMachine(pKinesisVideoClient->base.pStateMachine));
+        } else {
+            CHK(FALSE, retStatus);
+        }
+    }
 
     pKinesisVideoStream->base.serviceCallContext.pAuthInfo = &pKinesisVideoClient->tokenAuthInfo;
     pKinesisVideoStream->base.serviceCallContext.version = SERVICE_CALL_CONTEXT_CURRENT_VERSION;

--- a/src/client/src/StreamState.c
+++ b/src/client/src/StreamState.c
@@ -486,7 +486,6 @@ STATUS executeGetEndpointStreamState(UINT64 customData, UINT64 time)
 
     // Step the client state machine first
     if (STATUS_FAILED(retStatus = stepClientStateMachine(pKinesisVideoClient))) {
-        DLOGD("retStatus: 0x%08x", retStatus);
 
         if(retStatus == STATUS_CLIENT_AUTH_CALL_FAILED) {
             // reset client state machine to READY state

--- a/src/client/src/StreamState.c
+++ b/src/client/src/StreamState.c
@@ -486,6 +486,7 @@ STATUS executeGetEndpointStreamState(UINT64 customData, UINT64 time)
 
     // Step the client state machine first
     if (STATUS_FAILED(retStatus = stepClientStateMachine(pKinesisVideoClient))) {
+        DLOGD("retStatus: 0x%08x", retStatus);
 
         if(retStatus == STATUS_CLIENT_AUTH_CALL_FAILED) {
             // reset client state machine to READY state


### PR DESCRIPTION
*Issue #, if available:*https://github.com/awslabs/amazon-kinesis-video-streams-producer-c/issues/221

*Description of changes:*

There's a bug where if auth refresh fails and we call `putFrame` it will try to step the stream state machine from STOPPED to GET ENDPOINT, in this process it will try to step the client state machine from READY to AUTH state in this transition it actually attempts to make the curl call to refresh the creds but due to a boolean that was set it will just return and cause `putFrame` to commence without error when in fact we don't have creds.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
