### PR TITLE
Updating stepStateMachine to use stateTransitionHookFunc to get next retry wait time for local state retries

### DIFF
--- a/src/state/include/com/amazonaws/kinesis/video/state/Include.h
+++ b/src/state/include/com/amazonaws/kinesis/video/state/Include.h
@@ -86,7 +86,7 @@ struct __StateMachineState {
     GetNextStateFunc getNextStateFn;
     ExecuteStateFunc executeStateFn;
     StateTransitionHookFunc stateTransitionHookFunc;
-    UINT32 retry;
+    UINT32 maxLocalStateRetryCount;
     STATUS status;
 };
 typedef struct __StateMachineState* PStateMachineState;

--- a/src/state/src/Include_i.h
+++ b/src/state/src/Include_i.h
@@ -29,8 +29,13 @@ extern "C" {
 typedef struct __StateMachineContext StateMachineContext;
 struct __StateMachineContext {
     PStateMachineState pCurrentState;
-    UINT32 retryCount;
-    UINT64 time;
+    // Current retry count for a given state.
+    // This is incremented only for retries happening within the same state. Once the
+    // state transitions to a different state, localRetryCount is reset to 0.
+    UINT32 localStateRetryCount;
+    // Wait time before transitioning to next state.
+    // Next state could be the same state OR a different state
+    UINT64 stateTransitionWaitTime;
 };
 typedef struct __StateMachineContext* PStateMachineContext;
 

--- a/src/state/src/State.c
+++ b/src/state/src/State.c
@@ -169,7 +169,7 @@ STATUS stepStateMachine(PStateMachine pStateMachine)
         pStateMachineImpl->context.localStateRetryCount++;
     }
 
-    DLOGD("State Machine - Current state: 0x%016" PRIx64 ", Next state: 0x%016" PRIx64 ", "
+    DLOGV("State Machine - Current state: 0x%016" PRIx64 ", Next state: 0x%016" PRIx64 ", "
           "Current local state retry count [%u], Max local state retry count [%u], State transition wait time [" PRIx64 "] ms",
           pStateMachineImpl->context.pCurrentState->state,
           nextState,

--- a/src/state/src/State.c
+++ b/src/state/src/State.c
@@ -136,7 +136,7 @@ STATUS stepStateMachine(PStateMachine pStateMachine)
     UINT64 nextState, time;
     UINT64 customData;
     PStateMachineImpl pStateMachineImpl = (PStateMachineImpl) pStateMachine;
-    UINT64 errorStateTransitionWaitTime;
+    UINT64 errorStateTransitionWaitTime = 0;
 
     CHK(pStateMachineImpl != NULL, STATUS_NULL_ARG);
     customData = pStateMachineImpl->customData;
@@ -153,37 +153,42 @@ STATUS stepStateMachine(PStateMachine pStateMachine)
     // Clear the iteration info if a different state and transition the state
     time = pStateMachineImpl->getCurrentTimeFunc(pStateMachineImpl->getCurrentTimeFuncCustomData);
 
-    // Check if we are changing the state
-    if (pState->state != pStateMachineImpl->context.pCurrentState->state) {
-        // Clear the iteration data
-        pStateMachineImpl->context.retryCount = 0;
-        pStateMachineImpl->context.time = time;
-
-        // Call the state machine error handler
-        // This call could be a no-op if the state transition is happening for SERVICE_CALL_RESULT_OK code
-        if (pStateMachineImpl->context.pCurrentState->stateTransitionHookFunc != NULL) {
-            CHK_STATUS(pStateMachineImpl->context.pCurrentState->stateTransitionHookFunc(pStateMachineImpl->customData, &errorStateTransitionWaitTime));
-            pStateMachineImpl->context.time = time + errorStateTransitionWaitTime;
-        }
-
-        DLOGD("State Machine - Current state: 0x%016" PRIx64 ", Next state: 0x%016" PRIx64, pStateMachineImpl->context.pCurrentState->state,
-              nextState);
-    } else {
-        // Increment the state retry count
-        pStateMachineImpl->context.retryCount++;
-        pStateMachineImpl->context.time = time + NEXT_SERVICE_CALL_RETRY_DELAY(pStateMachineImpl->context.retryCount);
-
-        // Check if we have tried enough times
-        if (pState->retry != INFINITE_RETRY_COUNT_SENTINEL) {
-            CHK(pStateMachineImpl->context.retryCount <= pState->retry, pState->status);
-        }
+    // This stateTransitionHookFunc will return state transition wait time if the state transition is happening for non 200 service response
+    // For 200 service response, errorStateTransitionWaitTime will be 0.
+    if (pStateMachineImpl->context.pCurrentState->stateTransitionHookFunc != NULL) {
+        CHK_STATUS(pStateMachineImpl->context.pCurrentState->stateTransitionHookFunc(pStateMachineImpl->customData, &errorStateTransitionWaitTime));
     }
 
+    // Check if we are changing the state
+    if (pState->state != pStateMachineImpl->context.pCurrentState->state) {
+        // Since we're transitioning to a different state from this state, reset the local state retry count to0
+        pStateMachineImpl->context.localStateRetryCount = 0;
+    } else {
+        // Increment the local state retry count.
+        // Local state retry count determines the number of retries done within the same state.
+        pStateMachineImpl->context.localStateRetryCount++;
+    }
+
+    DLOGD("State Machine - Current state: 0x%016" PRIx64 ", Next state: 0x%016" PRIx64 ", "
+          "Current local state retry count [%u], Max local state retry count [%u], State transition wait time [" PRIx64 "] ms",
+          pStateMachineImpl->context.pCurrentState->state,
+          nextState,
+          pStateMachineImpl->context.localStateRetryCount,
+          pState->maxLocalStateRetryCount,
+          errorStateTransitionWaitTime/HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+
+    // Check if we have tried enough times within the same state
+    if (pState->maxLocalStateRetryCount != INFINITE_RETRY_COUNT_SENTINEL) {
+        CHK(pStateMachineImpl->context.localStateRetryCount <= pState->maxLocalStateRetryCount, pState->status);
+    }
+
+    pStateMachineImpl->context.stateTransitionWaitTime = time + errorStateTransitionWaitTime;
     pStateMachineImpl->context.pCurrentState = pState;
 
     // Execute the state function if specified
+    // The executeStateFn callback is expected to wait for stateTransitionWaitTime before executing the actual logic
     if (pStateMachineImpl->context.pCurrentState->executeStateFn != NULL) {
-        CHK_STATUS(pStateMachineImpl->context.pCurrentState->executeStateFn(pStateMachineImpl->customData, pStateMachineImpl->context.time));
+        CHK_STATUS(pStateMachineImpl->context.pCurrentState->executeStateFn(pStateMachineImpl->customData, pStateMachineImpl->context.stateTransitionWaitTime));
     }
 
 CleanUp:
@@ -247,8 +252,8 @@ STATUS resetStateMachineRetryCount(PStateMachine pStateMachine)
     CHK(pStateMachineImpl != NULL, STATUS_NULL_ARG);
 
     // Reset the state
-    pStateMachineImpl->context.retryCount = 0;
-    pStateMachineImpl->context.time = 0;
+    pStateMachineImpl->context.localStateRetryCount = 0;
+    pStateMachineImpl->context.stateTransitionWaitTime = 0;
 
 CleanUp:
 

--- a/src/state/tst/StateApiFunctionalityTest.cpp
+++ b/src/state/tst/StateApiFunctionalityTest.cpp
@@ -21,9 +21,9 @@ TEST_F(StateApiFunctionalityTest, checkStateIterationFailure)
     }
 
     // Validate the retry
-    EXPECT_EQ(SERVICE_CALL_MAX_RETRY_COUNT + 10, pStateMachineImpl->context.retryCount);
+    EXPECT_EQ(SERVICE_CALL_MAX_RETRY_COUNT + 10, pStateMachineImpl->context.localStateRetryCount);
     EXPECT_EQ(STATUS_SUCCESS, resetStateMachineRetryCount(mStateMachine));
-    EXPECT_EQ(0, pStateMachineImpl->context.retryCount);
+    EXPECT_EQ(0, pStateMachineImpl->context.localStateRetryCount);
 
     // Step to next state
     mTestTransitions[0].nextState = TEST_STATE_1;
@@ -165,7 +165,7 @@ TEST_F(StateApiFunctionalityTest, checkStateErrorHandlerOnStateTransitions)
     EXPECT_EQ(1, this->testErrorHandlerMetaData.errorHandlerExecutionCount);
     // State's local retry count should be zero since no retries are
     // happening within this state.
-    EXPECT_EQ(0, pStateMachineImpl->context.retryCount);
+    EXPECT_EQ(0, pStateMachineImpl->context.localStateRetryCount);
 
     // Mock a service API call response to be 200 OK in state 1 before
     // transitioning to state 2. Verify that the error handler's execution
@@ -179,7 +179,7 @@ TEST_F(StateApiFunctionalityTest, checkStateErrorHandlerOnStateTransitions)
     EXPECT_EQ(1, this->testErrorHandlerMetaData.errorHandlerExecutionCount);
     // State's local retry count should be zero since no retries are
     // happening within this state.
-    EXPECT_EQ(0, pStateMachineImpl->context.retryCount);
+    EXPECT_EQ(0, pStateMachineImpl->context.localStateRetryCount);
 
     // Mock a service API call response to be a timeout in state 2 before
     // transitioning to state 3. Verify that the error handler's business
@@ -193,7 +193,7 @@ TEST_F(StateApiFunctionalityTest, checkStateErrorHandlerOnStateTransitions)
     EXPECT_EQ(2, this->testErrorHandlerMetaData.errorHandlerExecutionCount);
     // State's local retry count should be zero since no retries are
     // happening within this state.
-    EXPECT_EQ(0, pStateMachineImpl->context.retryCount);
+    EXPECT_EQ(0, pStateMachineImpl->context.localStateRetryCount);
 
     // Mock a service API call response to be a timeout in state 3 before
     // transitioning to state 3 (same state). Verify that the error was
@@ -207,7 +207,7 @@ TEST_F(StateApiFunctionalityTest, checkStateErrorHandlerOnStateTransitions)
     // Error handler execution count did not increment
     EXPECT_EQ(2, this->testErrorHandlerMetaData.errorHandlerExecutionCount);
     // State's local retry count should be 1 since we retried once within TEST_STATE_3
-    EXPECT_EQ(1, pStateMachineImpl->context.retryCount);
+    EXPECT_EQ(1, pStateMachineImpl->context.localStateRetryCount);
 
     // Mock a service API call response to be 200 OK in state 3 before
     // transitioning to state 2. Verify that the error handler's execution
@@ -221,7 +221,7 @@ TEST_F(StateApiFunctionalityTest, checkStateErrorHandlerOnStateTransitions)
     EXPECT_EQ(2, this->testErrorHandlerMetaData.errorHandlerExecutionCount);
     // State's local retry count should be zero since no retries are
     // happening within this state.
-    EXPECT_EQ(0, pStateMachineImpl->context.retryCount);
+    EXPECT_EQ(0, pStateMachineImpl->context.localStateRetryCount);
 
     // Mock a service API call response to be a timeout in state 2 before
     // transitioning to state 3. Verify that the error handler's business
@@ -235,5 +235,5 @@ TEST_F(StateApiFunctionalityTest, checkStateErrorHandlerOnStateTransitions)
     EXPECT_EQ(3, this->testErrorHandlerMetaData.errorHandlerExecutionCount);
     // State's local retry count should be zero since no retries are
     // happening within this state.
-    EXPECT_EQ(0, pStateMachineImpl->context.retryCount);
+    EXPECT_EQ(0, pStateMachineImpl->context.localStateRetryCount);
 }

--- a/src/utils/src/ExponentialBackoffRetryStrategy.c
+++ b/src/utils/src/ExponentialBackoffRetryStrategy.c
@@ -266,9 +266,9 @@ STATUS getExponentialBackoffRetryStrategyWaitTime(PRetryStrategy pRetryStrategy,
 
     DLOGD("\n Thread Id [%"PRIu64"] "
           "Number of retries [%"PRIu64"], "
-          "Retry wait time [%"PRIu64"], "
+          "Retry wait time [%"PRIu64"] ms, "
           "Retry system time [%"PRIu64"]",
-          GETTID(), pRetryState->currentRetryCount, pRetryState->lastRetryWaitTime, pRetryState->lastRetrySystemTime);
+          GETTID(), pRetryState->currentRetryCount, pRetryState->lastRetryWaitTime/HUNDREDS_OF_NANOS_IN_A_MILLISECOND, pRetryState->lastRetrySystemTime);
 
 CleanUp:
     if (retStatus == STATUS_EXPONENTIAL_BACKOFF_RETRIES_EXHAUSTED) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updating stepStateMachine to use stateTransitionHookFunc to get next retry wait time for local state retries
We're planning to emit an internal metric on the retry count, this change is required to ensure we're using same exponential backoff logic for adding wait time while transitioning to same OR different states. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
