### PR TITLE
make INLINE compatible with C99

### DIFF
--- a/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
+++ b/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
@@ -36,7 +36,11 @@ extern "C" {
 #endif
 #else
 #if __GNUC__ >= 4
+#ifdef __GNUC_STDC_INLINE__
+#define INLINE       __attribute__((gnu_inline))
+#else
 #define INLINE       inline
+#endif
 #define LIB_EXPORT   __attribute__((visibility("default")))
 #define LIB_IMPORT   __attribute__((visibility("default")))
 #define LIB_INTERNAL __attribute__((visibility("hidden")))


### PR DESCRIPTION
*Description of changes:*
C99 has an incompatible inline behaviour but GCC provides the `gnu_inline` attribute to switch to the old behaviour.
It it suggested to check via `__GNUC_STDC_INLINE__` if the new behaviour is active.

Without this change you get several warnings (or errors with -Werror) like this one when compiled in C99:
`CommonDefs.h:622:14: error: inline function 'defaultMemAlloc' declared but never defined [-Werror]`

Support for `gnu_inline` and `__GNUC_STDC_INLINE__`  was introduced in GCC 4.1.3 (current check is for 4.x) but it might be an option to always use the `gnu_inline` attribute.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
