### PR TITLE
Add string length checks for events

### DIFF
--- a/src/client/include/com/amazonaws/kinesis/video/client/Include.h
+++ b/src/client/include/com/amazonaws/kinesis/video/client/Include.h
@@ -187,6 +187,9 @@ extern "C" {
 #define STATUS_MULTIPLE_CONSECUTIVE_EOFR                         STATUS_CLIENT_BASE + 0x0000008a
 #define STATUS_DUPLICATE_STREAM_EVENT_TYPE                       STATUS_CLIENT_BASE + 0x0000008b
 #define STATUS_STREAM_NOT_STARTED                                STATUS_CLIENT_BASE + 0x0000008c
+#define STATUS_INVALID_IMAGE_PREFIX_LENGTH                       STATUS_CLIENT_BASE + 0x0000008d
+#define STATUS_INVALID_IMAGE_METADATA_KEY_LENGTH                 STATUS_CLIENT_BASE + 0x0000008e
+#define STATUS_INVALID_IMAGE_METADATA_VALUE_LENGTH               STATUS_CLIENT_BASE + 0x0000008f
 
 #define IS_RECOVERABLE_ERROR(error)                                                                                                                  \
     ((error) == STATUS_SERVICE_CALL_RESOURCE_NOT_FOUND_ERROR || (error) == STATUS_SERVICE_CALL_RESOURCE_IN_USE_ERROR ||                              \
@@ -279,7 +282,7 @@ extern "C" {
 /**
  * Max name/value pairs for custom event metadata
  */
-#define MAX_EVENT_CUSTOM_PAIRS 5
+#define MAX_EVENT_CUSTOM_PAIRS 10
 
 /**
  * Max length of the fragment sequence number
@@ -380,6 +383,11 @@ extern "C" {
  * Max client id string length
  */
 #define MAX_CLIENT_ID_STRING_LENGTH 64
+
+/**
+ * Max image prefix max length: Including the NULL character
+ */
+#define MAX_IMAGE_PREFIX_LENGTH 256
 
 /**
  * Default timecode scale sentinel value

--- a/src/client/src/Stream.c
+++ b/src/client/src/Stream.c
@@ -1913,10 +1913,13 @@ STATUS putEventMetadata(PKinesisVideoStream pKinesisVideoStream, UINT32 event, P
         for (iter = 0; iter < pMetadata->numberOfPairs; iter++) {
             CHK(0 != STRNCMP(AWS_INTERNAL_METADATA_PREFIX, pMetadata->names[iter], (SIZEOF(AWS_INTERNAL_METADATA_PREFIX) - 1) / SIZEOF(CHAR)),
                 STATUS_INVALID_METADATA_NAME);
+            CHK(STRLEN(pMetadata->names[iter]) <= MKV_MAX_TAG_NAME_LEN, STATUS_INVALID_IMAGE_METADATA_KEY_LENGTH);
+            CHK(STRLEN(pMetadata->values[iter]) <= MKV_MAX_TAG_VALUE_LEN, STATUS_INVALID_IMAGE_METADATA_VALUE_LENGTH);
         }
         if (pMetadata->imagePrefix != NULL) {
             CHK(0 != STRNCMP(AWS_INTERNAL_METADATA_PREFIX, pMetadata->imagePrefix, (SIZEOF(AWS_INTERNAL_METADATA_PREFIX) - 1) / SIZEOF(CHAR)),
                 STATUS_INVALID_METADATA_NAME);
+            CHK(STRLEN(pMetadata->imagePrefix) <= MAX_IMAGE_PREFIX_LENGTH, STATUS_INVALID_IMAGE_PREFIX_LENGTH);
         }
         neededNodes += pMetadata->numberOfPairs;
     }

--- a/src/client/tst/StreamApiTest.cpp
+++ b/src/client/tst/StreamApiTest.cpp
@@ -384,6 +384,69 @@ TEST_F(StreamApiTest, insertKinesisVideoEvent_NULL_Invalid)
     EXPECT_EQ(STATUS_INVALID_ARG, putKinesisVideoEventMetadata(mStreamHandle, STREAM_EVENT_TYPE_LAST + rand() % STREAM_EVENT_TYPE_LAST, &Meta));
 }
 
+TEST_F(StreamApiTest, insertKinesisVideoEvent_Invalid_Length)
+{
+    StreamEventMetadata Meta{STREAM_EVENT_METADATA_CURRENT_VERSION, NULL, 1, {}, {}};
+
+    CHAR tagName1[MKV_MAX_TAG_NAME_LEN + 2] = {'\0'};
+    CHAR tagValue1[MKV_MAX_TAG_VALUE_LEN] = {'\0'};
+
+    CHAR tagName2[MKV_MAX_TAG_NAME_LEN] = {'\0'};
+    CHAR tagValue2[MKV_MAX_TAG_VALUE_LEN + 2] = {'\0'};
+
+    CHAR tagName3[MKV_MAX_TAG_NAME_LEN] = {'\0'};
+    CHAR tagValue3[MKV_MAX_TAG_VALUE_LEN] = {'\0'};
+
+    CHAR imagePrefixInvalid[MAX_IMAGE_PREFIX_LENGTH + 2] = {'\0'};
+
+    Frame frame;
+    UINT64 timestamp = 100;
+    BYTE tempBuffer[1000];
+
+    Meta.names[0] = tagName1;
+    Meta.values[0] = tagValue1;
+
+    // To give space for NULL character
+    MEMSET(tagName1, 'a', SIZEOF(tagName1) - 1);
+    MEMSET(tagValue1, 'b', SIZEOF(tagValue1) - 1);
+
+    // Create and ready stream
+    ReadyStream();
+    EXPECT_EQ(STATUS_STREAM_NOT_STARTED, putKinesisVideoEventMetadata(mStreamHandle, STREAM_EVENT_TYPE_NOTIFICATION, &Meta));
+
+    frame.duration = TEST_LONG_FRAME_DURATION;
+    frame.decodingTs = timestamp;
+    frame.presentationTs = timestamp;
+    frame.size = SIZEOF(tempBuffer);
+    frame.frameData = tempBuffer;
+    frame.trackId = TEST_TRACKID;
+    frame.flags = FRAME_FLAG_KEY_FRAME;
+    EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(mStreamHandle, &frame));
+
+    EXPECT_EQ(STATUS_INVALID_IMAGE_METADATA_KEY_LENGTH, putKinesisVideoEventMetadata(mStreamHandle, STREAM_EVENT_TYPE_NOTIFICATION, &Meta));
+
+    Meta.names[0] = tagName2;
+    Meta.values[0] = tagValue2;
+
+    // To give space for NULL character
+    MEMSET(tagName2, 'c', SIZEOF(tagName2) - 1);
+    MEMSET(tagValue2, 'd', SIZEOF(tagValue2) - 1);
+    EXPECT_EQ(STATUS_INVALID_IMAGE_METADATA_VALUE_LENGTH, putKinesisVideoEventMetadata(mStreamHandle, STREAM_EVENT_TYPE_NOTIFICATION, &Meta));
+
+    Meta.names[0] = tagName3;
+    Meta.values[0] = tagValue3;
+
+    // To give space for NULL character
+    MEMSET(tagName3, 'e', SIZEOF(tagName3) - 1);
+    MEMSET(tagValue3, 'f', SIZEOF(tagValue3) - 1);
+    EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoEventMetadata(mStreamHandle, STREAM_EVENT_TYPE_NOTIFICATION, &Meta));
+
+    Meta.imagePrefix = imagePrefixInvalid;
+    MEMSET(imagePrefixInvalid, 'h', SIZEOF(imagePrefixInvalid) - 1);
+    EXPECT_EQ(STATUS_INVALID_IMAGE_PREFIX_LENGTH, putKinesisVideoEventMetadata(mStreamHandle, STREAM_EVENT_TYPE_IMAGE_GENERATION, &Meta));
+
+}
+
 TEST_F(StreamApiTest, insertKinesisVideoTag_Invalid_Name)
 {
     // Create and ready stream


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

What was changed?

Added string length limits for event metadata and image prefix as per https://docs.aws.amazon.com/kinesisvideostreams/latest/dg/gs-s3Delivery.html#gs-limits. Also changed the number of supported event metadata pairs as per the public documentation

Why was it changed?

The checks were added to ensure that the string length sanity checks are done early on in the SDK for fail early to avoid back and forth once the metadata is sent and the service rejects it.

How was it changed?

Added length specific macros and related checks in putStreamEventMetadata

Testing:

- Added unit tests for length specific checks

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
