### PR TITLE
Create retry strategy after fixing up device info

### DIFF
--- a/src/client/src/Client.c
+++ b/src/client/src/Client.c
@@ -221,13 +221,13 @@ STATUS createKinesisVideoClient(PDeviceInfo pDeviceInfo, PClientCallbacks pClien
     // Copy the structures in their entirety
     MEMCPY(&pKinesisVideoClient->clientCallbacks, pClientCallbacks, SIZEOF(ClientCallbacks));
 
-    CHK_STATUS(configureClientWithRetryStrategy(pKinesisVideoClient));
-
     // Fix-up the defaults if needed
     // IMPORTANT!!! The calloc allocator will zero the memory which will also act as a
     // sentinel value in case of an earlier version of the structure
     // is used and the remaining fields are not copied
     fixupDeviceInfo(&pKinesisVideoClient->deviceInfo, pDeviceInfo);
+
+    CHK_STATUS(configureClientWithRetryStrategy(pKinesisVideoClient));
 
     // Fix-up the name of the device if not specified
     if (pKinesisVideoClient->deviceInfo.name[0] == '\0') {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Crate retry strategy after fixing up device info. `fixupDeviceInfo` overwrites deviceInfo.clientInfo and hence we were losing the retry strategy callbacks which are set in configureClientWithRetryStrategy.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
