### PR TITLE
acquire frame order coordinator lock in this thread so guarantee same…

### DIFF
--- a/src/client/src/Client.c
+++ b/src/client/src/Client.c
@@ -58,7 +58,7 @@ STATUS checkIntermittentProducerCallback(UINT32 timerId, UINT64 currentTime, UIN
             if (NULL != pKinesisVideoClient->streams[i]) {
                 pCurrStream = pKinesisVideoClient->streams[i];
                 pFrameOrderCoordinator = pCurrStream->pFrameOrderCoordinator;
-                if (pCurrStream->streamInfo.streamCaps.frameOrderingMode == FRAME_ORDER_MODE_PASS_THROUGH) {
+                if (pCurrStream->streamInfo.streamCaps.frameOrderingMode != FRAME_ORDER_MODE_PASS_THROUGH) {
                     pKinesisVideoClient->clientCallbacks.lockMutexFn(pKinesisVideoClient->clientCallbacks.customData, pFrameOrderCoordinator->lock);
                     frameOrderCoordinatorLocked = TRUE;
                 }

--- a/src/client/src/Client.c
+++ b/src/client/src/Client.c
@@ -59,6 +59,8 @@ STATUS checkIntermittentProducerCallback(UINT32 timerId, UINT64 currentTime, UIN
                 pCurrStream = pKinesisVideoClient->streams[i];
                 pFrameOrderCoordinator = pCurrStream->pFrameOrderCoordinator;
                 if (pCurrStream->streamInfo.streamCaps.frameOrderingMode != FRAME_ORDER_MODE_PASS_THROUGH) {
+                    // In the case that frameOrderingMode = FRAME_ORDER_MODE_PASS_THROUGH, the mutex below does not even exist
+                    // so we will segfault, so the check is important
                     pKinesisVideoClient->clientCallbacks.lockMutexFn(pKinesisVideoClient->clientCallbacks.customData, pFrameOrderCoordinator->lock);
                     frameOrderCoordinatorLocked = TRUE;
                 }

--- a/src/client/src/Client.c
+++ b/src/client/src/Client.c
@@ -59,8 +59,8 @@ STATUS checkIntermittentProducerCallback(UINT32 timerId, UINT64 currentTime, UIN
                 pCurrStream = pKinesisVideoClient->streams[i];
                 pFrameOrderCoordinator = pCurrStream->pFrameOrderCoordinator;
                 if (pCurrStream->streamInfo.streamCaps.frameOrderingMode != FRAME_ORDER_MODE_PASS_THROUGH) {
-                    // In the case that frameOrderingMode = FRAME_ORDER_MODE_PASS_THROUGH, the mutex below does not even exist
-                    // so we will segfault, so the check is important
+                    // In the case that frameOrderingMode = FRAME_ORDER_MODE_PASS_THROUGH, pFrameOrderCoordinator is NULL
+                    // so we will segfault, so the check for the frameOrderingMode is important
                     pKinesisVideoClient->clientCallbacks.lockMutexFn(pKinesisVideoClient->clientCallbacks.customData, pFrameOrderCoordinator->lock);
                     frameOrderCoordinatorLocked = TRUE;
                 }

--- a/src/client/src/Stream.c
+++ b/src/client/src/Stream.c
@@ -852,6 +852,11 @@ STATUS putFrame(PKinesisVideoStream pKinesisVideoStream, PFrame pFrame)
     // Might need to block on the availability in the OFFLINE mode
     CHK_STATUS(handleAvailability(pKinesisVideoStream, overallSize, &allocHandle));
 
+    if (IS_OFFLINE_STREAMING_MODE(pKinesisVideoStream->streamInfo.streamCaps.streamingType)) {
+        // offline streaming mode can block so we need to reset the currentTime just in case
+        currentTime = pKinesisVideoClient->clientCallbacks.getCurrentTimeFn(pKinesisVideoClient->clientCallbacks.customData);
+    }
+
     // Lock the client
     pKinesisVideoClient->clientCallbacks.lockMutexFn(pKinesisVideoClient->clientCallbacks.customData, pKinesisVideoClient->base.lock);
     clientLocked = TRUE;


### PR DESCRIPTION
… lock acquisition order as a media thread putKinesisVideoFrame API call

*Issue #, if available:* https://github.com/awslabs/amazon-kinesis-video-streams-pic/issues/129

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
