### PR TITLE
Fix timestamp ms precision

### DIFF
--- a/src/utils/include/com/amazonaws/kinesis/video/utils/Include.h
+++ b/src/utils/include/com/amazonaws/kinesis/video/utils/Include.h
@@ -1018,7 +1018,8 @@ PUBLIC_API STATUS generateTimestampStrInMilliseconds(PCHAR, PCHAR, UINT32, PUINT
 // yyyy-mm-dd HH:MM:SS
 #define MAX_TIMESTAMP_FORMAT_STR_LEN 26
 
-#define MAX_MILLISECOND_PORTION_LENGTH 8
+// Length = len (.) + len(sss) + len('\0')
+#define MAX_MILLISECOND_PORTION_LENGTH 5
 
 // Max timestamp string length including null terminator
 #define MAX_TIMESTAMP_STR_LEN 17

--- a/src/utils/src/Time.c
+++ b/src/utils/src/Time.c
@@ -57,7 +57,7 @@ STATUS generateTimestampStrInMilliseconds(PCHAR formatStr, PCHAR pDestBuffer, UI
     formattedStrLen = (UINT32) STRFTIME(pDestBuffer, destBufferLen - MAX_MILLISECOND_PORTION_LENGTH, formatStr, timeinfo);
     CHK(formattedStrLen != 0, STATUS_STRFTIME_FALIED);
     // Total length is 8 plus terminating null character. Generated string would have utmost size - 1. Hence need to add 1 to max length
-    SNPRINTF(pDestBuffer + formattedStrLen, MAX_MILLISECOND_PORTION_LENGTH + 1, ".%06d ", millisecondVal);
+    SNPRINTF(pDestBuffer + formattedStrLen, MAX_MILLISECOND_PORTION_LENGTH + 1, ".%03d ", millisecondVal);
     formattedStrLen = (UINT32) STRLEN(pDestBuffer);
     pDestBuffer[formattedStrLen] = '\0';
     *pFormattedStrLen = formattedStrLen;

--- a/src/utils/tst/FileLogger.cpp
+++ b/src/utils/tst/FileLogger.cpp
@@ -1,7 +1,7 @@
 #include "UtilTestFixture.h"
 
-// length of time and log level string in log: "2019-11-09 19:11:16.xxxxxx VERBOSE "
-#define TIMESTRING_OFFSET               35
+// length of time and log level string in log: "2019-11-09 19:11:16.xxx VERBOSE "
+#define TIMESTRING_OFFSET               32
 
 #ifdef _WIN32
 #define TEST_TEMP_DIR_PATH                                      (PCHAR) "C:\\Windows\\Temp\\"
@@ -41,6 +41,7 @@ TEST_F(FileLoggerTest, basicFileLoggerUsage)
     FREMOVE(TEST_TEMP_DIR_PATH "kvsFileLog.0");
     FREMOVE(TEST_TEMP_DIR_PATH "kvsFileLog.1");
     FREMOVE(TEST_TEMP_DIR_PATH "kvsFileLog.2");
+    DLOGW("Testing log line");
 
     createFileLogger(MIN_FILE_LOGGER_STRING_BUFFER_SIZE,
                      5,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Fix millisecond precision in log timestamps.
Earlier: `yyyy-mm-dd HH:MM:SS.ssssss`
After change: `yyyy-mm-dd HH:MM:SS.sss`

Example log line before this change
`2023-08-29 19:29:29.000588 DEBUG   turnConnectionStepState(): TurnConnection state changed from TURN_STATE_BIND_CHANNEL to TURN_STATE_READY`

Example log line after this change
`2023-08-29 19:29:29.588 DEBUG   turnConnectionStepState(): TurnConnection state changed from TURN_STATE_BIND_CHANNEL to TURN_STATE_READY`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
