### PR TITLE
Log git hash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,16 @@ option(ALIGNED_MEMORY_MODEL "Aligned memory model ONLY." OFF)
 option(FIXUP_ANNEX_B_TRAILING_NALU_ZERO "Fix-up some bad encoder behavior leaving a trailing zero at the end of NALu" OFF)
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 
+execute_process(
+        COMMAND git rev-parse HEAD
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE GIT_COMMIT_HASH
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+add_definitions(-DSDK_VERSION=\"${GIT_COMMIT_HASH}\")
+add_definitions(-DDETECTED_GIT_HASH)
+
+
 if(BUILD_SHARED_LIBS)
   set(LIBTYPE SHARED)
 elseif()

--- a/src/client/src/Stream.c
+++ b/src/client/src/Stream.c
@@ -3515,7 +3515,7 @@ VOID logStreamInfo(PStreamInfo pStreamInfo)
     if (pStreamInfo == NULL) {
         return;
     }
-
+    LOG_GIT_HASH();
     DLOGD("Kinesis Video Stream Info");
     DLOGD("\tStream name: %s ", pStreamInfo->name);
     DLOGD("\tStreaming type: %s ", GET_STREAMING_TYPE_STR(pStreamInfo->streamCaps.streamingType));

--- a/src/common/include/com/amazonaws/kinesis/video/common/PlatformUtils.h
+++ b/src/common/include/com/amazonaws/kinesis/video/common/PlatformUtils.h
@@ -15,6 +15,12 @@ extern "C" {
 #define LOG_CLASS "platform-utils"
 #endif
 
+#ifdef DETECTED_GIT_HASH
+#define GIT_HASH SDK_VERSION
+#else
+#define GIT_HASH EMPTY_STRING
+#endif
+
 // Log print function definition
 typedef VOID (*logPrintFunc)(UINT32, PCHAR, PCHAR, ...);
 
@@ -126,6 +132,10 @@ extern logPrintFunc globalCustomLogPrintFn;
 #ifndef CHECK_EXT
 #define CHECK_EXT(x, fmt, ...)                                                                                                                       \
     LOG_ALWAYS_FATAL_IF(!(x), "%s::%s: ASSERTION FAILED at %s:%d: " fmt, (PCHAR) LOG_CLASS, __FUNCTION__, SANITIZED_FILE, __LINE__, ##__VA_ARGS__)
+#endif
+
+#ifndef LOG_GIT_HASH    
+#define LOG_GIT_HASH()    DLOGI("SDK version: %s", GIT_HASH)
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We do not log the SDK version / git hash. This will be super convenient when debugging issues or when trying to get details from customer on the git version that is being used. When used in producer C, the git hash of producer SDK would be available as an INFO log and when used in WebRTC, the git hash of WebRTC SDK will be available. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
