### PR TITLE
Decoupling retry strategy callbacks from the actual retry strategy, adding retry strategy type check before casting retry strategy state

### DIFF
--- a/src/client/include/com/amazonaws/kinesis/video/client/Include.h
+++ b/src/client/include/com/amazonaws/kinesis/video/client/Include.h
@@ -1171,8 +1171,8 @@ typedef struct __ClientInfo {
     // Retry strategy for the client and all the streams under it
     KvsRetryStrategy kvsRetryStrategy;
 
-    // Function pointer for application to provide a custom retry strategy
-    GetKvsRetryStrategyFn getKvsRetryStrategyFn;
+    // Function pointers for application to provide a custom retry strategy
+    KvsRetryStrategyCallbacks kvsRetryStrategyCallbacks;
 } ClientInfo, *PClientInfo;
 
 /**

--- a/src/client/src/ClientState.c
+++ b/src/client/src/ClientState.c
@@ -83,12 +83,14 @@ STATUS defaultClientStateTransitionHook(
     STATUS retStatus = STATUS_SUCCESS;
     PKinesisVideoClient pKinesisVideoClient = NULL;
     PKvsRetryStrategy pKvsRetryStrategy = NULL;
+    PKvsRetryStrategyCallbacks pKvsRetryStrategyCallbacks = NULL;
     UINT64 retryWaitTime = 0;
 
     pKinesisVideoClient = CLIENT_FROM_CUSTOM_DATA(customData);
     CHK(pKinesisVideoClient != NULL && stateTransitionWaitTime != NULL, STATUS_NULL_ARG);
 
     pKvsRetryStrategy = &(pKinesisVideoClient->deviceInfo.clientInfo.kvsRetryStrategy);
+    pKvsRetryStrategyCallbacks = &(pKinesisVideoClient->deviceInfo.clientInfo.kvsRetryStrategyCallbacks);
 
     // result > SERVICE_CALL_RESULT_OK covers case for -
     // result != SERVICE_CALL_RESULT_NOT_SET and != SERVICE_CALL_RESULT_OK
@@ -97,11 +99,12 @@ STATUS defaultClientStateTransitionHook(
     CHK(pKinesisVideoClient->base.result > SERVICE_CALL_RESULT_OK &&
             pKvsRetryStrategy != NULL &&
             pKvsRetryStrategy->pRetryStrategy != NULL &&
-            pKvsRetryStrategy->executeRetryStrategyFn != NULL, STATUS_SUCCESS);
+            pKvsRetryStrategyCallbacks->executeRetryStrategyFn != NULL, STATUS_SUCCESS);
 
-    DLOGD("KinesisVideoClient base result is [%u]. Executing KVS retry handler of retry strategy type [%u]",
+    DLOGV("KinesisVideoClient base result is [%u]. Executing KVS retry handler of retry strategy type [%u]",
           pKinesisVideoClient->base.result, pKvsRetryStrategy->retryStrategyType);
-    pKvsRetryStrategy->executeRetryStrategyFn(pKvsRetryStrategy->pRetryStrategy, &retryWaitTime);
+
+    pKvsRetryStrategyCallbacks->executeRetryStrategyFn(pKvsRetryStrategy, &retryWaitTime);
     *stateTransitionWaitTime = retryWaitTime;
 
 CleanUp:

--- a/src/client/src/InputValidator.c
+++ b/src/client/src/InputValidator.c
@@ -308,6 +308,7 @@ VOID fixupClientInfo(PClientInfo pClientInfo, PClientInfo pOrigClientInfo)
         pClientInfo->logMetric = pOrigClientInfo->logMetric;
         pClientInfo->automaticStreamingFlags = AUTOMATIC_STREAMING_INTERMITTENT_PRODUCER;
         pClientInfo->reservedCallbackPeriod = INTERMITTENT_PRODUCER_PERIOD_SENTINEL_VALUE;
+        pClientInfo->kvsRetryStrategyCallbacks = pOrigClientInfo->kvsRetryStrategyCallbacks;
 
         switch (pOrigClientInfo->version) {
             case 2:

--- a/src/client/src/StreamState.c
+++ b/src/client/src/StreamState.c
@@ -117,6 +117,7 @@ STATUS defaultStreamStateTransitionHook(
     PKinesisVideoStream pKinesisVideoStream = NULL;
     PKinesisVideoClient pKinesisVideoClient = NULL;
     PKvsRetryStrategy pKvsRetryStrategy = NULL;
+    PKvsRetryStrategyCallbacks pKvsRetryStrategyCallbacks = NULL;
     UINT64 retryWaitTime = 0;
 
     pKinesisVideoStream = STREAM_FROM_CUSTOM_DATA(customData);
@@ -126,6 +127,7 @@ STATUS defaultStreamStateTransitionHook(
     CHK(pKinesisVideoClient != NULL, STATUS_NULL_ARG);
 
     pKvsRetryStrategy = &(pKinesisVideoClient->deviceInfo.clientInfo.kvsRetryStrategy);
+    pKvsRetryStrategyCallbacks = &(pKinesisVideoClient->deviceInfo.clientInfo.kvsRetryStrategyCallbacks);
 
     // result > SERVICE_CALL_RESULT_OK covers case for -
     // result != SERVICE_CALL_RESULT_NOT_SET and != SERVICE_CALL_RESULT_OK
@@ -134,11 +136,12 @@ STATUS defaultStreamStateTransitionHook(
     CHK(pKinesisVideoStream->base.result > SERVICE_CALL_RESULT_OK &&
             pKvsRetryStrategy != NULL &&
             pKvsRetryStrategy->pRetryStrategy != NULL &&
-            pKvsRetryStrategy->executeRetryStrategyFn != NULL, STATUS_SUCCESS);
+            pKvsRetryStrategyCallbacks->executeRetryStrategyFn != NULL, STATUS_SUCCESS);
 
     DLOGD("\n KinesisVideoStream base result is [%u]. Executing KVS retry handler of retry strategy type [%u]",
           pKinesisVideoStream->base.result, pKvsRetryStrategy->retryStrategyType);
-    pKvsRetryStrategy->executeRetryStrategyFn(pKvsRetryStrategy->pRetryStrategy, &retryWaitTime);
+
+    pKvsRetryStrategyCallbacks->executeRetryStrategyFn(pKvsRetryStrategy, &retryWaitTime);
     *stateTransitionWaitTime = retryWaitTime;
 
 CleanUp:

--- a/src/client/tst/ClientTestFixture.h
+++ b/src/client/tst/ClientTestFixture.h
@@ -416,7 +416,11 @@ class ClientTestBase : public ::testing::Test {
         mDeviceInfo.clientInfo.metricLoggingPeriod = 1 * HUNDREDS_OF_NANOS_IN_A_MINUTE;
         mDeviceInfo.clientInfo.automaticStreamingFlags = AUTOMATIC_STREAMING_INTERMITTENT_PRODUCER;
         mDeviceInfo.clientInfo.reservedCallbackPeriod = INTERMITTENT_PRODUCER_PERIOD_DEFAULT;
-        mDeviceInfo.clientInfo.getKvsRetryStrategyFn = getClientRetryStrategyFn;
+
+        mDeviceInfo.clientInfo.kvsRetryStrategyCallbacks.createRetryStrategyFn = createRetryStrategyFn;
+        mDeviceInfo.clientInfo.kvsRetryStrategyCallbacks.getCurrentRetryAttemptNumberFn = getCurrentRetryAttemptNumberFn;
+        mDeviceInfo.clientInfo.kvsRetryStrategyCallbacks.freeRetryStrategyFn = freeRetryStrategyFn;
+        mDeviceInfo.clientInfo.kvsRetryStrategyCallbacks.executeRetryStrategyFn = executeRetryStrategyFn;
 
         // Initialize stream info
         mStreamInfo.version = STREAM_INFO_CURRENT_VERSION;
@@ -1051,7 +1055,10 @@ class ClientTestBase : public ::testing::Test {
 
     static STATUS fragmentAckReceivedFunc(UINT64, STREAM_HANDLE, UPLOAD_HANDLE, PFragmentAck);
 
-    static STATUS getClientRetryStrategyFn(CLIENT_HANDLE);
+    static STATUS createRetryStrategyFn(PKvsRetryStrategy);
+    static STATUS getCurrentRetryAttemptNumberFn(PKvsRetryStrategy, PUINT32);
+    static STATUS freeRetryStrategyFn(PKvsRetryStrategy);
+    static STATUS executeRetryStrategyFn(PKvsRetryStrategy, PUINT64);
 
     static STATUS clientShutdownFunc(UINT64, CLIENT_HANDLE);
     static STATUS streamShutdownFunc(UINT64, STREAM_HANDLE, BOOL);

--- a/src/state/tst/StateApiFunctionalityTest.cpp
+++ b/src/state/tst/StateApiFunctionalityTest.cpp
@@ -151,7 +151,7 @@ TEST_F(StateApiFunctionalityTest, checkStateErrorHandlerOnStateTransitions)
     PStateMachineImpl pStateMachineImpl = (PStateMachineImpl) mStateMachine;
 
     // Verify that the state machine error handler has not been executed
-    EXPECT_EQ(0, this->testErrorHandlerMetaData.errorHandlerExecutionCount);
+    EXPECT_EQ(0, this->stateTransitionsHookFunctionMetadata.hookFunctionExecutionCountForNon200Response);
 
     // Mock a service API call response to be a timeout in state 0 before
     // transitioning to state 1. Verify that the error handler's business
@@ -162,7 +162,7 @@ TEST_F(StateApiFunctionalityTest, checkStateErrorHandlerOnStateTransitions)
     EXPECT_EQ(STATUS_SUCCESS, getStateMachineCurrentState(mStateMachine, &pStateMachineState));
     EXPECT_EQ(TEST_STATE_1, pStateMachineState->state);
     // Error handler execution count was correctly incremented
-    EXPECT_EQ(1, this->testErrorHandlerMetaData.errorHandlerExecutionCount);
+    EXPECT_EQ(1, this->stateTransitionsHookFunctionMetadata.hookFunctionExecutionCountForNon200Response);
     // State's local retry count should be zero since no retries are
     // happening within this state.
     EXPECT_EQ(0, pStateMachineImpl->context.localStateRetryCount);
@@ -176,7 +176,7 @@ TEST_F(StateApiFunctionalityTest, checkStateErrorHandlerOnStateTransitions)
     EXPECT_EQ(STATUS_SUCCESS, getStateMachineCurrentState(mStateMachine, &pStateMachineState));
     EXPECT_EQ(TEST_STATE_2, pStateMachineState->state);
     // Error handler execution count did not increment
-    EXPECT_EQ(1, this->testErrorHandlerMetaData.errorHandlerExecutionCount);
+    EXPECT_EQ(1, this->stateTransitionsHookFunctionMetadata.hookFunctionExecutionCountForNon200Response);
     // State's local retry count should be zero since no retries are
     // happening within this state.
     EXPECT_EQ(0, pStateMachineImpl->context.localStateRetryCount);
@@ -190,7 +190,7 @@ TEST_F(StateApiFunctionalityTest, checkStateErrorHandlerOnStateTransitions)
     EXPECT_EQ(STATUS_SUCCESS, getStateMachineCurrentState(mStateMachine, &pStateMachineState));
     EXPECT_EQ(TEST_STATE_3, pStateMachineState->state);
     // Error handler execution count was correctly incremented
-    EXPECT_EQ(2, this->testErrorHandlerMetaData.errorHandlerExecutionCount);
+    EXPECT_EQ(2, this->stateTransitionsHookFunctionMetadata.hookFunctionExecutionCountForNon200Response);
     // State's local retry count should be zero since no retries are
     // happening within this state.
     EXPECT_EQ(0, pStateMachineImpl->context.localStateRetryCount);
@@ -204,8 +204,8 @@ TEST_F(StateApiFunctionalityTest, checkStateErrorHandlerOnStateTransitions)
     EXPECT_EQ(STATUS_SUCCESS, stepStateMachine(mStateMachine));
     EXPECT_EQ(STATUS_SUCCESS, getStateMachineCurrentState(mStateMachine, &pStateMachineState));
     EXPECT_EQ(TEST_STATE_3, pStateMachineState->state);
-    // Error handler execution count did not increment
-    EXPECT_EQ(2, this->testErrorHandlerMetaData.errorHandlerExecutionCount);
+    // Error handler execution count will increment because testServiceAPICallResult was non 200
+    EXPECT_EQ(3, this->stateTransitionsHookFunctionMetadata.hookFunctionExecutionCountForNon200Response);
     // State's local retry count should be 1 since we retried once within TEST_STATE_3
     EXPECT_EQ(1, pStateMachineImpl->context.localStateRetryCount);
 
@@ -217,8 +217,8 @@ TEST_F(StateApiFunctionalityTest, checkStateErrorHandlerOnStateTransitions)
     EXPECT_EQ(STATUS_SUCCESS, stepStateMachine(mStateMachine));
     EXPECT_EQ(STATUS_SUCCESS, getStateMachineCurrentState(mStateMachine, &pStateMachineState));
     EXPECT_EQ(TEST_STATE_2, pStateMachineState->state);
-    // Error handler execution count did not increment
-    EXPECT_EQ(2, this->testErrorHandlerMetaData.errorHandlerExecutionCount);
+    // Error handler execution count did not increment because testServiceAPICallResult was 200
+    EXPECT_EQ(3, this->stateTransitionsHookFunctionMetadata.hookFunctionExecutionCountForNon200Response);
     // State's local retry count should be zero since no retries are
     // happening within this state.
     EXPECT_EQ(0, pStateMachineImpl->context.localStateRetryCount);
@@ -231,8 +231,8 @@ TEST_F(StateApiFunctionalityTest, checkStateErrorHandlerOnStateTransitions)
     EXPECT_EQ(STATUS_SUCCESS, stepStateMachine(mStateMachine));
     EXPECT_EQ(STATUS_SUCCESS, getStateMachineCurrentState(mStateMachine, &pStateMachineState));
     EXPECT_EQ(TEST_STATE_3, pStateMachineState->state);
-    // Error handler execution count was correctly incremented
-    EXPECT_EQ(3, this->testErrorHandlerMetaData.errorHandlerExecutionCount);
+    // Error handler execution count will increment because testServiceAPICallResult was non 200
+    EXPECT_EQ(4, this->stateTransitionsHookFunctionMetadata.hookFunctionExecutionCountForNon200Response);
     // State's local retry count should be zero since no retries are
     // happening within this state.
     EXPECT_EQ(0, pStateMachineImpl->context.localStateRetryCount);

--- a/src/state/tst/StateTestFixture.cpp
+++ b/src/state/tst/StateTestFixture.cpp
@@ -21,7 +21,7 @@ STATUS stateTransitionHook(UINT64 customData, PUINT64 returnData)
 
     StateTestBase* pTest = (StateTestBase*) customData;
     if (pTest->testServiceAPICallResult != SERVICE_CALL_RESULT_OK) {
-        pTest->testErrorHandlerMetaData.errorHandlerExecutionCount++;
+        pTest->stateTransitionsHookFunctionMetadata.hookFunctionExecutionCountForNon200Response++;
     }
 
 CleanUp:

--- a/src/state/tst/StateTestFixture.h
+++ b/src/state/tst/StateTestFixture.h
@@ -30,8 +30,8 @@ typedef struct {
 } TestTransitions, *PTestTransitions;
 
 typedef struct {
-    UINT32 errorHandlerExecutionCount;
-} StateTransitionsTestErrorHandlerData;
+    UINT32 hookFunctionExecutionCountForNon200Response;
+} StateTransitionsHookFunctionMetadata;
 
 class StateTestBase : public ::testing::Test {
   public:
@@ -45,7 +45,7 @@ class StateTestBase : public ::testing::Test {
         mTestTransitions[4].nextState = TEST_STATE_5;
         mTestTransitions[5].nextState = TEST_STATE_0;
 
-        testErrorHandlerMetaData.errorHandlerExecutionCount = 0;
+        stateTransitionsHookFunctionMetadata.hookFunctionExecutionCountForNon200Response = 0;
     }
 
     UINT32 GetCurrentStateIndex()
@@ -71,7 +71,7 @@ class StateTestBase : public ::testing::Test {
     TestTransitions mTestTransitions[TEST_STATE_COUNT];
     PStateMachine mStateMachine;
 
-    StateTransitionsTestErrorHandlerData testErrorHandlerMetaData;
+    StateTransitionsHookFunctionMetadata stateTransitionsHookFunctionMetadata;
     UINT32 testServiceAPICallResult;
 
   protected:

--- a/src/utils/src/ExponentialBackoffRetryStrategy.c
+++ b/src/utils/src/ExponentialBackoffRetryStrategy.c
@@ -10,7 +10,7 @@ STATUS normalizeExponentialBackoffConfig(PExponentialBackoffRetryStrategyConfig 
     pExponentialBackoffRetryStrategyConfig->retryFactorTime *= HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
     pExponentialBackoffRetryStrategyConfig->minTimeToResetRetryState *= HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
 
-    DLOGD("Thread Id [%"PRIu64"]. Exponential backoff retry strategy config - "
+    DLOGV("Thread Id [%"PRIu64"]. Exponential backoff retry strategy config - "
         "maxRetryCount: [%"PRIu64"], "
         "maxRetryWaitTime: [%"PRIu64"], "
         "retryFactorTime: [%"PRIu64"], "
@@ -39,7 +39,7 @@ STATUS resetExponentialBackoffRetryState(PExponentialBackoffRetryStrategyState p
 
     CHK(pExponentialBackoffRetryStrategyState != NULL, STATUS_NULL_ARG);
 
-    DLOGD("Thread Id [%"PRIu64"]. Resetting Exponential Backoff State. Last retry system time [%"PRIu64"], "
+    DLOGV("Thread Id [%"PRIu64"]. Resetting Exponential Backoff State. Last retry system time [%"PRIu64"], "
         "retry count so far [%u], Current system time [%"PRIu64"]",
         GETTID(),
         pExponentialBackoffRetryStrategyState->lastRetrySystemTime,
@@ -56,12 +56,12 @@ CleanUp:
     return retStatus;
 }
 
-STATUS exponentialBackoffRetryStrategyWithDefaultConfigCreate(PRetryStrategy* ppRetryStrategy) {
+STATUS exponentialBackoffRetryStrategyWithDefaultConfigCreate(PKvsRetryStrategy pKvsRetryStrategy) {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     PExponentialBackoffRetryStrategyState pExponentialBackoffRetryStrategyState = NULL;
 
-    CHK(ppRetryStrategy != NULL, STATUS_NULL_ARG);
+    CHK(pKvsRetryStrategy != NULL, STATUS_NULL_ARG);
 
     pExponentialBackoffRetryStrategyState = (PExponentialBackoffRetryStrategyState) MEMCALLOC(1, SIZEOF(ExponentialBackoffRetryStrategyState));
     CHK(pExponentialBackoffRetryStrategyState != NULL, STATUS_NOT_ENOUGH_MEMORY);
@@ -71,11 +71,13 @@ STATUS exponentialBackoffRetryStrategyWithDefaultConfigCreate(PRetryStrategy* pp
     // Normalize the time parameters in config to be in HUNDREDS_OF_NANOS_IN_A_MILLISECOND
     CHK_STATUS(normalizeExponentialBackoffConfig(&(pExponentialBackoffRetryStrategyState->exponentialBackoffRetryStrategyConfig)));
     CHK_STATUS(resetExponentialBackoffRetryState(pExponentialBackoffRetryStrategyState));
-    DLOGD("Created exponential backoff retry strategy state with default configuration.");
+
+    pKvsRetryStrategy->retryStrategyType = KVS_RETRY_STRATEGY_EXPONENTIAL_BACKOFF_WAIT;
+    DLOGV("Created exponential backoff retry strategy state with default configuration.");
 
 CleanUp:
     if (STATUS_SUCCEEDED(retStatus)) {
-        (*ppRetryStrategy) = (PRetryStrategy)pExponentialBackoffRetryStrategyState;
+        pKvsRetryStrategy->pRetryStrategy = (PRetryStrategy)pExponentialBackoffRetryStrategyState;
     }
 
     LEAVES();
@@ -109,19 +111,20 @@ CleanUp:
     return retStatus;
 }
 
-STATUS exponentialBackoffRetryStrategyCreate(PRetryStrategyConfig pRetryStrategyConfig, PRetryStrategy* ppRetryStrategy) {
+STATUS exponentialBackoffRetryStrategyCreate(PKvsRetryStrategy pKvsRetryStrategy) {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     PExponentialBackoffRetryStrategyState pExponentialBackoffRetryStrategyState = NULL;
     PExponentialBackoffRetryStrategyConfig pExponentialBackoffConfig = NULL;
-    CHK(ppRetryStrategy != NULL, STATUS_NULL_ARG);
+
+    CHK(pKvsRetryStrategy != NULL, STATUS_NULL_ARG);
 
     // If no config provided, create retry strategy with default config
-    if (pRetryStrategyConfig == NULL) {
-        return exponentialBackoffRetryStrategyWithDefaultConfigCreate(ppRetryStrategy);
+    if (pKvsRetryStrategy->pRetryStrategyConfig == NULL) {
+        return exponentialBackoffRetryStrategyWithDefaultConfigCreate(pKvsRetryStrategy);
     }
 
-    pExponentialBackoffConfig = TO_EXPONENTIAL_BACKOFF_CONFIG(pRetryStrategyConfig);
+    pExponentialBackoffConfig = TO_EXPONENTIAL_BACKOFF_CONFIG(pKvsRetryStrategy->pRetryStrategyConfig);
     CHK_STATUS(validateExponentialBackoffConfig(pExponentialBackoffConfig));
 
     pExponentialBackoffRetryStrategyState = (PExponentialBackoffRetryStrategyState) MEMCALLOC(1, SIZEOF(ExponentialBackoffRetryStrategyState));
@@ -132,11 +135,13 @@ STATUS exponentialBackoffRetryStrategyCreate(PRetryStrategyConfig pRetryStrategy
     // Normalize the time parameters in config to be in HUNDREDS_OF_NANOS_IN_A_MILLISECOND
     CHK_STATUS(normalizeExponentialBackoffConfig(&(pExponentialBackoffRetryStrategyState->exponentialBackoffRetryStrategyConfig)));
     CHK_STATUS(resetExponentialBackoffRetryState(pExponentialBackoffRetryStrategyState));
-    DLOGD("Created exponential backoff retry strategy state with provided retry configuration.");
+
+    pKvsRetryStrategy->retryStrategyType = KVS_RETRY_STRATEGY_EXPONENTIAL_BACKOFF_WAIT;
+    DLOGV("Created exponential backoff retry strategy state with provided retry configuration.");
 
 CleanUp:
     if (STATUS_SUCCEEDED(retStatus)) {
-        (*ppRetryStrategy) = (PRetryStrategy)pExponentialBackoffRetryStrategyState;
+        pKvsRetryStrategy->pRetryStrategy = (PRetryStrategy)pExponentialBackoffRetryStrategyState;
     }
 
     LEAVES();
@@ -185,18 +190,18 @@ STATUS validateAndUpdateExponentialBackoffStatus(PExponentialBackoffRetryStrateg
     switch (pExponentialBackoffRetryStrategyState->status) {
         case BACKOFF_NOT_STARTED:
             pExponentialBackoffRetryStrategyState->status = BACKOFF_IN_PROGRESS;
-            DLOGD("Status changed from BACKOFF_NOT_STARTED to BACKOFF_IN_PROGRESS");
+            DLOGV("Status changed from BACKOFF_NOT_STARTED to BACKOFF_IN_PROGRESS");
             break;
         case BACKOFF_IN_PROGRESS:
             // Do nothing
-            DLOGD("Current status is BACKOFF_IN_PROGRESS");
+            DLOGV("Current status is BACKOFF_IN_PROGRESS");
             break;
         case BACKOFF_TERMINATED:
-            DLOGD("Cannot execute exponentialBackoffBlockingWait. Current status is BACKOFF_TERMINATED");
+            DLOGV("Cannot execute exponentialBackoffBlockingWait. Current status is BACKOFF_TERMINATED");
             CHK_ERR(FALSE, STATUS_EXPONENTIAL_BACKOFF_INVALID_STATE, "Exponential backoff is already terminated");
             // No 'break' needed since CHK(FALSE, ...) will always jump to CleanUp
         default:
-            DLOGD("Cannot execute exponentialBackoffBlockingWait. Unexpected state [%"PRIu64"]", pExponentialBackoffRetryStrategyState->status);
+            DLOGV("Cannot execute exponentialBackoffBlockingWait. Unexpected state [%"PRIu64"]", pExponentialBackoffRetryStrategyState->status);
             CHK_ERR(FALSE, STATUS_EXPONENTIAL_BACKOFF_INVALID_STATE, "Unexpected exponential backoff state");
     }
 
@@ -205,18 +210,24 @@ CleanUp:
     return retStatus;
 }
 
-STATUS getExponentialBackoffRetryStrategyWaitTime(PRetryStrategy pRetryStrategy, PUINT64 retryWaitTime) {
+STATUS getExponentialBackoffRetryStrategyWaitTime(PKvsRetryStrategy pKvsRetryStrategy, PUINT64 retryWaitTime) {
     ENTERS();
     PExponentialBackoffRetryStrategyState pRetryState = NULL;
     PExponentialBackoffRetryStrategyConfig pRetryConfig = NULL;
     UINT64 currentSystemTime = 0, currentRetryWaitTime = 0, jitter = 0;
     STATUS retStatus = STATUS_SUCCESS;
 
-    if (pRetryStrategy == NULL || retryWaitTime == NULL) {
+    // CAUTION: DO NOT use CHK/CHK_STATUS macros here. In the code below, we're acquiring mutex which is getting
+    // released in CleanUp section. Jump from here to CleanUp will result in releasing of the mutex which is not acquired.
+    if (pKvsRetryStrategy == NULL || retryWaitTime == NULL) {
         return STATUS_NULL_ARG;
     }
 
-    pRetryState = TO_EXPONENTIAL_BACKOFF_STATE(pRetryStrategy);
+    if (pKvsRetryStrategy->retryStrategyType != KVS_RETRY_STRATEGY_EXPONENTIAL_BACKOFF_WAIT) {
+        return STATUS_INVALID_ARG;
+    }
+
+    pRetryState = TO_EXPONENTIAL_BACKOFF_STATE(pKvsRetryStrategy->pRetryStrategy);
     MUTEX_LOCK(pRetryState->retryStrategyLock);
 
     CHK_STATUS(validateAndUpdateExponentialBackoffStatus(pRetryState));
@@ -264,7 +275,7 @@ STATUS getExponentialBackoffRetryStrategyWaitTime(PRetryStrategy pRetryStrategy,
 
     *retryWaitTime = currentRetryWaitTime;
 
-    DLOGD("\n Thread Id [%"PRIu64"] "
+    DLOGV("\n Thread Id [%"PRIu64"] "
           "Number of retries [%"PRIu64"], "
           "Retry wait time [%"PRIu64"] ms, "
           "Retry system time [%"PRIu64"]",
@@ -272,7 +283,7 @@ STATUS getExponentialBackoffRetryStrategyWaitTime(PRetryStrategy pRetryStrategy,
 
 CleanUp:
     if (retStatus == STATUS_EXPONENTIAL_BACKOFF_RETRIES_EXHAUSTED) {
-        DLOGD("Exhausted exponential retries");
+        DLOGV("Exhausted exponential retries");
         resetExponentialBackoffRetryState(pRetryState);
     }
 
@@ -281,12 +292,15 @@ CleanUp:
     return retStatus;
 }
 
-STATUS getExponentialBackoffRetryCount(PRetryStrategy pRetryStrategy, PUINT32 pRetryCount) {
+STATUS getExponentialBackoffRetryCount(PKvsRetryStrategy pKvsRetryStrategy, PUINT32 pRetryCount) {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     PExponentialBackoffRetryStrategyState pRetryState = NULL;
-    CHK(pRetryStrategy != NULL && pRetryCount != NULL, STATUS_NULL_ARG);
-    pRetryState = TO_EXPONENTIAL_BACKOFF_STATE(pRetryStrategy);
+
+    CHK(pKvsRetryStrategy != NULL && pRetryCount != NULL, STATUS_NULL_ARG);
+    CHK(pKvsRetryStrategy->retryStrategyType != KVS_RETRY_STRATEGY_EXPONENTIAL_BACKOFF_WAIT, STATUS_INVALID_ARG);
+
+    pRetryState = TO_EXPONENTIAL_BACKOFF_STATE(pKvsRetryStrategy->pRetryStrategy);
     MUTEX_LOCK(pRetryState->retryStrategyLock);
     *pRetryCount = pRetryState->currentRetryCount;
     MUTEX_UNLOCK(pRetryState->retryStrategyLock);
@@ -296,12 +310,12 @@ CleanUp:
     return retStatus;
 }
 
-STATUS exponentialBackoffRetryStrategyBlockingWait(PRetryStrategy pRetryStrategy) {
+STATUS exponentialBackoffRetryStrategyBlockingWait(PKvsRetryStrategy pKvsRetryStrategy) {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     UINT64 retryWaitTime;
 
-    CHK_STATUS(getExponentialBackoffRetryStrategyWaitTime(pRetryStrategy, &retryWaitTime));
+    CHK_STATUS(getExponentialBackoffRetryStrategyWaitTime(pKvsRetryStrategy, &retryWaitTime));
     THREAD_SLEEP(retryWaitTime);
 
 CleanUp:
@@ -309,23 +323,23 @@ CleanUp:
     return retStatus;
 }
 
-STATUS exponentialBackoffRetryStrategyFree(PRetryStrategy* ppRetryStrategy) {
+STATUS exponentialBackoffRetryStrategyFree(PKvsRetryStrategy pKvsRetryStrategy) {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     PExponentialBackoffRetryStrategyState pExponentialBackoffRetryStrategyState;
 
-    if (ppRetryStrategy == NULL) {
-        return retStatus;
-    }
+    CHK(pKvsRetryStrategy != NULL, STATUS_NULL_ARG);
+    CHK(pKvsRetryStrategy->retryStrategyType == KVS_RETRY_STRATEGY_EXPONENTIAL_BACKOFF_WAIT, STATUS_INVALID_ARG);
 
-    pExponentialBackoffRetryStrategyState = TO_EXPONENTIAL_BACKOFF_STATE(*ppRetryStrategy);
+    pExponentialBackoffRetryStrategyState = TO_EXPONENTIAL_BACKOFF_STATE(pKvsRetryStrategy->pRetryStrategy);
     if (pExponentialBackoffRetryStrategyState != NULL) {
         MUTEX_FREE(pExponentialBackoffRetryStrategyState->retryStrategyLock);
     }
 
     SAFE_MEMFREE(pExponentialBackoffRetryStrategyState);
-    *ppRetryStrategy = NULL;
+    pKvsRetryStrategy->pRetryStrategy = NULL;
 
+CleanUp:
     LEAVES();
     return retStatus;
 }

--- a/src/utils/tst/ExponentialBackoffUtilsTest.cpp
+++ b/src/utils/tst/ExponentialBackoffUtilsTest.cpp
@@ -183,9 +183,13 @@ TEST_F(ExponentialBackoffUtilsTest, testExponentialBackoffBlockingWait_Unbounded
     };
 
     UINT64 retryWaitTimeToVerify;
+    UINT32 actualRetryCount = 0;
     for (int retryCount = 0; retryCount < 7; retryCount++) {
         retryWaitTimeToVerify = 0;
         EXPECT_EQ(STATUS_SUCCESS, getExponentialBackoffRetryStrategyWaitTime(&kvsRetryStrategy, &retryWaitTimeToVerify));
+        EXPECT_EQ(STATUS_SUCCESS, getExponentialBackoffRetryCount(&kvsRetryStrategy, &actualRetryCount));
+
+        EXPECT_EQ(retryCount + 1, actualRetryCount);
         validateExponentialBackoffWaitTime(
                 pExponentialBackoffRetryStrategyState,
                 retryWaitTimeToVerify,
@@ -240,9 +244,13 @@ TEST_F(ExponentialBackoffUtilsTest, testExponentialBackoffBlockingWait_Bounded)
     };
 
     UINT64 retryWaitTimeToVerify;
+    UINT32 actualRetryCount = 0;
     for (int retryCount = 0; retryCount < maxTestRetryCount; retryCount++) {
         retryWaitTimeToVerify = 0;
         EXPECT_EQ(STATUS_SUCCESS, getExponentialBackoffRetryStrategyWaitTime(&kvsRetryStrategy, &retryWaitTimeToVerify));
+        EXPECT_EQ(STATUS_SUCCESS, getExponentialBackoffRetryCount(&kvsRetryStrategy, &actualRetryCount));
+
+        EXPECT_EQ(retryCount + 1, actualRetryCount);
         validateExponentialBackoffWaitTime(
                 pExponentialBackoffRetryStrategyState,
                 retryWaitTimeToVerify,
@@ -293,9 +301,13 @@ TEST_F(ExponentialBackoffUtilsTest, testExponentialBackoffBlockingWait_FullJitte
     };
 
     UINT64 retryWaitTimeToVerify;
+    UINT32 actualRetryCount = 0;
     for (int retryCount = 0; retryCount < maxTestRetryCount; retryCount++) {
         retryWaitTimeToVerify = 0;
         EXPECT_EQ(STATUS_SUCCESS, getExponentialBackoffRetryStrategyWaitTime(&kvsRetryStrategy, &retryWaitTimeToVerify));
+        EXPECT_EQ(STATUS_SUCCESS, getExponentialBackoffRetryCount(&kvsRetryStrategy, &actualRetryCount));
+
+        EXPECT_EQ(retryCount + 1, actualRetryCount);
         validateExponentialBackoffWaitTime(
                 pExponentialBackoffRetryStrategyState,
                 retryWaitTimeToVerify,


### PR DESCRIPTION
This change includes following - 

- Decoupling retry strategy callbacks from the actual retry strategy
- Adding retry strategy type check before casting retry strategy state

*Issue #, if available:*

*Description of changes:*

Decoupling retry strategy callbacks from the actual retry strategy, adding retry strategy type check before casting retry strategy state

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
