### PR TITLE
use CMAKE_INSTALL_LIBDIR and CMAKE_INSTALL_BINDIR for proper install paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake;${CMAKE_MODULE_PATH}")
 include(Utilities)
 project(pic_project)
 
+include(GNUInstallDirs)
+
 # User Flags
 option(BUILD_DEPENDENCIES "Whether or not to build depending libraries from source" ON)
 
@@ -146,9 +148,9 @@ endif()
 
 install(
   TARGETS kvspic kvspicClient kvspicState kvspicUtils
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin)
+  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
 
 install(
   DIRECTORY ${PIC_HEADERS}
@@ -160,7 +162,7 @@ install(
     ${CMAKE_CURRENT_BINARY_DIR}/libkvspicClient.pc
     ${CMAKE_CURRENT_BINARY_DIR}/libkvspicState.pc
     ${CMAKE_CURRENT_BINARY_DIR}/libkvspicUtils.pc
-  DESTINATION lib/pkgconfig)
+  DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
 if(BUILD_TEST)
   set(CMAKE_CXX_STANDARD 11)

--- a/libkvspic.pc.cmake
+++ b/libkvspic.pc.cmake
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 includedir=${prefix}/include
-libdir=${exec_prefix}/lib
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 
 Name: KVS-libkvspic
 Description: KVS PIC library

--- a/libkvspicClient.pc.cmake
+++ b/libkvspicClient.pc.cmake
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 includedir=${prefix}/include
-libdir=${exec_prefix}/lib
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 
 Name: KVS-libkvspicClient
 Description: KVS PIC client only library

--- a/libkvspicState.pc.cmake
+++ b/libkvspicState.pc.cmake
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 includedir=${prefix}/include
-libdir=${exec_prefix}/lib
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 
 Name: KVS-libkvspicState
 Description: KVS PIC state only library

--- a/libkvspicUtils.pc.cmake
+++ b/libkvspicUtils.pc.cmake
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 includedir=${prefix}/include
-libdir=${exec_prefix}/lib
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 
 Name: KVS-libkvspicUtils
 Description: KVS PIC utils only library


### PR DESCRIPTION
Description of changes:

As is, this software does not install properly on Red Hat based systems because it has "lib" hardcoded throughout. This pull request adjusts the cmake tooling to use GNUInstallDirs (and the associated CMAKE_INSTALL_LIBDIR/CMAKE_INSTALL_BINDIR) variables. The .pc.in files are also updated to use these variables.

With this change, files are installed into the proper locations on Fedora/Red Hat Enterprise Linux/CentOS/Amazon Linux.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
