### PR TITLE
Remove INLINE from functions that are declared but not defined becaus…

### DIFF
--- a/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
+++ b/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
@@ -619,11 +619,11 @@ typedef BOOL (*memChk)(PVOID ptr, BYTE val, SIZE_T size);
 //
 // Default allocator functions
 //
-INLINE PVOID defaultMemAlloc(SIZE_T size);
-INLINE PVOID defaultMemAlignAlloc(SIZE_T size, SIZE_T alignment);
-INLINE PVOID defaultMemCalloc(SIZE_T num, SIZE_T size);
-INLINE PVOID defaultMemRealloc(PVOID ptr, SIZE_T size);
-INLINE VOID defaultMemFree(VOID* ptr);
+PVOID defaultMemAlloc(SIZE_T size);
+PVOID defaultMemAlignAlloc(SIZE_T size, SIZE_T alignment);
+PVOID defaultMemCalloc(SIZE_T num, SIZE_T size);
+PVOID defaultMemRealloc(PVOID ptr, SIZE_T size);
+VOID defaultMemFree(VOID* ptr);
 
 //
 // Global allocator function pointers
@@ -647,10 +647,10 @@ typedef PCHAR (*dlError)();
 //
 // Default dynamic library loading functions
 //
-INLINE PVOID defaultDlOpen(PCHAR filename, UINT32 flag);
-INLINE INT32 defaultDlClose(PVOID handle);
-INLINE PVOID defaultDlSym(PVOID handle, PCHAR symbol);
-INLINE PCHAR defaultDlError();
+PVOID defaultDlOpen(PCHAR filename, UINT32 flag);
+INT32 defaultDlClose(PVOID handle);
+PVOID defaultDlSym(PVOID handle, PCHAR symbol);
+PCHAR defaultDlError();
 
 //
 // Global dynamic library loading function pointers
@@ -682,7 +682,7 @@ typedef UINT64 (*getTime)();
 //
 #define TIME_DIFF_UNIX_WINDOWS_TIME 116444736000000000ULL
 
-PUBLIC_API INLINE UINT64 defaultGetTime();
+PUBLIC_API UINT64 defaultGetTime();
 
 //
 // Thread related functionality

--- a/src/common/include/com/amazonaws/kinesis/video/common/PlatformUtils.h
+++ b/src/common/include/com/amazonaws/kinesis/video/common/PlatformUtils.h
@@ -27,7 +27,7 @@ typedef VOID (*logPrintFunc)(UINT32, PCHAR, PCHAR, ...);
 //
 // Default logger function
 //
-PUBLIC_API INLINE VOID defaultLogPrint(UINT32 level, PCHAR tag, PCHAR fmt, ...);
+PUBLIC_API VOID defaultLogPrint(UINT32 level, PCHAR tag, PCHAR fmt, ...);
 
 extern logPrintFunc globalCustomLogPrintFn;
 

--- a/src/utils/src/Include_i.h
+++ b/src/utils/src/Include_i.h
@@ -83,36 +83,36 @@ STATUS getFileDirSize(UINT64, DIR_ENTRY_TYPES, PCHAR, PCHAR);
 /**
  * Endianness functionality
  */
-INLINE INT16 getInt16Swap(INT16);
-INLINE INT16 getInt16NoSwap(INT16);
-INLINE INT32 getInt32Swap(INT32);
-INLINE INT32 getInt32NoSwap(INT32);
-INLINE INT64 getInt64Swap(INT64);
-INLINE INT64 getInt64NoSwap(INT64);
+INT16 getInt16Swap(INT16);
+INT16 getInt16NoSwap(INT16);
+INT32 getInt32Swap(INT32);
+INT32 getInt32NoSwap(INT32);
+INT64 getInt64Swap(INT64);
+INT64 getInt64NoSwap(INT64);
 
-INLINE VOID putInt16Swap(PINT16, INT16);
-INLINE VOID putInt16NoSwap(PINT16, INT16);
-INLINE VOID putInt32Swap(PINT32, INT32);
-INLINE VOID putInt32NoSwap(PINT32, INT32);
-INLINE VOID putInt64Swap(PINT64, INT64);
-INLINE VOID putInt64NoSwap(PINT64, INT64);
+VOID putInt16Swap(PINT16, INT16);
+VOID putInt16NoSwap(PINT16, INT16);
+VOID putInt32Swap(PINT32, INT32);
+VOID putInt32NoSwap(PINT32, INT32);
+VOID putInt64Swap(PINT64, INT64);
+VOID putInt64NoSwap(PINT64, INT64);
 
 /**
  * Unaligned access functionality
  */
-INLINE INT16 getUnalignedInt16Be(PVOID);
-INLINE INT16 getUnalignedInt16Le(PVOID);
-INLINE INT32 getUnalignedInt32Be(PVOID);
-INLINE INT32 getUnalignedInt32Le(PVOID);
-INLINE INT64 getUnalignedInt64Be(PVOID);
-INLINE INT64 getUnalignedInt64Le(PVOID);
+INT16 getUnalignedInt16Be(PVOID);
+INT16 getUnalignedInt16Le(PVOID);
+INT32 getUnalignedInt32Be(PVOID);
+INT32 getUnalignedInt32Le(PVOID);
+INT64 getUnalignedInt64Be(PVOID);
+INT64 getUnalignedInt64Le(PVOID);
 
-INLINE VOID putUnalignedInt16Be(PVOID, INT16);
-INLINE VOID putUnalignedInt16Le(PVOID, INT16);
-INLINE VOID putUnalignedInt32Be(PVOID, INT32);
-INLINE VOID putUnalignedInt32Le(PVOID, INT32);
-INLINE VOID putUnalignedInt64Be(PVOID, INT64);
-INLINE VOID putUnalignedInt64Le(PVOID, INT64);
+VOID putUnalignedInt16Be(PVOID, INT16);
+VOID putUnalignedInt16Le(PVOID, INT16);
+VOID putUnalignedInt32Be(PVOID, INT32);
+VOID putUnalignedInt32Le(PVOID, INT32);
+VOID putUnalignedInt64Be(PVOID, INT64);
+VOID putUnalignedInt64Le(PVOID, INT64);
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 // TimerQueue functionality


### PR DESCRIPTION
Cleans up the build a bit so it's easier to see what's going on when things break