### PR TITLE
Adding mulaw multicontent type back

### DIFF
--- a/src/mkvgen/include/com/amazonaws/kinesis/video/mkvgen/Include.h
+++ b/src/mkvgen/include/com/amazonaws/kinesis/video/mkvgen/Include.h
@@ -150,6 +150,7 @@ extern "C" {
 #define MKV_AVC_CONTENT_TYPE              ((PCHAR) "video/avc")
 #define MKV_HEVC_CONTENT_TYPE             ((PCHAR) "video/hevc")
 #define MKV_H264_AAC_MULTI_CONTENT_TYPE   ((PCHAR) "video/h264,audio/aac")
+#define MKV_H264_MULAW_MULTI_CONTENT_TYPE ((PCHAR) "video/h264,audio/mulaw")
 /**
  * Constant definitions for some known codec IDs
  */


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/amazon-kinesis-video-streams-pic/pull/130
*Description of changes:*
Missed adding back the mulaw-multicontent-type to my previous [PR](https://github.com/awslabs/amazon-kinesis-video-streams-pic/pull/130). Adding it back in this PR for backward compatibility 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
