### PR TITLE
Add completion timeout configurability

### DIFF
--- a/src/client/include/com/amazonaws/kinesis/video/client/Include.h
+++ b/src/client/include/com/amazonaws/kinesis/video/client/Include.h
@@ -322,9 +322,15 @@ extern "C" {
 #define MIN_VIEW_BUFFER_DURATION (MAX(MIN_BUFFER_DURATION_IN_SECONDS * HUNDREDS_OF_NANOS_IN_A_SECOND, MIN_CONTENT_VIEW_BUFFER_DURATION))
 
 /**
- * Service call default timeout - 5 seconds
+ * Service call default connection timeout - 5 seconds
  */
-#define SERVICE_CALL_DEFAULT_TIMEOUT (5 * HUNDREDS_OF_NANOS_IN_A_SECOND)
+#define SERVICE_CALL_DEFAULT_CONNECTION_TIMEOUT (5 * HUNDREDS_OF_NANOS_IN_A_SECOND)
+
+/**
+ * Service call default completion timeout - 10 seconds. Needs to be more than connection timeout
+ */
+#define SERVICE_CALL_DEFAULT_TIMEOUT (10 * HUNDREDS_OF_NANOS_IN_A_SECOND)
+
 
 /**
  * Service call infinite timeout for streaming
@@ -455,12 +461,12 @@ extern "C" {
 #define SEGMENT_INFO_CURRENT_VERSION          0
 #define STORAGE_INFO_CURRENT_VERSION          0
 #define AUTH_INFO_CURRENT_VERSION             0
-#define SERVICE_CALL_CONTEXT_CURRENT_VERSION  0
+#define SERVICE_CALL_CONTEXT_CURRENT_VERSION  1
 #define STREAM_DESCRIPTION_CURRENT_VERSION    1
 #define FRAGMENT_ACK_CURRENT_VERSION          0
 #define STREAM_METRICS_CURRENT_VERSION        3
 #define CLIENT_METRICS_CURRENT_VERSION        2
-#define CLIENT_INFO_CURRENT_VERSION           2
+#define CLIENT_INFO_CURRENT_VERSION           3
 #define STREAM_EVENT_METADATA_CURRENT_VERSION 0
 
 /**
@@ -1148,6 +1154,8 @@ typedef struct __ClientInfo {
     // Version of the struct
     UINT32 version;
 
+    // ------------------------------- V0 compat ----------------------
+
     // Client sync creation timeout. 0 or INVALID_TIMESTAMP_VALUE = use default
     UINT64 createClientTimeout;
 
@@ -1166,12 +1174,12 @@ typedef struct __ClientInfo {
     // whether to log metric or not
     BOOL logMetric;
 
-    // ------------------------------- V0 compat ----------------------
+    // ------------------------------- V1 compat ----------------------
 
     // Time that allowed to be elapsed between the metric loggings if enabled
     UINT64 metricLoggingPeriod;
 
-    // ------------------------------ V1 compat --------------------------
+    // ------------------------------ V2 compat --------------------------
 
     // flag for automatic handling of intermittent producer
     AUTOMATIC_STREAMING_FLAGS automaticStreamingFlags;
@@ -1185,6 +1193,11 @@ typedef struct __ClientInfo {
 
     // Function pointers for application to provide a custom retry strategy
     KvsRetryStrategyCallbacks kvsRetryStrategyCallbacks;
+
+    // ------------------------------ V3 compat --------------------------
+    UINT64 serviceCallCompletionTimeout;
+    UINT64 serviceCallConnectionTimeout;
+
 } ClientInfo, *PClientInfo;
 
 /**
@@ -1484,6 +1497,9 @@ struct __ServiceCallContext {
 
     // Authentication info
     PAuthInfo pAuthInfo;
+
+    // -------- V1 compat --------
+    UINT64 connectionTimeout;
 };
 
 typedef struct __ServiceCallContext* PServiceCallContext;

--- a/src/client/include/com/amazonaws/kinesis/video/client/Include.h
+++ b/src/client/include/com/amazonaws/kinesis/video/client/Include.h
@@ -1154,8 +1154,6 @@ typedef struct __ClientInfo {
     // Version of the struct
     UINT32 version;
 
-    // ------------------------------- V0 compat ----------------------
-
     // Client sync creation timeout. 0 or INVALID_TIMESTAMP_VALUE = use default
     UINT64 createClientTimeout;
 
@@ -1174,12 +1172,12 @@ typedef struct __ClientInfo {
     // whether to log metric or not
     BOOL logMetric;
 
-    // ------------------------------- V1 compat ----------------------
+    // ------------------------------- V0 compat ----------------------
 
     // Time that allowed to be elapsed between the metric loggings if enabled
     UINT64 metricLoggingPeriod;
 
-    // ------------------------------ V2 compat --------------------------
+    // ------------------------------ V1 compat --------------------------
 
     // flag for automatic handling of intermittent producer
     AUTOMATIC_STREAMING_FLAGS automaticStreamingFlags;
@@ -1194,7 +1192,7 @@ typedef struct __ClientInfo {
     // Function pointers for application to provide a custom retry strategy
     KvsRetryStrategyCallbacks kvsRetryStrategyCallbacks;
 
-    // ------------------------------ V3 compat --------------------------
+    // ------------------------------ V2 compat --------------------------
     UINT64 serviceCallCompletionTimeout;
     UINT64 serviceCallConnectionTimeout;
 
@@ -1498,7 +1496,7 @@ struct __ServiceCallContext {
     // Authentication info
     PAuthInfo pAuthInfo;
 
-    // -------- V1 compat --------
+    // -------- V0 compat --------
     UINT64 connectionTimeout;
 };
 

--- a/src/client/src/ClientState.c
+++ b/src/client/src/ClientState.c
@@ -362,7 +362,9 @@ STATUS executeGetTokenClientState(UINT64 customData, UINT64 time)
     pKinesisVideoClient->base.serviceCallContext.pAuthInfo = &pKinesisVideoClient->certAuthInfo;
     pKinesisVideoClient->base.serviceCallContext.version = SERVICE_CALL_CONTEXT_CURRENT_VERSION;
     pKinesisVideoClient->base.serviceCallContext.customData = TO_CUSTOM_DATA(pKinesisVideoClient);
-    pKinesisVideoClient->base.serviceCallContext.timeout = SERVICE_CALL_DEFAULT_TIMEOUT;
+    pKinesisVideoClient->base.serviceCallContext.timeout = pKinesisVideoClient->deviceInfo.clientInfo.serviceCallCompletionTimeout;
+    pKinesisVideoClient->base.serviceCallContext.connectionTimeout = pKinesisVideoClient->deviceInfo.clientInfo.serviceCallConnectionTimeout;
+
     pKinesisVideoClient->base.serviceCallContext.callAfter = time;
 
     // Reset the call result
@@ -420,7 +422,9 @@ STATUS executeCreateClientState(UINT64 customData, UINT64 time)
     pKinesisVideoClient->base.serviceCallContext.pAuthInfo = &pKinesisVideoClient->tokenAuthInfo;
     pKinesisVideoClient->base.serviceCallContext.version = SERVICE_CALL_CONTEXT_CURRENT_VERSION;
     pKinesisVideoClient->base.serviceCallContext.customData = TO_CUSTOM_DATA(pKinesisVideoClient);
-    pKinesisVideoClient->base.serviceCallContext.timeout = SERVICE_CALL_DEFAULT_TIMEOUT;
+    pKinesisVideoClient->base.serviceCallContext.timeout = pKinesisVideoClient->deviceInfo.clientInfo.serviceCallCompletionTimeout;
+    pKinesisVideoClient->base.serviceCallContext.connectionTimeout = pKinesisVideoClient->deviceInfo.clientInfo.serviceCallConnectionTimeout;
+
     pKinesisVideoClient->base.serviceCallContext.callAfter = time;
 
     // Reset the call result
@@ -469,7 +473,9 @@ STATUS executeTagClientState(UINT64 customData, UINT64 time)
     pKinesisVideoClient->base.serviceCallContext.pAuthInfo = &pKinesisVideoClient->tokenAuthInfo;
     pKinesisVideoClient->base.serviceCallContext.version = SERVICE_CALL_CONTEXT_CURRENT_VERSION;
     pKinesisVideoClient->base.serviceCallContext.customData = TO_CUSTOM_DATA(pKinesisVideoClient);
-    pKinesisVideoClient->base.serviceCallContext.timeout = SERVICE_CALL_DEFAULT_TIMEOUT;
+    pKinesisVideoClient->base.serviceCallContext.timeout = pKinesisVideoClient->deviceInfo.clientInfo.serviceCallCompletionTimeout;
+    pKinesisVideoClient->base.serviceCallContext.connectionTimeout = pKinesisVideoClient->deviceInfo.clientInfo.serviceCallConnectionTimeout;
+
     pKinesisVideoClient->base.serviceCallContext.callAfter = time;
 
     // Reset the call result

--- a/src/client/src/InputValidator.c
+++ b/src/client/src/InputValidator.c
@@ -308,9 +308,16 @@ VOID fixupClientInfo(PClientInfo pClientInfo, PClientInfo pOrigClientInfo)
         pClientInfo->logMetric = pOrigClientInfo->logMetric;
         pClientInfo->automaticStreamingFlags = AUTOMATIC_STREAMING_INTERMITTENT_PRODUCER;
         pClientInfo->reservedCallbackPeriod = INTERMITTENT_PRODUCER_PERIOD_SENTINEL_VALUE;
+        pClientInfo->serviceCallConnectionTimeout = SERVICE_CALL_DEFAULT_CONNECTION_TIMEOUT;
+        pClientInfo->serviceCallCompletionTimeout = SERVICE_CALL_DEFAULT_TIMEOUT;
         pClientInfo->kvsRetryStrategyCallbacks = pOrigClientInfo->kvsRetryStrategyCallbacks;
 
         switch (pOrigClientInfo->version) {
+            case 3:
+                pClientInfo->serviceCallCompletionTimeout = pOrigClientInfo->serviceCallCompletionTimeout;
+                pClientInfo->serviceCallConnectionTimeout = pOrigClientInfo->serviceCallConnectionTimeout;
+
+                // explicit fall through
             case 2:
                 // Copy individual fields and skip to V1
                 pClientInfo->automaticStreamingFlags = pOrigClientInfo->automaticStreamingFlags;
@@ -324,6 +331,23 @@ VOID fixupClientInfo(PClientInfo pClientInfo, PClientInfo pOrigClientInfo)
             default:
                 DLOGW("Invalid ClientInfo version");
         }
+    }
+
+    if(pClientInfo->serviceCallConnectionTimeout > pClientInfo->serviceCallCompletionTimeout) {
+        DLOGW("Completion timeout should be more than connection timeout...setting to defaults");
+        pClientInfo->serviceCallConnectionTimeout = SERVICE_CALL_DEFAULT_CONNECTION_TIMEOUT;
+        pClientInfo->serviceCallCompletionTimeout = SERVICE_CALL_DEFAULT_TIMEOUT;
+    }
+
+    if(pClientInfo->serviceCallConnectionTimeout == 0 || !IS_VALID_TIMESTAMP(pClientInfo->serviceCallConnectionTimeout)) {
+        // Although curl sets default if the value is 0, the default is 300 seconds (5 minutes) which is very high
+        DLOGW("Connection timeout should be non zero...setting to default");
+        pClientInfo->serviceCallConnectionTimeout = SERVICE_CALL_DEFAULT_CONNECTION_TIMEOUT;
+    }
+
+    if(pClientInfo->serviceCallCompletionTimeout == 0 || !IS_VALID_TIMESTAMP(pClientInfo->serviceCallCompletionTimeout)) {
+        // If 0, it means there is no timeout on completion of the curl call which could be dangerous
+        pClientInfo->serviceCallCompletionTimeout = SERVICE_CALL_DEFAULT_TIMEOUT;
     }
 
     if (pClientInfo->reservedCallbackPeriod == INTERMITTENT_PRODUCER_PERIOD_SENTINEL_VALUE) {

--- a/src/client/src/InputValidator.c
+++ b/src/client/src/InputValidator.c
@@ -341,11 +341,12 @@ VOID fixupClientInfo(PClientInfo pClientInfo, PClientInfo pOrigClientInfo)
 
     if(pClientInfo->serviceCallConnectionTimeout == 0 || !IS_VALID_TIMESTAMP(pClientInfo->serviceCallConnectionTimeout)) {
         // Although curl sets default if the value is 0, the default is 300 seconds (5 minutes) which is very high
-        DLOGW("Connection timeout should be non zero...setting to default");
+        DLOGW("Connection timeout is invalid...setting to default");
         pClientInfo->serviceCallConnectionTimeout = SERVICE_CALL_DEFAULT_CONNECTION_TIMEOUT;
     }
 
     if(pClientInfo->serviceCallCompletionTimeout == 0 || !IS_VALID_TIMESTAMP(pClientInfo->serviceCallCompletionTimeout)) {
+        DLOGW("Completion timeout is invalid...setting to default");
         // If 0, it means there is no timeout on completion of the curl call which could be dangerous
         pClientInfo->serviceCallCompletionTimeout = SERVICE_CALL_DEFAULT_TIMEOUT;
     }

--- a/src/client/src/StreamState.c
+++ b/src/client/src/StreamState.c
@@ -220,7 +220,9 @@ STATUS executeDescribeStreamState(UINT64 customData, UINT64 time)
     pKinesisVideoStream->base.serviceCallContext.pAuthInfo = &pKinesisVideoClient->tokenAuthInfo;
     pKinesisVideoStream->base.serviceCallContext.version = SERVICE_CALL_CONTEXT_CURRENT_VERSION;
     pKinesisVideoStream->base.serviceCallContext.customData = TO_STREAM_HANDLE(pKinesisVideoStream);
-    pKinesisVideoStream->base.serviceCallContext.timeout = SERVICE_CALL_DEFAULT_TIMEOUT;
+    pKinesisVideoStream->base.serviceCallContext.timeout = pKinesisVideoClient->deviceInfo.clientInfo.serviceCallCompletionTimeout;
+    pKinesisVideoStream->base.serviceCallContext.connectionTimeout = pKinesisVideoClient->deviceInfo.clientInfo.serviceCallConnectionTimeout;
+
     pKinesisVideoStream->base.serviceCallContext.callAfter = time;
 
     // Reset the call result
@@ -630,7 +632,9 @@ STATUS executeGetEndpointStreamState(UINT64 customData, UINT64 time)
     pKinesisVideoStream->base.serviceCallContext.pAuthInfo = &pKinesisVideoClient->tokenAuthInfo;
     pKinesisVideoStream->base.serviceCallContext.version = SERVICE_CALL_CONTEXT_CURRENT_VERSION;
     pKinesisVideoStream->base.serviceCallContext.customData = TO_STREAM_HANDLE(pKinesisVideoStream);
-    pKinesisVideoStream->base.serviceCallContext.timeout = SERVICE_CALL_DEFAULT_TIMEOUT;
+    pKinesisVideoStream->base.serviceCallContext.timeout = pKinesisVideoClient->deviceInfo.clientInfo.serviceCallCompletionTimeout;
+    pKinesisVideoStream->base.serviceCallContext.connectionTimeout = pKinesisVideoClient->deviceInfo.clientInfo.serviceCallConnectionTimeout;
+
     pKinesisVideoStream->base.serviceCallContext.callAfter = time;
 
     // Reset the call result
@@ -664,7 +668,9 @@ STATUS executeGetTokenStreamState(UINT64 customData, UINT64 time)
     pKinesisVideoStream->base.serviceCallContext.pAuthInfo = &pKinesisVideoClient->tokenAuthInfo;
     pKinesisVideoStream->base.serviceCallContext.version = SERVICE_CALL_CONTEXT_CURRENT_VERSION;
     pKinesisVideoStream->base.serviceCallContext.customData = TO_STREAM_HANDLE(pKinesisVideoStream);
-    pKinesisVideoStream->base.serviceCallContext.timeout = SERVICE_CALL_DEFAULT_TIMEOUT;
+    pKinesisVideoStream->base.serviceCallContext.timeout = pKinesisVideoClient->deviceInfo.clientInfo.serviceCallCompletionTimeout;
+    pKinesisVideoStream->base.serviceCallContext.connectionTimeout = pKinesisVideoClient->deviceInfo.clientInfo.serviceCallConnectionTimeout;
+
     pKinesisVideoStream->base.serviceCallContext.callAfter = time;
 
     // Reset the call result
@@ -698,7 +704,9 @@ STATUS executeCreateStreamState(UINT64 customData, UINT64 time)
     pKinesisVideoStream->base.serviceCallContext.pAuthInfo = &pKinesisVideoClient->tokenAuthInfo;
     pKinesisVideoStream->base.serviceCallContext.version = SERVICE_CALL_CONTEXT_CURRENT_VERSION;
     pKinesisVideoStream->base.serviceCallContext.customData = TO_STREAM_HANDLE(pKinesisVideoStream);
-    pKinesisVideoStream->base.serviceCallContext.timeout = SERVICE_CALL_DEFAULT_TIMEOUT;
+    pKinesisVideoStream->base.serviceCallContext.timeout = pKinesisVideoClient->deviceInfo.clientInfo.serviceCallCompletionTimeout;
+    pKinesisVideoStream->base.serviceCallContext.connectionTimeout = pKinesisVideoClient->deviceInfo.clientInfo.serviceCallConnectionTimeout;
+
     pKinesisVideoStream->base.serviceCallContext.callAfter = time;
 
     // Reset the call result
@@ -734,7 +742,9 @@ STATUS executeTagStreamState(UINT64 customData, UINT64 time)
     pKinesisVideoStream->base.serviceCallContext.pAuthInfo = &pKinesisVideoClient->tokenAuthInfo;
     pKinesisVideoStream->base.serviceCallContext.version = SERVICE_CALL_CONTEXT_CURRENT_VERSION;
     pKinesisVideoStream->base.serviceCallContext.customData = TO_STREAM_HANDLE(pKinesisVideoStream);
-    pKinesisVideoStream->base.serviceCallContext.timeout = SERVICE_CALL_DEFAULT_TIMEOUT;
+    pKinesisVideoStream->base.serviceCallContext.timeout = pKinesisVideoClient->deviceInfo.clientInfo.serviceCallCompletionTimeout;
+    pKinesisVideoStream->base.serviceCallContext.connectionTimeout = pKinesisVideoClient->deviceInfo.clientInfo.serviceCallConnectionTimeout;
+
     pKinesisVideoStream->base.serviceCallContext.callAfter = time;
 
     // Reset the call result
@@ -808,6 +818,8 @@ STATUS executePutStreamState(UINT64 customData, UINT64 time)
     pKinesisVideoStream->base.serviceCallContext.customData = TO_STREAM_HANDLE(pKinesisVideoStream);
     // Infinite wait for streaming
     pKinesisVideoStream->base.serviceCallContext.timeout = SERVICE_CALL_INFINITE_TIMEOUT;
+    pKinesisVideoStream->base.serviceCallContext.connectionTimeout = pKinesisVideoClient->deviceInfo.clientInfo.serviceCallConnectionTimeout;
+
     pKinesisVideoStream->base.serviceCallContext.callAfter = time;
 
     // We need to call the put stream API the first time

--- a/src/client/tst/ClientApiFunctionalityTest.cpp
+++ b/src/client/tst/ClientApiFunctionalityTest.cpp
@@ -199,7 +199,7 @@ TEST_F(ClientApiFunctionalityTest, createClientCreateStream_Iterate)
 
         // Create a few streams and don't delete immediately
         for (UINT32 i = 0; i < ARRAY_SIZE(streams); i++) {
-            SPRINTF(mStreamInfo.name, "TestStream_%d", i);
+            SNPRINTF(mStreamInfo.name, MAX_STREAM_NAME_LEN + 1, "TestStream_%d", i);
             EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoStreamSync(mClientHandle, &mStreamInfo, &mStreamHandle));
             EXPECT_TRUE(IS_VALID_STREAM_HANDLE(mStreamHandle));
         }
@@ -216,7 +216,7 @@ TEST_F(ClientApiFunctionalityTest, createClientCreateStream_Iterate)
 
         // Create a few streams and don't delete immediately
         for (UINT32 i = 0; i < ARRAY_SIZE(streams); i++) {
-            SPRINTF(mStreamInfo.name, "TestStream_%d", i);
+            SNPRINTF(mStreamInfo.name, MAX_STREAM_NAME_LEN + 1, "TestStream_%d", i);
             EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoStreamSync(mClientHandle, &mStreamInfo, &streams[i]));
             EXPECT_TRUE(IS_VALID_STREAM_HANDLE(streams[i]));
         }

--- a/src/client/tst/ClientApiTest.cpp
+++ b/src/client/tst/ClientApiTest.cpp
@@ -284,6 +284,117 @@ TEST_F(ClientApiTest, createKinesisVideoClient_ValidateDeviceInfo)
     EXPECT_EQ(STATUS_SUCCESS, freeKinesisVideoClient(&clientHandle));
 }
 
+TEST_F(ClientApiTest, client_info_version_test)
+{
+    CLIENT_HANDLE clientHandle;
+    PKinesisVideoClient pKinesisVideoClient;
+
+    // Test with version 0
+    mDeviceInfo.clientInfo.version = 0;
+    EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoClient(&mDeviceInfo, &mClientCallbacks, &clientHandle));
+    pKinesisVideoClient = FROM_CLIENT_HANDLE(clientHandle);
+
+    EXPECT_EQ(mDeviceInfo.clientInfo.createClientTimeout, pKinesisVideoClient->deviceInfo.clientInfo.createClientTimeout);
+    EXPECT_EQ(mDeviceInfo.clientInfo.stopStreamTimeout, pKinesisVideoClient->deviceInfo.clientInfo.stopStreamTimeout);
+    EXPECT_EQ(mDeviceInfo.clientInfo.offlineBufferAvailabilityTimeout, pKinesisVideoClient->deviceInfo.clientInfo.offlineBufferAvailabilityTimeout);
+    EXPECT_EQ(mDeviceInfo.clientInfo.loggerLogLevel, pKinesisVideoClient->deviceInfo.clientInfo.loggerLogLevel);
+    EXPECT_EQ(mDeviceInfo.clientInfo.logMetric, pKinesisVideoClient->deviceInfo.clientInfo.logMetric);
+    EXPECT_EQ(AUTOMATIC_STREAMING_INTERMITTENT_PRODUCER, pKinesisVideoClient->deviceInfo.clientInfo.automaticStreamingFlags);
+    EXPECT_EQ(INTERMITTENT_PRODUCER_PERIOD_DEFAULT, pKinesisVideoClient->deviceInfo.clientInfo.reservedCallbackPeriod);
+    EXPECT_EQ(SERVICE_CALL_DEFAULT_CONNECTION_TIMEOUT, pKinesisVideoClient->deviceInfo.clientInfo.serviceCallConnectionTimeout);
+    EXPECT_EQ(SERVICE_CALL_DEFAULT_TIMEOUT, pKinesisVideoClient->deviceInfo.clientInfo.serviceCallCompletionTimeout);
+    EXPECT_EQ(STATUS_SUCCESS, freeKinesisVideoClient(&clientHandle));
+
+
+    // Test with version 1
+    mDeviceInfo.clientInfo.version = 1;
+    EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoClient(&mDeviceInfo, &mClientCallbacks, &clientHandle));
+    pKinesisVideoClient = FROM_CLIENT_HANDLE(clientHandle);
+
+    EXPECT_EQ(mDeviceInfo.clientInfo.createClientTimeout, pKinesisVideoClient->deviceInfo.clientInfo.createClientTimeout);
+    EXPECT_EQ(mDeviceInfo.clientInfo.stopStreamTimeout, pKinesisVideoClient->deviceInfo.clientInfo.stopStreamTimeout);
+    EXPECT_EQ(mDeviceInfo.clientInfo.offlineBufferAvailabilityTimeout, pKinesisVideoClient->deviceInfo.clientInfo.offlineBufferAvailabilityTimeout);
+    EXPECT_EQ(mDeviceInfo.clientInfo.loggerLogLevel, pKinesisVideoClient->deviceInfo.clientInfo.loggerLogLevel);
+    EXPECT_EQ(mDeviceInfo.clientInfo.logMetric, pKinesisVideoClient->deviceInfo.clientInfo.logMetric);
+    EXPECT_EQ(AUTOMATIC_STREAMING_INTERMITTENT_PRODUCER, pKinesisVideoClient->deviceInfo.clientInfo.automaticStreamingFlags);
+    EXPECT_EQ(INTERMITTENT_PRODUCER_PERIOD_DEFAULT, pKinesisVideoClient->deviceInfo.clientInfo.reservedCallbackPeriod);
+    EXPECT_EQ(SERVICE_CALL_DEFAULT_CONNECTION_TIMEOUT, pKinesisVideoClient->deviceInfo.clientInfo.serviceCallConnectionTimeout);
+    EXPECT_EQ(SERVICE_CALL_DEFAULT_TIMEOUT, pKinesisVideoClient->deviceInfo.clientInfo.serviceCallCompletionTimeout);
+    EXPECT_EQ(STATUS_SUCCESS, freeKinesisVideoClient(&clientHandle));
+
+    // Test with version 2
+    mDeviceInfo.clientInfo.version = 2;
+    mDeviceInfo.clientInfo.automaticStreamingFlags = AUTOMATIC_STREAMING_ALWAYS_CONTINUOUS;
+    mDeviceInfo.clientInfo.reservedCallbackPeriod = 10000LL * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+    EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoClient(&mDeviceInfo, &mClientCallbacks, &clientHandle));
+    pKinesisVideoClient = FROM_CLIENT_HANDLE(clientHandle);
+
+    EXPECT_EQ(mDeviceInfo.clientInfo.createClientTimeout, pKinesisVideoClient->deviceInfo.clientInfo.createClientTimeout);
+    EXPECT_EQ(mDeviceInfo.clientInfo.stopStreamTimeout, pKinesisVideoClient->deviceInfo.clientInfo.stopStreamTimeout);
+    EXPECT_EQ(mDeviceInfo.clientInfo.offlineBufferAvailabilityTimeout, pKinesisVideoClient->deviceInfo.clientInfo.offlineBufferAvailabilityTimeout);
+    EXPECT_EQ(mDeviceInfo.clientInfo.loggerLogLevel, pKinesisVideoClient->deviceInfo.clientInfo.loggerLogLevel);
+    EXPECT_EQ(mDeviceInfo.clientInfo.logMetric, pKinesisVideoClient->deviceInfo.clientInfo.logMetric);
+    EXPECT_EQ(AUTOMATIC_STREAMING_ALWAYS_CONTINUOUS, pKinesisVideoClient->deviceInfo.clientInfo.automaticStreamingFlags);
+    EXPECT_EQ(10000LL * HUNDREDS_OF_NANOS_IN_A_MILLISECOND, pKinesisVideoClient->deviceInfo.clientInfo.reservedCallbackPeriod);
+    EXPECT_EQ(SERVICE_CALL_DEFAULT_CONNECTION_TIMEOUT, pKinesisVideoClient->deviceInfo.clientInfo.serviceCallConnectionTimeout);
+    EXPECT_EQ(SERVICE_CALL_DEFAULT_TIMEOUT, pKinesisVideoClient->deviceInfo.clientInfo.serviceCallCompletionTimeout);
+    EXPECT_EQ(STATUS_SUCCESS, freeKinesisVideoClient(&clientHandle));
+
+    // Test with version 3. Default serviceCallConnectionTimeout expected since value is 0
+    mDeviceInfo.clientInfo.version = 3;
+    mDeviceInfo.clientInfo.serviceCallConnectionTimeout = 0;
+    mDeviceInfo.clientInfo.serviceCallCompletionTimeout = 3000LL * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+    EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoClient(&mDeviceInfo, &mClientCallbacks, &clientHandle));
+    pKinesisVideoClient = FROM_CLIENT_HANDLE(clientHandle);
+
+    EXPECT_EQ(mDeviceInfo.clientInfo.createClientTimeout, pKinesisVideoClient->deviceInfo.clientInfo.createClientTimeout);
+    EXPECT_EQ(mDeviceInfo.clientInfo.stopStreamTimeout, pKinesisVideoClient->deviceInfo.clientInfo.stopStreamTimeout);
+    EXPECT_EQ(mDeviceInfo.clientInfo.offlineBufferAvailabilityTimeout, pKinesisVideoClient->deviceInfo.clientInfo.offlineBufferAvailabilityTimeout);
+    EXPECT_EQ(mDeviceInfo.clientInfo.loggerLogLevel, pKinesisVideoClient->deviceInfo.clientInfo.loggerLogLevel);
+    EXPECT_EQ(mDeviceInfo.clientInfo.logMetric, pKinesisVideoClient->deviceInfo.clientInfo.logMetric);
+    EXPECT_EQ(AUTOMATIC_STREAMING_ALWAYS_CONTINUOUS, pKinesisVideoClient->deviceInfo.clientInfo.automaticStreamingFlags);
+    EXPECT_EQ(10000LL * HUNDREDS_OF_NANOS_IN_A_MILLISECOND, pKinesisVideoClient->deviceInfo.clientInfo.reservedCallbackPeriod);
+    EXPECT_EQ(SERVICE_CALL_DEFAULT_CONNECTION_TIMEOUT, pKinesisVideoClient->deviceInfo.clientInfo.serviceCallConnectionTimeout);
+    EXPECT_EQ(3000LL * HUNDREDS_OF_NANOS_IN_A_MILLISECOND, pKinesisVideoClient->deviceInfo.clientInfo.serviceCallCompletionTimeout);
+    EXPECT_EQ(STATUS_SUCCESS, freeKinesisVideoClient(&clientHandle));
+
+    // Test with version 3. Default serviceCallCompletionTimeout expected since value is 0
+    mDeviceInfo.clientInfo.version = 3;
+    mDeviceInfo.clientInfo.serviceCallConnectionTimeout = 5000LL * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+    mDeviceInfo.clientInfo.serviceCallCompletionTimeout = 0;
+    EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoClient(&mDeviceInfo, &mClientCallbacks, &clientHandle));
+    pKinesisVideoClient = FROM_CLIENT_HANDLE(clientHandle);
+
+    EXPECT_EQ(mDeviceInfo.clientInfo.createClientTimeout, pKinesisVideoClient->deviceInfo.clientInfo.createClientTimeout);
+    EXPECT_EQ(mDeviceInfo.clientInfo.stopStreamTimeout, pKinesisVideoClient->deviceInfo.clientInfo.stopStreamTimeout);
+    EXPECT_EQ(mDeviceInfo.clientInfo.offlineBufferAvailabilityTimeout, pKinesisVideoClient->deviceInfo.clientInfo.offlineBufferAvailabilityTimeout);
+    EXPECT_EQ(mDeviceInfo.clientInfo.loggerLogLevel, pKinesisVideoClient->deviceInfo.clientInfo.loggerLogLevel);
+    EXPECT_EQ(mDeviceInfo.clientInfo.logMetric, pKinesisVideoClient->deviceInfo.clientInfo.logMetric);
+    EXPECT_EQ(AUTOMATIC_STREAMING_ALWAYS_CONTINUOUS, pKinesisVideoClient->deviceInfo.clientInfo.automaticStreamingFlags);
+    EXPECT_EQ(10000LL * HUNDREDS_OF_NANOS_IN_A_MILLISECOND, pKinesisVideoClient->deviceInfo.clientInfo.reservedCallbackPeriod);
+    EXPECT_EQ(5000LL * HUNDREDS_OF_NANOS_IN_A_MILLISECOND, pKinesisVideoClient->deviceInfo.clientInfo.serviceCallConnectionTimeout);
+    EXPECT_EQ(SERVICE_CALL_DEFAULT_TIMEOUT, pKinesisVideoClient->deviceInfo.clientInfo.serviceCallCompletionTimeout);
+    EXPECT_EQ(STATUS_SUCCESS, freeKinesisVideoClient(&clientHandle));
+
+    // Test with version 3. Default serviceCallCompletionTimeout expected since value is 0
+    mDeviceInfo.clientInfo.version = 3;
+    mDeviceInfo.clientInfo.serviceCallConnectionTimeout = 5000LL * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+    mDeviceInfo.clientInfo.serviceCallCompletionTimeout = 10000LL * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+    EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoClient(&mDeviceInfo, &mClientCallbacks, &clientHandle));
+    pKinesisVideoClient = FROM_CLIENT_HANDLE(clientHandle);
+
+    EXPECT_EQ(mDeviceInfo.clientInfo.createClientTimeout, pKinesisVideoClient->deviceInfo.clientInfo.createClientTimeout);
+    EXPECT_EQ(mDeviceInfo.clientInfo.stopStreamTimeout, pKinesisVideoClient->deviceInfo.clientInfo.stopStreamTimeout);
+    EXPECT_EQ(mDeviceInfo.clientInfo.offlineBufferAvailabilityTimeout, pKinesisVideoClient->deviceInfo.clientInfo.offlineBufferAvailabilityTimeout);
+    EXPECT_EQ(mDeviceInfo.clientInfo.loggerLogLevel, pKinesisVideoClient->deviceInfo.clientInfo.loggerLogLevel);
+    EXPECT_EQ(mDeviceInfo.clientInfo.logMetric, pKinesisVideoClient->deviceInfo.clientInfo.logMetric);
+    EXPECT_EQ(AUTOMATIC_STREAMING_ALWAYS_CONTINUOUS, pKinesisVideoClient->deviceInfo.clientInfo.automaticStreamingFlags);
+    EXPECT_EQ(10000LL * HUNDREDS_OF_NANOS_IN_A_MILLISECOND, pKinesisVideoClient->deviceInfo.clientInfo.reservedCallbackPeriod);
+    EXPECT_EQ(mDeviceInfo.clientInfo.serviceCallConnectionTimeout, pKinesisVideoClient->deviceInfo.clientInfo.serviceCallConnectionTimeout);
+    EXPECT_EQ(mDeviceInfo.clientInfo.serviceCallCompletionTimeout, pKinesisVideoClient->deviceInfo.clientInfo.serviceCallCompletionTimeout);
+    EXPECT_EQ(STATUS_SUCCESS, freeKinesisVideoClient(&clientHandle));
+}
+
 TEST_F(ClientApiTest, kinesisVideoClientCreateSync_Valid_Timeout)
 {
     CLIENT_HANDLE clientHandle;

--- a/src/client/tst/ClientTestFixture.h
+++ b/src/client/tst/ClientTestFixture.h
@@ -596,7 +596,6 @@ class ClientTestBase : public ::testing::Test {
 
         // Set the random number generator seed for reproducibility
         SRAND(12345);
-
         // Create the client
         STATUS status = createKinesisVideoClient(&mDeviceInfo, &mClientCallbacks, &mClientHandle);
 

--- a/src/client/tst/StreamApiTest.cpp
+++ b/src/client/tst/StreamApiTest.cpp
@@ -470,8 +470,8 @@ TEST_F(StreamApiTest, insertKinesisVideoTag_Non_Persistent_Count)
     ReadyStream();
 
     for (i = 0; i < MAX_FRAGMENT_METADATA_COUNT; i++) {
-        SPRINTF(tagName, "tagName_%d", i);
-        SPRINTF(tagValue, "tagValue_%d", i);
+        SNPRINTF(tagName, MKV_MAX_TAG_NAME_LEN + 1, "tagName_%d", i);
+        SNPRINTF(tagValue, MKV_MAX_TAG_VALUE_LEN + 1, "tagValue_%d", i);
         EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFragmentMetadata(mStreamHandle, tagName, tagValue, FALSE));
     }
 
@@ -489,8 +489,8 @@ TEST_F(StreamApiTest, insertKinesisVideoTag_Persistent_Count)
     ReadyStream();
 
     for (i = 0; i < MAX_FRAGMENT_METADATA_COUNT; i++) {
-        SPRINTF(tagName, "tagName_%d", i);
-        SPRINTF(tagValue, "tagValue_%d", i);
+        SNPRINTF(tagName, MKV_MAX_TAG_NAME_LEN + 1, "tagName_%d", i);
+        SNPRINTF(tagValue, MKV_MAX_TAG_VALUE_LEN + 1, "tagValue_%d", i);
         EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFragmentMetadata(mStreamHandle, tagName, tagValue, TRUE));
     }
 
@@ -508,8 +508,8 @@ TEST_F(StreamApiTest, insertKinesisVideoTag_Mixed_Count)
     ReadyStream();
 
     for (i = 0; i < MAX_FRAGMENT_METADATA_COUNT; i++) {
-        SPRINTF(tagName, "tagName_%d", i);
-        SPRINTF(tagValue, "tagValue_%d", i);
+        SNPRINTF(tagName, MKV_MAX_TAG_NAME_LEN + 1, "tagName_%d", i);
+        SNPRINTF(tagValue, MKV_MAX_TAG_VALUE_LEN + 1, "tagValue_%d", i);
         EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFragmentMetadata(mStreamHandle, tagName, tagValue, i % 2 == 0));
     }
 

--- a/src/client/tst/StreamParallelTest.cpp
+++ b/src/client/tst/StreamParallelTest.cpp
@@ -115,7 +115,7 @@ TEST_F(StreamParallelTest, putFrame_BasicParallelPutGet)
 
     // Create and ready a stream
     for (mStreamCount = 0; mStreamCount < MAX_TEST_STREAM_COUNT; mStreamCount++) {
-        SPRINTF(streamName, "%s %d", TEST_STREAM_NAME, mStreamCount);
+        SNPRINTF(streamName, MAX_STREAM_NAME_LEN, "%s %d", TEST_STREAM_NAME, mStreamCount);
         STRCPY(mStreamInfo.name, streamName);
         EXPECT_TRUE(STATUS_SUCCEEDED(createKinesisVideoStream(mClientHandle, &mStreamInfo, &mStreamHandle)));
 

--- a/src/client/tst/StreamPutGetTest.cpp
+++ b/src/client/tst/StreamPutGetTest.cpp
@@ -1697,12 +1697,12 @@ TEST_F(StreamPutGetTest, putFrame_PutGetPersistentTagsStoreData)
 
         if ((frame.flags & FRAME_FLAG_KEY_FRAME) == FRAME_FLAG_KEY_FRAME) {
             // Modify the name of a tag
-            sprintf(tagValue, "persistentValue%d", frame.index);
+            SNPRINTF(tagValue, 1000, "persistentValue%d", frame.index);
             EXPECT_EQ(STATUS_SUCCESS, putFragmentMetadata(pKinesisVideoStream, (PCHAR) "persistentName", (PCHAR) tagValue, TRUE)) << i;
         }
 
         if (frame.index % 9 == 0) {
-            sprintf(tagValue, "tagValue%d", frame.index);
+            SNPRINTF(tagValue, 1000, "tagValue%d", frame.index);
             EXPECT_EQ(STATUS_SUCCESS, putFragmentMetadata(pKinesisVideoStream, (PCHAR) "tagName1", (PCHAR) "nonPersistentTagValue", FALSE)) << i;
             EXPECT_EQ(STATUS_SUCCESS, putFragmentMetadata(pKinesisVideoStream, (PCHAR) "tagName1", tagValue, TRUE)) << i;
 

--- a/src/client/tst/StreamTokenRotationTest.cpp
+++ b/src/client/tst/StreamTokenRotationTest.cpp
@@ -7,7 +7,7 @@ UINT64 gPresetTimeValue = 0;
 UINT32 gPutStreamFuncCount = 0;
 CHAR gStreamingToken[100];
 
-#define UPDATE_TEST_STREAMING_TOKEN(x) (sprintf(gStreamingToken, "%s%d", "StreamingToken_", (x)))
+#define UPDATE_TEST_STREAMING_TOKEN(x) (SNPRINTF(gStreamingToken, 100, "%s%d", "StreamingToken_", (x)))
 
 UINT64 getCurrentTimePreset(UINT64 customData)
 {
@@ -39,7 +39,7 @@ STATUS testPutStream(UINT64 customData,
 
     EXPECT_EQ(SERVICE_CALL_CONTEXT_CURRENT_VERSION, pCallbackContext->version);
     if (pCallbackContext->pAuthInfo != NULL) {
-        EXPECT_EQ(AUTH_INFO_CURRENT_VERSION, pCallbackContext->version);
+        EXPECT_EQ(AUTH_INFO_CURRENT_VERSION, pCallbackContext->pAuthInfo->version);
         if (pCallbackContext->pAuthInfo->type == AUTH_INFO_TYPE_STS) {
             EXPECT_EQ(0, STRCMP(gStreamingToken, (PCHAR) pCallbackContext->pAuthInfo->data));
         }

--- a/src/heap/tst/HybridFileHeapTest.cpp
+++ b/src/heap/tst/HybridFileHeapTest.cpp
@@ -79,7 +79,7 @@ TEST_P(HybridFileHeapTest, hybridFileHeapOperationsAivPrimaryHeap)
 
     // Validate the allocations
     for (i = 0; i < numAlloc; i++) {
-        SPRINTF(filePath, "%s%c%u" FILE_HEAP_FILE_EXTENSION, FILE_HEAP_DEFAULT_ROOT_DIRECTORY, FPATHSEPARATOR, i + 1);
+        SNPRINTF(filePath, MAX_PATH_LEN + 1, "%s%c%u" FILE_HEAP_FILE_EXTENSION, FILE_HEAP_DEFAULT_ROOT_DIRECTORY, FPATHSEPARATOR, i + 1);
         exist = FALSE;
         EXPECT_EQ(STATUS_SUCCESS, fileExists(filePath, &exist));
         EXPECT_EQ(TRUE, exist);
@@ -134,7 +134,7 @@ TEST_P(HybridFileHeapTest, hybridFileHeapOperationsAivPrimaryHeap)
 
     // Validate the allocations
     for (i = 0; i < numAlloc; i++) {
-        SPRINTF(filePath, "%s%c%u" FILE_HEAP_FILE_EXTENSION, FILE_HEAP_DEFAULT_ROOT_DIRECTORY, FPATHSEPARATOR, i + 1);
+        SNPRINTF(filePath, MAX_PATH_LEN + 1, "%s%c%u" FILE_HEAP_FILE_EXTENSION, FILE_HEAP_DEFAULT_ROOT_DIRECTORY, FPATHSEPARATOR, i + 1);
         exist = FALSE;
         EXPECT_EQ(STATUS_SUCCESS, fileExists(filePath, &exist));
         EXPECT_EQ(TRUE, exist);

--- a/src/mkvgen/tst/MkvgenApiFunctionalityTest.cpp
+++ b/src/mkvgen/tst/MkvgenApiFunctionalityTest.cpp
@@ -115,7 +115,7 @@ TEST_F(MkvgenApiFunctionalityTest, mkvgenPackageFrame_CreateStoreMkvFromJpegAsH2
                                                  2 * HUNDREDS_OF_NANOS_IN_A_SECOND, MKV_TEST_SEGMENT_UUID, &mTrackInfo,
                                                  mTrackInfoCount, MKV_TEST_CLIENT_ID, NULL, 0, &mkvGenerator));
     for (i = 0, index = 0; i < 100; i++) {
-        SPRINTF(fileName, (PCHAR) "samples" FPATHSEPARATOR_STR "gif%03d.jpg", i);
+        SNPRINTF(fileName, MAX_PATH_LEN, (PCHAR) "samples" FPATHSEPARATOR_STR "gif%03d.jpg", i);
         fileSize = MKV_TEST_BUFFER_SIZE;
 
         if (STATUS_FAILED(readFile(fileName, TRUE, NULL, &fileSize))) {
@@ -141,8 +141,8 @@ TEST_F(MkvgenApiFunctionalityTest, mkvgenPackageFrame_CreateStoreMkvFromJpegAsH2
     // Add tags
     for (i = 0; i < MKV_TEST_TAG_COUNT; i++) {
         packagedSize = size;
-        SPRINTF(tagName, "testTag_%d", i);
-        SPRINTF(tagVal, "testTag_%d_Value", i);
+        SNPRINTF(tagName, MKV_MAX_TAG_NAME_LEN, "testTag_%d", i);
+        SNPRINTF(tagVal, MKV_MAX_TAG_VALUE_LEN, "testTag_%d_Value", i);
         EXPECT_EQ(STATUS_SUCCESS, mkvgenGenerateTag(mkvGenerator,
                                                     mkvBuffer + index,
                                                     tagName,

--- a/src/utils/tst/Tags.cpp
+++ b/src/utils/tst/Tags.cpp
@@ -14,8 +14,8 @@ TEST_F(TagsFunctionalityTest, basisTagsFunctionality)
         tags[i].name = (PCHAR) MEMALLOC((MAX_TAG_NAME_LEN + 2) * SIZEOF(CHAR));
         tags[i].value = (PCHAR) MEMALLOC((MAX_TAG_VALUE_LEN + 2) * SIZEOF(CHAR));
 
-        SPRINTF(tags[i].name, "Tag Name %u", i);
-        SPRINTF(tags[i].value, "Tag Value %u", i);
+        SNPRINTF(tags[i].name, MAX_TAG_NAME_LEN + 2, "Tag Name %u", i);
+        SNPRINTF(tags[i].value, MAX_TAG_VALUE_LEN + 2, "Tag Value %u", i);
     }
 
     EXPECT_EQ(STATUS_SUCCESS, validateTags(0, NULL));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add configurability for curl call connection and completion timeouts. 
- Fix compiler warning for sprintf in several unit tests
- Add unit test for version (client info)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
