### PR TITLE
Added codecs enums for video and audio, removed multi-content type

### DIFF
--- a/src/client/include/com/amazonaws/kinesis/video/client/Include.h
+++ b/src/client/include/com/amazonaws/kinesis/video/client/Include.h
@@ -542,6 +542,23 @@ typedef enum {
     STREAMING_TYPE_OFFLINE,
 } STREAMING_TYPE;
 
+/**
+ * Audio codec id
+ */
+typedef enum {
+    AUDIO_CODEC_ID_AAC,
+    AUDIO_CODEC_ID_PCM_ALAW,
+    AUDIO_CODEC_ID_PCM_MULAW,
+} AUDIO_CODEC_ID, *PAUDIO_CODEC_ID;
+
+/**
+ * Video codec id
+ */
+typedef enum {
+    VIDEO_CODEC_ID_H264,
+    VIDEO_CODEC_ID_H265,
+} VIDEO_CODEC_ID, *PVIDEO_CODEC_ID;
+
 #define GET_STREAMING_TYPE_STR(st)                                                                                                                   \
     ((st) == STREAMING_TYPE_REALTIME ? (PCHAR) "STREAMING_TYPE_REALTIME"                                                                             \
                                      : (st) == STREAMING_TYPE_NEAR_REALTIME ? (PCHAR) "STREAMING_TYPE_NEAR_REALTIME" : "STREAMING_TYPE_OFFLINE")

--- a/src/mkvgen/include/com/amazonaws/kinesis/video/mkvgen/Include.h
+++ b/src/mkvgen/include/com/amazonaws/kinesis/video/mkvgen/Include.h
@@ -149,7 +149,7 @@ extern "C" {
 #define MKV_MULAW_CONTENT_TYPE            ((PCHAR) "audio/mulaw")
 #define MKV_AVC_CONTENT_TYPE              ((PCHAR) "video/avc")
 #define MKV_HEVC_CONTENT_TYPE             ((PCHAR) "video/hevc")
-
+#define MKV_H264_AAC_MULTI_CONTENT_TYPE   ((PCHAR) "video/h264,audio/aac")
 /**
  * Constant definitions for some known codec IDs
  */

--- a/src/mkvgen/include/com/amazonaws/kinesis/video/mkvgen/Include.h
+++ b/src/mkvgen/include/com/amazonaws/kinesis/video/mkvgen/Include.h
@@ -149,8 +149,6 @@ extern "C" {
 #define MKV_MULAW_CONTENT_TYPE            ((PCHAR) "audio/mulaw")
 #define MKV_AVC_CONTENT_TYPE              ((PCHAR) "video/avc")
 #define MKV_HEVC_CONTENT_TYPE             ((PCHAR) "video/hevc")
-#define MKV_H264_AAC_MULTI_CONTENT_TYPE   ((PCHAR) "video/h264,audio/aac")
-#define MKV_H264_MULAW_MULTI_CONTENT_TYPE ((PCHAR) "video/h264,audio/mulaw")
 
 /**
  * Constant definitions for some known codec IDs
@@ -160,6 +158,7 @@ extern "C" {
 #define MKV_H265_HEVC_CODEC_ID      ((PCHAR) "V_MPEGH/ISO/HEVC")
 #define MKV_AAC_MPEG4_MAIN_CODEC_ID ((PCHAR) "A_AAC/MPEG4/MAIN")
 #define MKV_AAC_CODEC_ID            ((PCHAR) "A_AAC")
+#define MKV_PCM_CODEC_ID            ((PCHAR) "A_MS/ACM")
 #define MKV_PCM_INT_LIT_CODEC_ID    ((PCHAR) "A_PCM/INT/LIT")
 #define MKV_PCM_INT_BIG_CODEC_ID    ((PCHAR) "A_PCM/INT/BIG")
 #define MKV_PCM_FLOAT_IEEE_CODEC_ID ((PCHAR) "A_PCM/FLOAT/IEEE")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Created audio codec id _enum_ and video codec id _enum_ to provide codec flexibility with Producer SDK. Removed multi-content type as it can be constructed by concatenating two base content types

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
