### PR TITLE
Add threadsafe blocking queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ cmake-build-debug/
 cmake-build-release/
 open-source/
 outputs
+*.swp
+*.swo
+tags

--- a/src/utils/include/com/amazonaws/kinesis/video/utils/Include.h
+++ b/src/utils/include/com/amazonaws/kinesis/video/utils/Include.h
@@ -1798,6 +1798,56 @@ PUBLIC_API STATUS exponentialBackoffRetryStrategyFree(PKvsRetryStrategy);
  */
 PUBLIC_API STATUS computePower(UINT64, UINT64, PUINT64);
 
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+// Threadsafe Blocking Queue APIs
+//////////////////////////////////////////////////////////////////////////////////////////////////////
+
+typedef struct {
+    PStackQueue queue;
+    MUTEX       mutex;
+    SEMAPHORE_HANDLE semaphore;
+} SafeBlockingQueue, *PSafeBlockingQueue;
+
+/**
+ * Create a new thread safe blocking queue
+ */
+PUBLIC_API STATUS safeBlockingQueueCreate(PSafeBlockingQueue*);
+
+/**
+ * Frees and de-allocates the thread safe blocking queue
+ */
+PUBLIC_API STATUS safeBlockingQueueFree(PSafeBlockingQueue);
+
+/**
+ * Clears and de-allocates all the items
+ */
+PUBLIC_API STATUS safeBlockingQueueClear(PSafeBlockingQueue, BOOL);
+
+/**
+ * Gets the number of items in the stack/queue
+ */
+PUBLIC_API STATUS safeBlockingQueueGetCount(PSafeBlockingQueue, PUINT32);
+
+/**
+ * Removes the item at the given item
+ */
+PUBLIC_API STATUS safeBlockingQueueRemoveItem(PSafeBlockingQueue, UINT64);
+
+/**
+ * Whether the thread safe blocking queue is empty
+ */
+PUBLIC_API STATUS safeBlockingQueueIsEmpty(PSafeBlockingQueue, PBOOL);
+
+/**
+ * Enqueues an item in the queue
+ */
+PUBLIC_API STATUS safeBlockingQueueEnqueue(PSafeBlockingQueue, UINT64);
+
+/**
+ * Dequeues an item from the queue
+ */
+PUBLIC_API STATUS safeBlockingQueueDequeue(PSafeBlockingQueue, PUINT64);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/utils/include/com/amazonaws/kinesis/video/utils/Include.h
+++ b/src/utils/include/com/amazonaws/kinesis/video/utils/Include.h
@@ -28,7 +28,7 @@ extern "C" {
  * EMA (Exponential Moving Average) alpha value and 1-alpha value - over appx 20 samples
  */
 #define EMA_ALPHA_VALUE           ((DOUBLE) 0.05)
-#define ONE_MINUS_EMA_ALPHA_VALUE ((DOUBLE)(1 - EMA_ALPHA_VALUE))
+#define ONE_MINUS_EMA_ALPHA_VALUE ((DOUBLE) (1 - EMA_ALPHA_VALUE))
 
 /**
  * Calculates the EMA (Exponential Moving Average) accumulator value
@@ -918,31 +918,34 @@ extern putUnalignedInt64Func putUnalignedInt64LittleEndian;
 
 // Helper macro for unaligned
 #define GET_UNALIGNED(ptr)                                                                                                                           \
-    SIZEOF(*(ptr)) == 1 ? *(ptr)                                                                                                                     \
-                        : SIZEOF(*(ptr)) == 2 ? getUnalignedInt16(ptr)                                                                               \
-                                              : SIZEOF(*(ptr)) == 4 ? getUnalignedInt32(ptr) : SIZEOF(*(ptr)) == 8 ? getUnalignedInt64(ptr) : 0
+    SIZEOF(*(ptr)) == 1       ? *(ptr)                                                                                                               \
+        : SIZEOF(*(ptr)) == 2 ? getUnalignedInt16(ptr)                                                                                               \
+        : SIZEOF(*(ptr)) == 4 ? getUnalignedInt32(ptr)                                                                                               \
+        : SIZEOF(*(ptr)) == 8 ? getUnalignedInt64(ptr)                                                                                               \
+                              : 0
 
 #define GET_UNALIGNED_BIG_ENDIAN(ptr)                                                                                                                \
-    SIZEOF(*(ptr)) == 1                                                                                                                              \
-        ? *(ptr)                                                                                                                                     \
+    SIZEOF(*(ptr)) == 1       ? *(ptr)                                                                                                               \
         : SIZEOF(*(ptr)) == 2 ? getUnalignedInt16BigEndian(ptr)                                                                                      \
-                              : SIZEOF(*(ptr)) == 4 ? getUnalignedInt32BigEndian(ptr) : SIZEOF(*(ptr)) == 8 ? getUnalignedInt64BigEndian(ptr) : 0
+        : SIZEOF(*(ptr)) == 4 ? getUnalignedInt32BigEndian(ptr)                                                                                      \
+        : SIZEOF(*(ptr)) == 8 ? getUnalignedInt64BigEndian(ptr)                                                                                      \
+                              : 0
 
 #define PUT_UNALIGNED(ptr, val)                                                                                                                      \
     do {                                                                                                                                             \
         PVOID __pVoid = (ptr);                                                                                                                       \
         switch (SIZEOF(*(ptr))) {                                                                                                                    \
             case 1:                                                                                                                                  \
-                *(PINT8) __pVoid = (INT8)(val);                                                                                                      \
+                *(PINT8) __pVoid = (INT8) (val);                                                                                                     \
                 break;                                                                                                                               \
             case 2:                                                                                                                                  \
-                putUnalignedInt16(__pVoid, (INT16)(val));                                                                                            \
+                putUnalignedInt16(__pVoid, (INT16) (val));                                                                                           \
                 break;                                                                                                                               \
             case 4:                                                                                                                                  \
-                putUnalignedInt32(__pVoid, (INT32)(val));                                                                                            \
+                putUnalignedInt32(__pVoid, (INT32) (val));                                                                                           \
                 break;                                                                                                                               \
             case 8:                                                                                                                                  \
-                putUnalignedInt64(__pVoid, (INT64)(val));                                                                                            \
+                putUnalignedInt64(__pVoid, (INT64) (val));                                                                                           \
                 break;                                                                                                                               \
             default:                                                                                                                                 \
                 CHECK_EXT(FALSE, "Bad alignment size.");                                                                                             \
@@ -955,16 +958,16 @@ extern putUnalignedInt64Func putUnalignedInt64LittleEndian;
         PVOID __pVoid = (ptr);                                                                                                                       \
         switch (SIZEOF(*(ptr))) {                                                                                                                    \
             case 1:                                                                                                                                  \
-                *(PINT8) __pVoid = (INT8)(val);                                                                                                      \
+                *(PINT8) __pVoid = (INT8) (val);                                                                                                     \
                 break;                                                                                                                               \
             case 2:                                                                                                                                  \
-                putUnalignedInt16BigEndian(__pVoid, (INT16)(val));                                                                                   \
+                putUnalignedInt16BigEndian(__pVoid, (INT16) (val));                                                                                  \
                 break;                                                                                                                               \
             case 4:                                                                                                                                  \
-                putUnalignedInt32BigEndian(__pVoid, (INT32)(val));                                                                                   \
+                putUnalignedInt32BigEndian(__pVoid, (INT32) (val));                                                                                  \
                 break;                                                                                                                               \
             case 8:                                                                                                                                  \
-                putUnalignedInt64BigEndian(__pVoid, (INT64)(val));                                                                                   \
+                putUnalignedInt64BigEndian(__pVoid, (INT64) (val));                                                                                  \
                 break;                                                                                                                               \
             default:                                                                                                                                 \
                 CHECK_EXT(FALSE, "Bad alignment size.");                                                                                             \
@@ -1280,6 +1283,16 @@ typedef SEMAPHORE_HANDLE* PSEMAPHORE_HANDLE;
  */
 PUBLIC_API STATUS semaphoreCreate(UINT32, PSEMAPHORE_HANDLE);
 
+/**
+ * Create a semaphore object that starts with 0 count
+ *
+ * @param - UINT32 - IN - The permit count
+ * @param - PSEMAPHORE_HANDLE - OUT - Semaphore handle
+ *
+ * @return  - STATUS code of the execution
+ */
+PUBLIC_API STATUS semaphoreEmptyCreate(UINT32, PSEMAPHORE_HANDLE);
+
 /*
  * Frees the semaphore object releasing all the awaiting threads.
  *
@@ -1467,10 +1480,7 @@ PUBLIC_API STATUS freeFileLogger();
 /**
  * Retry configuration type
  */
-typedef enum {
-    KVS_RETRY_STRATEGY_DISABLED                 = 0x00,
-    KVS_RETRY_STRATEGY_EXPONENTIAL_BACKOFF_WAIT = 0x01
-} KVS_RETRY_STRATEGY_TYPE;
+typedef enum { KVS_RETRY_STRATEGY_DISABLED = 0x00, KVS_RETRY_STRATEGY_EXPONENTIAL_BACKOFF_WAIT = 0x01 } KVS_RETRY_STRATEGY_TYPE;
 
 // Opaque pointers to hold retry strategy state and configuration
 // depending on the underlying implementation
@@ -1513,7 +1523,7 @@ typedef STATUS (*CreateRetryStrategyFn)(PKvsRetryStrategy);
  *
  * @return Status of the callback
  */
-typedef STATUS (*GetCurrentRetryAttemptNumberFn) (PKvsRetryStrategy, PUINT32);
+typedef STATUS (*GetCurrentRetryAttemptNumberFn)(PKvsRetryStrategy, PUINT32);
 
 /**
  * Handler to release resources associated with a retry strategy
@@ -1549,7 +1559,6 @@ struct __KvsRetryStrategyCallbacks {
 typedef struct __KvsRetryStrategyCallbacks KvsRetryStrategyCallbacks;
 typedef struct __KvsRetryStrategyCallbacks* PKvsRetryStrategyCallbacks;
 
-
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // APIs for exponential backoff retry strategy
 //////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1563,14 +1572,14 @@ typedef struct __KvsRetryStrategyCallbacks* PKvsRetryStrategyCallbacks;
  * Factor for computing the exponential backoff wait time
  * The larger the value, the slower the retries will be.
  */
-#define MIN_KVS_RETRY_TIME_FACTOR_MILLISECONDS                       50
-#define LIMIT_KVS_RETRY_TIME_FACTOR_MILLISECONDS                    1000
-#define DEFAULT_KVS_RETRY_TIME_FACTOR_MILLISECONDS                  LIMIT_KVS_RETRY_TIME_FACTOR_MILLISECONDS
+#define MIN_KVS_RETRY_TIME_FACTOR_MILLISECONDS     50
+#define LIMIT_KVS_RETRY_TIME_FACTOR_MILLISECONDS   1000
+#define DEFAULT_KVS_RETRY_TIME_FACTOR_MILLISECONDS LIMIT_KVS_RETRY_TIME_FACTOR_MILLISECONDS
 
 /**
  * Factor determining the curve of exponential wait time
  */
-#define DEFAULT_KVS_EXPONENTIAL_FACTOR                              2
+#define DEFAULT_KVS_EXPONENTIAL_FACTOR 2
 
 /**
  * Maximum exponential wait time. Once the exponential wait time
@@ -1579,66 +1588,65 @@ typedef struct __KvsRetryStrategyCallbacks* PKvsRetryStrategyCallbacks;
  * required to put a reasonable upper bound on wait time. If not provided
  * in the config, we'll use the default value
  */
-#define MIN_KVS_MAX_WAIT_TIME_MILLISECONDS                      10000
-#define LIMIT_KVS_MAX_WAIT_TIME_MILLISECONDS                    25000
-#define DEFAULT_KVS_MAX_WAIT_TIME_MILLISECONDS                  16000
+#define MIN_KVS_MAX_WAIT_TIME_MILLISECONDS     10000
+#define LIMIT_KVS_MAX_WAIT_TIME_MILLISECONDS   25000
+#define DEFAULT_KVS_MAX_WAIT_TIME_MILLISECONDS 16000
 
 /**
  * Maximum time between two consecutive calls to exponentialBackoffBlockingWait
  * after which the retry count will be reset to initial state. This is needed
  * to restart the exponential wait time from base value if
  */
-#define MIN_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS          90000
-#define LIMIT_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS       120000
-#define DEFAULT_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS     MIN_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS
+#define MIN_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS     90000
+#define LIMIT_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS   120000
+#define DEFAULT_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS MIN_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS
 
 /**
  * Factor to get a random jitter. Jitter values [0, 300).
  * Only applicable for Fixed jitter variant
  */
-#define MIN_KVS_JITTER_FACTOR_MILLISECONDS                           50
-#define LIMIT_KVS_JITTER_FACTOR_MILLISECONDS                        600
-#define DEFAULT_KVS_JITTER_FACTOR_MILLISECONDS                      300
+#define MIN_KVS_JITTER_FACTOR_MILLISECONDS     50
+#define LIMIT_KVS_JITTER_FACTOR_MILLISECONDS   600
+#define DEFAULT_KVS_JITTER_FACTOR_MILLISECONDS 300
 
 typedef enum {
-    BACKOFF_NOT_STARTED     = (UINT16) 0x01,
-    BACKOFF_IN_PROGRESS     = (UINT16) 0x02,
-    BACKOFF_TERMINATED      = (UINT16) 0x03
+    BACKOFF_NOT_STARTED = (UINT16) 0x01,
+    BACKOFF_IN_PROGRESS = (UINT16) 0x02,
+    BACKOFF_TERMINATED = (UINT16) 0x03
 } ExponentialBackoffStatus;
 
 typedef enum {
-    FULL_JITTER     = (UINT16) 0x01,
-    FIXED_JITTER    = (UINT16) 0x02,
-    NO_JITTER       = (UINT16) 0x03,
-    } ExponentialBackoffJitterType;
+    FULL_JITTER = (UINT16) 0x01,
+    FIXED_JITTER = (UINT16) 0x02,
+    NO_JITTER = (UINT16) 0x03,
+} ExponentialBackoffJitterType;
 
 typedef struct __ExponentialBackoffRetryStrategyConfig {
     // Max retries after which an error will be returned
     // to the application. For infinite retries, set this
     // to KVS_INFINITE_EXPONENTIAL_RETRIES.
-    UINT32  maxRetryCount;
+    UINT32 maxRetryCount;
     // Maximum retry wait time. Once the retry wait time
     // reaches this value, subsequent retries will wait for
     // maxRetryWaitTime (plus jitter).
-    UINT64  maxRetryWaitTime;
+    UINT64 maxRetryWaitTime;
     // Factor for computing the exponential backoff wait time
-    UINT64  retryFactorTime;
+    UINT64 retryFactorTime;
     // The minimum time between two consecutive retries
     // after which retry state will be reset i.e. retries
     // will start from initial retry state.
-    UINT64  minTimeToResetRetryState;
+    UINT64 minTimeToResetRetryState;
     // Jitter type indicating how much jitter to be added
     // Default will be FULL_JITTER
     ExponentialBackoffJitterType jitterType;
     // Factor determining random jitter value.
     // Jitter will be between [0, jitterFactor)
     // This parameter is only valid for jitter type FIXED_JITTER
-    UINT32  jitterFactor;
+    UINT32 jitterFactor;
 } ExponentialBackoffRetryStrategyConfig, *PExponentialBackoffRetryStrategyConfig;
 
-#define TO_EXPONENTIAL_BACKOFF_STATE(ptr)  ((PExponentialBackoffRetryStrategyState)(ptr))
-#define TO_EXPONENTIAL_BACKOFF_CONFIG(ptr) ((PExponentialBackoffRetryStrategyConfig)(ptr))
-
+#define TO_EXPONENTIAL_BACKOFF_STATE(ptr)  ((PExponentialBackoffRetryStrategyState) (ptr))
+#define TO_EXPONENTIAL_BACKOFF_CONFIG(ptr) ((PExponentialBackoffRetryStrategyConfig) (ptr))
 
 typedef struct {
     ExponentialBackoffRetryStrategyConfig exponentialBackoffRetryStrategyConfig;
@@ -1670,12 +1678,12 @@ typedef struct {
  for FIXED_JITTER variant, jitter = random number between [0, DEFAULT_KVS_JITTER_FACTOR_MILLISECONDS)
 ************************************************************************/
 static const ExponentialBackoffRetryStrategyConfig DEFAULT_EXPONENTIAL_BACKOFF_CONFIGURATION = {
-        KVS_INFINITE_EXPONENTIAL_RETRIES, /* max retry count */
-        DEFAULT_KVS_MAX_WAIT_TIME_MILLISECONDS, /* max retry wait time */
-        DEFAULT_KVS_RETRY_TIME_FACTOR_MILLISECONDS, /* factor determining exponential curve */
-        DEFAULT_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS, /* minimum time to reset retry state */
-        FULL_JITTER, /* use FULL_JITTER variant */
-        0 /* jitter value unused for full jitter variant */
+    KVS_INFINITE_EXPONENTIAL_RETRIES,                       /* max retry count */
+    DEFAULT_KVS_MAX_WAIT_TIME_MILLISECONDS,                 /* max retry wait time */
+    DEFAULT_KVS_RETRY_TIME_FACTOR_MILLISECONDS,             /* factor determining exponential curve */
+    DEFAULT_KVS_MIN_TIME_TO_RESET_RETRY_STATE_MILLISECONDS, /* minimum time to reset retry state */
+    FULL_JITTER,                                            /* use FULL_JITTER variant */
+    0                                                       /* jitter value unused for full jitter variant */
 };
 
 /**************************************************************************************************
@@ -1803,8 +1811,9 @@ PUBLIC_API STATUS computePower(UINT64, UINT64, PUINT64);
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 
 typedef struct {
+    volatile ATOMIC_BOOL terminate;
     PStackQueue queue;
-    MUTEX       mutex;
+    MUTEX mutex;
     SEMAPHORE_HANDLE semaphore;
 } SafeBlockingQueue, *PSafeBlockingQueue;
 
@@ -1827,11 +1836,6 @@ PUBLIC_API STATUS safeBlockingQueueClear(PSafeBlockingQueue, BOOL);
  * Gets the number of items in the stack/queue
  */
 PUBLIC_API STATUS safeBlockingQueueGetCount(PSafeBlockingQueue, PUINT32);
-
-/**
- * Removes the item at the given item
- */
-PUBLIC_API STATUS safeBlockingQueueRemoveItem(PSafeBlockingQueue, UINT64);
 
 /**
  * Whether the thread safe blocking queue is empty

--- a/src/utils/src/Include_i.h
+++ b/src/utils/src/Include_i.h
@@ -154,8 +154,8 @@ typedef struct {
 } TimerQueue, *PTimerQueue;
 
 // Public handle to and from object converters
-#define TO_TIMER_QUEUE_HANDLE(p)   ((TIMER_QUEUE_HANDLE)(p))
-#define FROM_TIMER_QUEUE_HANDLE(h) (IS_VALID_TIMER_QUEUE_HANDLE(h) ? (PTimerQueue)(h) : NULL)
+#define TO_TIMER_QUEUE_HANDLE(p)   ((TIMER_QUEUE_HANDLE) (p))
+#define FROM_TIMER_QUEUE_HANDLE(h) (IS_VALID_TIMER_QUEUE_HANDLE(h) ? (PTimerQueue) (h) : NULL)
 
 // Internal Functions
 STATUS timerQueueCreateInternal(UINT32, PTimerQueue*);
@@ -185,6 +185,9 @@ typedef struct {
     // Whether we are shutting down
     volatile ATOMIC_BOOL shutdown;
 
+    // Whether semaphore is allowed to be deleted at 0 count
+    BOOL signalSemaphore;
+
     // Max allowed permits
     SIZE_T maxPermitCount;
 
@@ -202,11 +205,11 @@ typedef struct {
 } Semaphore, *PSemaphore;
 
 // Public handle to and from object converters
-#define TO_SEMAPHORE_HANDLE(p)   ((SEMAPHORE_HANDLE)(p))
-#define FROM_SEMAPHORE_HANDLE(h) (IS_VALID_SEMAPHORE_HANDLE(h) ? (PSemaphore)(h) : NULL)
+#define TO_SEMAPHORE_HANDLE(p)   ((SEMAPHORE_HANDLE) (p))
+#define FROM_SEMAPHORE_HANDLE(h) (IS_VALID_SEMAPHORE_HANDLE(h) ? (PSemaphore) (h) : NULL)
 
 // Internal Functions
-STATUS semaphoreCreateInternal(UINT32, PSemaphore*);
+STATUS semaphoreCreateInternal(UINT32, PSemaphore*, BOOL);
 STATUS semaphoreFreeInternal(PSemaphore*);
 STATUS semaphoreAcquireInternal(PSemaphore, UINT64);
 STATUS semaphoreReleaseInternal(PSemaphore);

--- a/src/utils/src/ThreadsafeBlockingQueue.c
+++ b/src/utils/src/ThreadsafeBlockingQueue.c
@@ -48,10 +48,10 @@ STATUS safeBlockingQueueFree(PSafeBlockingQueue pSafeQueue)
     ATOMIC_STORE_BOOL(&pSafeQueue->terminate, TRUE);
 
     MUTEX_LOCK(pSafeQueue->mutex);
-    CHK_STATUS(semaphoreFree(&(pSafeQueue->semaphore)));
+    semaphoreFree(&(pSafeQueue->semaphore));
     MUTEX_UNLOCK(pSafeQueue->mutex);
 
-    CHK_STATUS(stackQueueFree(pSafeQueue->queue));
+    stackQueueFree(pSafeQueue->queue);
     MUTEX_FREE(pSafeQueue->mutex);
 
     SAFE_MEMFREE(pSafeQueue);

--- a/src/utils/src/ThreadsafeBlockingQueue.c
+++ b/src/utils/src/ThreadsafeBlockingQueue.c
@@ -1,0 +1,212 @@
+#include "Include_i.h"
+
+/**
+ * Create a threadsafe blocking queue
+ */
+STATUS safeBlockingQueueCreate(PSafeBlockingQueue* ppSafeQueue)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    PSafeBlockingQueue pSafeQueue = NULL;
+
+    CHK(ppSafeQueue != NULL, STATUS_NULL_ARG);
+
+    //Allocate the main structure
+    pSafeQueue = (PSafeBlockingQueue) MEMCALLOC(1, SIZEOF(SafeBlockingQueue));
+    CHK(pSafeQueue != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
+    pSafeQueue->mutex = MUTEX_CREATE(FALSE);
+    CHK_STATUS(semaphoreCreate(UINT32_MAX, &(pSafeQueue->semaphore)));
+    CHK_STATUS(stackQueueCreate(&(pSafeQueue->queue)));
+
+CleanUp:
+    if(STATUS_FAILED(retStatus) && pSafeQueue != NULL) {
+        SAFE_MEMFREE(pSafeQueue);
+    }
+
+    return retStatus;
+}
+
+/**
+ * Frees and de-allocates the thread safe blocking queue
+ */
+PUBLIC_API STATUS safeBlockingQueueFree(PSafeBlockingQueue pSafeQueue)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    CHK(pSafeQueue != NULL, STATUS_NULL_ARG);
+
+    //free semaphore first, this will unblock any threads
+    //blocking on the queue.
+    CHK_STATUS(semaphoreFree(&(pSafeQueue->semaphore)));
+    CHK_STATUS(stackQueueFree(pSafeQueue->queue));
+    MUTEX_FREE(pSafeQueue->mutex);
+
+    SAFE_MEMFREE(pSafeQueue);
+
+CleanUp:
+
+    return retStatus;
+}
+
+/**
+ * Clears and de-allocates all the items
+ */
+PUBLIC_API STATUS safeBlockingQueueClear(PSafeBlockingQueue pSafeQueue, BOOL freeData)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    BOOL locked = FALSE;
+
+    CHK(pSafeQueue != NULL, STATUS_NULL_ARG);
+
+    //0 timeout semaphore acquire, eventually getting a timeout, this is done to clear
+    //the counting semaphore
+    while(semaphoreAcquire(pSafeQueue->semaphore, 0) == STATUS_SUCCESS);
+
+    MUTEX_LOCK(pSafeQueue->mutex);
+    locked = TRUE;
+    
+    CHK_STATUS(stackQueueClear(pSafeQueue->queue, freeData));
+
+    MUTEX_UNLOCK(pSafeQueue->mutex);
+    locked = FALSE;
+
+CleanUp:
+    if(locked) {
+        MUTEX_UNLOCK(pSafeQueue->mutex);
+    }
+
+    return retStatus;
+}
+
+/**
+ * Gets the number of items in the stack/queue
+ */
+PUBLIC_API STATUS safeBlockingQueueGetCount(PSafeBlockingQueue pSafeQueue, PUINT32 pCount)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    BOOL locked = FALSE;
+
+    CHK(pSafeQueue != NULL, STATUS_NULL_ARG);
+
+    MUTEX_LOCK(pSafeQueue->mutex);
+    locked = TRUE;
+    
+    CHK_STATUS(stackQueueGetCount(pSafeQueue->queue, pCount));
+
+    MUTEX_UNLOCK(pSafeQueue->mutex);
+    locked = FALSE;
+
+CleanUp:
+    if(locked) {
+        MUTEX_UNLOCK(pSafeQueue->mutex);
+    }
+
+    return retStatus;
+}
+
+/**
+ * Removes the item at the given item
+ */
+PUBLIC_API STATUS safeBlockingQueueRemoveItem(PSafeBlockingQueue pSafeQueue, UINT64 item)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    BOOL locked = FALSE;
+
+    CHK(pSafeQueue != NULL, STATUS_NULL_ARG);
+
+    MUTEX_LOCK(pSafeQueue->mutex);
+    locked = TRUE;
+    
+    CHK_STATUS(stackQueueRemoveItem(pSafeQueue->queue, item));
+
+    MUTEX_UNLOCK(pSafeQueue->mutex);
+    locked = FALSE;
+
+CleanUp:
+    if(locked) {
+        MUTEX_UNLOCK(pSafeQueue->mutex);
+    }
+
+    return retStatus;
+}
+
+/**
+ * Whether the thread safe blocking queue is empty
+ */
+PUBLIC_API STATUS safeBlockingQueueIsEmpty(PSafeBlockingQueue pSafeQueue, PBOOL pIsEmpty)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    BOOL locked = FALSE;
+
+    CHK(pSafeQueue != NULL && pIsEmpty != NULL, STATUS_NULL_ARG);
+
+    MUTEX_LOCK(pSafeQueue->mutex);
+    locked = TRUE;
+    
+    CHK_STATUS(stackQueueIsEmpty(pSafeQueue->queue, pIsEmpty));
+
+    MUTEX_UNLOCK(pSafeQueue->mutex);
+    locked = FALSE;
+
+CleanUp:
+    if(locked) {
+        MUTEX_UNLOCK(pSafeQueue->mutex);
+    }
+
+    return retStatus;
+}
+
+/**
+ * Enqueues an item in the queue
+ */
+PUBLIC_API STATUS safeBlockingQueueEnqueue(PSafeBlockingQueue pSafeQueue, UINT64 item)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    BOOL locked = FALSE;
+
+    CHK(pSafeQueue != NULL, STATUS_NULL_ARG);
+
+    MUTEX_LOCK(pSafeQueue->mutex);
+    locked = TRUE;
+    
+    CHK_STATUS(stackQueueEnqueue(pSafeQueue->queue, item));
+
+    MUTEX_UNLOCK(pSafeQueue->mutex);
+    locked = FALSE;
+
+    CHK_STATUS(semaphoreRelease(pSafeQueue->semaphore));
+
+CleanUp:
+    if(locked) {
+        MUTEX_UNLOCK(pSafeQueue->mutex);
+    }
+
+    return retStatus;
+}
+
+/**
+ * Dequeues an item from the queue
+ */
+PUBLIC_API STATUS safeBlockingQueueDequeue(PSafeBlockingQueue pSafeQueue, PUINT64 pItem)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    BOOL locked = FALSE;
+
+    CHK(pSafeQueue != NULL && pItem != NULL, STATUS_NULL_ARG);
+
+    CHK_STATUS(semaphoreAcquire(pSafeQueue->semaphore, INFINITE_TIME_VALUE));
+
+    MUTEX_LOCK(pSafeQueue->mutex);
+    locked = TRUE;
+    
+    CHK_STATUS(stackQueueDequeue(pSafeQueue->queue, pItem));
+
+    MUTEX_UNLOCK(pSafeQueue->mutex);
+    locked = FALSE;
+
+CleanUp:
+    if(locked) {
+        MUTEX_UNLOCK(pSafeQueue->mutex);
+    }
+
+    return retStatus;
+}

--- a/src/utils/tst/Semaphore.cpp
+++ b/src/utils/tst/Semaphore.cpp
@@ -40,9 +40,9 @@ TEST_F(SemaphoreFunctionalityTest, apiInputTest)
     EXPECT_NE(STATUS_SUCCESS, semaphoreCreate(0, &handle));
     EXPECT_NE(STATUS_SUCCESS, semaphoreCreate(10, NULL));
     EXPECT_NE(STATUS_SUCCESS, semaphoreCreate(0, NULL));
-    EXPECT_NE(STATUS_SUCCESS, semaphoreCreateInternal(0, &pSemaphore));
-    EXPECT_NE(STATUS_SUCCESS, semaphoreCreateInternal(10, NULL));
-    EXPECT_NE(STATUS_SUCCESS, semaphoreCreateInternal(0, NULL));
+    EXPECT_NE(STATUS_SUCCESS, semaphoreCreateInternal(0, &pSemaphore, FALSE));
+    EXPECT_NE(STATUS_SUCCESS, semaphoreCreateInternal(10, NULL, FALSE));
+    EXPECT_NE(STATUS_SUCCESS, semaphoreCreateInternal(0, NULL, FALSE));
     EXPECT_NE(STATUS_SUCCESS, semaphoreFree(NULL));
 
     for (UINT32 i = 1; i < 1000; i++) {
@@ -281,4 +281,22 @@ TEST_F(SemaphoreFunctionalityTest, freeWithoutReleaseAllThreadsTest)
     THREAD_SLEEP(300 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 
     EXPECT_EQ(0, (UINT32) ATOMIC_LOAD(&threadCount));
+}
+
+TEST_F(SemaphoreFunctionalityTest, emptySemaphoreAcquireBasicTest)
+{
+    EXPECT_EQ(STATUS_SUCCESS, semaphoreEmptyCreate(2, &handle));
+
+    EXPECT_EQ(STATUS_OPERATION_TIMED_OUT, semaphoreAcquire(handle, 0));
+    EXPECT_EQ(STATUS_SUCCESS, semaphoreRelease(handle));
+    EXPECT_EQ(STATUS_SUCCESS, semaphoreAcquire(handle, 0));
+
+    // Validate there is no interference with locked
+    EXPECT_EQ(STATUS_SUCCESS, semaphoreLock(handle));
+    EXPECT_EQ(STATUS_SUCCESS, semaphoreRelease(handle));
+    EXPECT_EQ(STATUS_SEMAPHORE_ACQUIRE_WHEN_LOCKED, semaphoreAcquire(handle, 0));
+    EXPECT_EQ(STATUS_SUCCESS, semaphoreUnlock(handle));
+    EXPECT_EQ(STATUS_SUCCESS, semaphoreAcquire(handle, 0));
+
+    EXPECT_EQ(STATUS_SUCCESS, semaphoreFree(&handle));
 }

--- a/src/utils/tst/ThreadsafeBlockingQueue.cpp
+++ b/src/utils/tst/ThreadsafeBlockingQueue.cpp
@@ -1,0 +1,153 @@
+#include "UtilTestFixture.h"
+#include <chrono>
+#include <thread>
+
+class ThreadsafeBlockingQueueFunctionalityTest : public UtilTestBase {
+};
+
+TEST_F(ThreadsafeBlockingQueueFunctionalityTest, createDestroyTest)
+{
+    PSafeBlockingQueue pSafeQueue = NULL;
+    EXPECT_EQ(STATUS_SUCCESS, safeBlockingQueueCreate(&pSafeQueue));
+    EXPECT_EQ(STATUS_SUCCESS, safeBlockingQueueFree(pSafeQueue));
+}
+
+TEST_F(ThreadsafeBlockingQueueFunctionalityTest, createEnqueueDestroyTest)
+{
+    PSafeBlockingQueue pSafeQueue = NULL;
+    UINT64 totalItems = 0;
+    srand(GETTIME());
+    totalItems = rand()%(UINT16_MAX) + 1;
+    EXPECT_EQ(STATUS_SUCCESS, safeBlockingQueueCreate(&pSafeQueue));
+    for(UINT64 i = 0; i < totalItems; i++) {
+        EXPECT_EQ(STATUS_SUCCESS, safeBlockingQueueEnqueue(pSafeQueue, i));
+    }
+    EXPECT_EQ(STATUS_SUCCESS, safeBlockingQueueFree(pSafeQueue));
+}
+
+TEST_F(ThreadsafeBlockingQueueFunctionalityTest, queueIsEmptyTest)
+{
+    PSafeBlockingQueue pSafeQueue = NULL;
+    UINT64 totalItems = 0, totalLoops = 0, item = 0;
+    BOOL empty = FALSE;
+    srand(GETTIME());
+    totalItems = rand()%(UINT16_MAX) + 1;
+    totalLoops = rand()%64;
+    EXPECT_EQ(STATUS_SUCCESS, safeBlockingQueueCreate(&pSafeQueue));
+    for(UINT64 j = 0; j < totalLoops; j++) {
+        EXPECT_EQ(STATUS_SUCCESS, safeBlockingQueueIsEmpty(pSafeQueue, &empty));
+        EXPECT_TRUE(empty);
+        for(UINT64 i = 0; i < totalItems; i++) {
+            EXPECT_EQ(STATUS_SUCCESS, safeBlockingQueueEnqueue(pSafeQueue, i));
+        }
+        EXPECT_EQ(STATUS_SUCCESS, safeBlockingQueueIsEmpty(pSafeQueue, &empty));
+        EXPECT_TRUE(!empty);
+        EXPECT_EQ(STATUS_SUCCESS, safeBlockingQueueDequeue(pSafeQueue, &item));
+        EXPECT_EQ(STATUS_SUCCESS, safeBlockingQueueIsEmpty(pSafeQueue, &empty));
+        if(totalItems > 1) {
+            EXPECT_TRUE(!empty);
+        }
+        else {
+            EXPECT_TRUE(empty);
+        }
+        EXPECT_EQ(STATUS_SUCCESS, safeBlockingQueueClear(pSafeQueue, FALSE));
+    }
+
+    EXPECT_EQ(STATUS_SUCCESS, safeBlockingQueueFree(pSafeQueue));
+}
+
+TEST_F(ThreadsafeBlockingQueueFunctionalityTest, queueCountCorrectTest)
+{
+    PSafeBlockingQueue pSafeQueue = NULL;
+    UINT64 totalItems = 0, totalLoops = 0, item = 0, itemsToQueue = 0;;
+    UINT32 items = 0;
+    BOOL empty = FALSE;
+    srand(GETTIME());
+    totalLoops = rand()%64;
+    EXPECT_EQ(STATUS_SUCCESS, safeBlockingQueueCreate(&pSafeQueue));
+    //queue and dequeue a random number of items in a loop, and check the value
+    for(UINT64 j = 0; j < totalLoops; j++) {
+        itemsToQueue = rand()%(UINT16_MAX-totalItems) + 1;
+        for(UINT64 i = 0; i < itemsToQueue; i++) {
+            EXPECT_EQ(STATUS_SUCCESS, safeBlockingQueueEnqueue(pSafeQueue, i));
+        }
+
+        totalItems += itemsToQueue;
+        EXPECT_EQ(STATUS_SUCCESS, safeBlockingQueueGetCount(pSafeQueue, &items));
+        EXPECT_EQ(totalItems, items);
+
+        itemsToQueue = rand()%(totalItems);
+        for(UINT64 i = 0; i < itemsToQueue; i++) {
+            EXPECT_EQ(STATUS_SUCCESS, safeBlockingQueueDequeue(pSafeQueue, &item));
+        }
+
+        totalItems -= itemsToQueue;
+        EXPECT_EQ(STATUS_SUCCESS, safeBlockingQueueGetCount(pSafeQueue, &items));
+        EXPECT_EQ(totalItems, items);
+    }
+    EXPECT_EQ(STATUS_SUCCESS, safeBlockingQueueFree(pSafeQueue));
+}
+#define STATIC_NUMBER_OF_ITEMS 50
+
+void* writingThread(void* ptr) {
+    PSafeBlockingQueue pSafeQueue = (PSafeBlockingQueue)ptr;
+
+    for(int i = 0; i < STATIC_NUMBER_OF_ITEMS; i++) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(rand()%50));
+        safeBlockingQueueEnqueue(pSafeQueue, i);
+    }
+     
+}
+
+void* readingThread(void* ptr) {
+    PSafeBlockingQueue pSafeQueue = (PSafeBlockingQueue)ptr;
+    UINT64 item = 0;
+
+    for(int i = 0; i < STATIC_NUMBER_OF_ITEMS; i++) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(rand()%50));
+        safeBlockingQueueDequeue(pSafeQueue, &item);
+    }
+}
+
+TEST_F(ThreadsafeBlockingQueueFunctionalityTest, multithreadQueueDequeueTest)
+{
+    PSafeBlockingQueue pSafeQueue = NULL;
+    UINT64 totalThreads = 0, item = 0, threadCount = 0;
+    BOOL empty = FALSE;
+    TID threads[8] = {0};
+    srand(GETTIME());
+    totalThreads = rand()%7 + 2;
+    //make it even
+    totalThreads -= totalThreads%2;
+    EXPECT_EQ(STATUS_SUCCESS, safeBlockingQueueCreate(&pSafeQueue));
+    for(UINT64 i = 0; i < totalThreads/2; i++) {
+        THREAD_CREATE(&threads[threadCount++], readingThread, pSafeQueue);
+    }
+    for(UINT64 i = 0; i < totalThreads/2; i++) {
+        THREAD_CREATE(&threads[threadCount++], writingThread, pSafeQueue);
+    }
+    for(UINT64 i = 0; i < totalThreads; i++) {
+        THREAD_JOIN(threads[i], NULL);
+    }
+    EXPECT_EQ(STATUS_SUCCESS, safeBlockingQueueFree(pSafeQueue));
+}
+
+TEST_F(ThreadsafeBlockingQueueFunctionalityTest, multithreadTeardownTest)
+{
+    PSafeBlockingQueue pSafeQueue = NULL;
+    UINT64 totalThreads = 0, item = 0, threadCount = 0;
+    BOOL empty = FALSE;
+    TID threads[8] = {0};
+    srand(GETTIME());
+    totalThreads = rand()%7 + 2;
+    //make it even
+    totalThreads -= totalThreads%2;
+    EXPECT_EQ(STATUS_SUCCESS, safeBlockingQueueCreate(&pSafeQueue));
+    for(UINT64 i = 0; i < totalThreads; i++) {
+        THREAD_CREATE(&threads[threadCount++], readingThread, pSafeQueue);
+    }
+    EXPECT_EQ(STATUS_SUCCESS, safeBlockingQueueFree(pSafeQueue));
+    for(UINT64 i = 0; i < totalThreads; i++) {
+        THREAD_JOIN(threads[i], NULL);
+    }
+}


### PR DESCRIPTION
*Description of changes:*
Added an implementation and testing for a thread safe blocking queue. Added a new constructor for a semaphore that allows it to behave as a signaling semaphore without adding a 200ms to the destructor.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
