### PR TITLE
Use const PCHAR so C++ compilers won't complain about passing string constants

### DIFF
--- a/src/common/include/com/amazonaws/kinesis/video/common/PlatformUtils.h
+++ b/src/common/include/com/amazonaws/kinesis/video/common/PlatformUtils.h
@@ -22,12 +22,12 @@ extern "C" {
 #endif
 
 // Log print function definition
-typedef VOID (*logPrintFunc)(UINT32, PCHAR, PCHAR, ...);
+typedef VOID (*logPrintFunc)(UINT32, const PCHAR, const PCHAR, ...);
 
 //
 // Default logger function
 //
-PUBLIC_API VOID defaultLogPrint(UINT32 level, PCHAR tag, PCHAR fmt, ...);
+PUBLIC_API VOID defaultLogPrint(UINT32 level, const PCHAR tag, const PCHAR fmt, ...);
 
 extern logPrintFunc globalCustomLogPrintFn;
 
@@ -54,36 +54,36 @@ extern logPrintFunc globalCustomLogPrintFn;
 #define LOG_LEVEL_SILENT  7
 #define LOG_LEVEL_PROFILE 8
 
-#define LOG_LEVEL_VERBOSE_STR (PCHAR) "VERBOSE"
-#define LOG_LEVEL_DEBUG_STR   (PCHAR) "DEBUG"
-#define LOG_LEVEL_INFO_STR    (PCHAR) "INFO"
-#define LOG_LEVEL_WARN_STR    (PCHAR) "WARN"
-#define LOG_LEVEL_ERROR_STR   (PCHAR) "ERROR"
-#define LOG_LEVEL_FATAL_STR   (PCHAR) "FATAL"
-#define LOG_LEVEL_SILENT_STR  (PCHAR) "SILENT"
-#define LOG_LEVEL_PROFILE_STR (PCHAR) "PROFILE"
+#define LOG_LEVEL_VERBOSE_STR (const PCHAR) "VERBOSE"
+#define LOG_LEVEL_DEBUG_STR   (const PCHAR) "DEBUG"
+#define LOG_LEVEL_INFO_STR    (const PCHAR) "INFO"
+#define LOG_LEVEL_WARN_STR    (const PCHAR) "WARN"
+#define LOG_LEVEL_ERROR_STR   (const PCHAR) "ERROR"
+#define LOG_LEVEL_FATAL_STR   (const PCHAR) "FATAL"
+#define LOG_LEVEL_SILENT_STR  (const PCHAR) "SILENT"
+#define LOG_LEVEL_PROFILE_STR (const PCHAR) "PROFILE"
 
 // LOG_LEVEL_VERBOSE_STR string length
 #define MAX_LOG_LEVEL_STRLEN 7
 
 // Extra logging macros
 #ifndef DLOGE
-#define DLOGE(fmt, ...) __LOG(LOG_LEVEL_ERROR, (PCHAR) LOG_CLASS, (PCHAR) "%s(): " fmt, __FUNCTION__, ##__VA_ARGS__)
+#define DLOGE(fmt, ...) __LOG(LOG_LEVEL_ERROR, (const PCHAR) LOG_CLASS, (const PCHAR) "%s(): " fmt, __FUNCTION__, ##__VA_ARGS__)
 #endif
 #ifndef DLOGW
-#define DLOGW(fmt, ...) __LOG(LOG_LEVEL_WARN, (PCHAR) LOG_CLASS, (PCHAR) "%s(): " fmt, __FUNCTION__, ##__VA_ARGS__)
+#define DLOGW(fmt, ...) __LOG(LOG_LEVEL_WARN, (const PCHAR) LOG_CLASS, (const PCHAR) "%s(): " fmt, __FUNCTION__, ##__VA_ARGS__)
 #endif
 #ifndef DLOGI
-#define DLOGI(fmt, ...) __LOG(LOG_LEVEL_INFO, (PCHAR) LOG_CLASS, (PCHAR) "%s(): " fmt, __FUNCTION__, ##__VA_ARGS__)
+#define DLOGI(fmt, ...) __LOG(LOG_LEVEL_INFO, (const PCHAR) LOG_CLASS, (const PCHAR) "%s(): " fmt, __FUNCTION__, ##__VA_ARGS__)
 #endif
 #ifndef DLOGD
-#define DLOGD(fmt, ...) __LOG(LOG_LEVEL_DEBUG, (PCHAR) LOG_CLASS, (PCHAR) "%s(): " fmt, __FUNCTION__, ##__VA_ARGS__)
+#define DLOGD(fmt, ...) __LOG(LOG_LEVEL_DEBUG, (const PCHAR) LOG_CLASS, (const PCHAR) "%s(): " fmt, __FUNCTION__, ##__VA_ARGS__)
 #endif
 #ifndef DLOGV
-#define DLOGV(fmt, ...) __LOG(LOG_LEVEL_VERBOSE, (PCHAR) LOG_CLASS, (PCHAR) "%s(): " fmt, __FUNCTION__, ##__VA_ARGS__)
+#define DLOGV(fmt, ...) __LOG(LOG_LEVEL_VERBOSE, (const PCHAR) LOG_CLASS, (const PCHAR) "%s(): " fmt, __FUNCTION__, ##__VA_ARGS__)
 #endif
 #ifndef DLOGP
-#define DLOGP(fmt, ...) __LOG(LOG_LEVEL_PROFILE, (PCHAR) LOG_CLASS, (PCHAR) "%s(): " fmt, __FUNCTION__, ##__VA_ARGS__)
+#define DLOGP(fmt, ...) __LOG(LOG_LEVEL_PROFILE, (const PCHAR) LOG_CLASS, (const PCHAR) "%s(): " fmt, __FUNCTION__, ##__VA_ARGS__)
 #endif
 
 #ifndef ENTER
@@ -119,25 +119,25 @@ extern logPrintFunc globalCustomLogPrintFn;
 #endif
 #endif
 #ifndef LOG_ALWAYS_FATAL_IF
-#define LOG_ALWAYS_FATAL_IF(cond, ...) ((CONDITION(cond)) ? ((void) __ASSERT(FALSE, (PCHAR) LOG_CLASS, ##__VA_ARGS__)) : (void) 0)
+#define LOG_ALWAYS_FATAL_IF(cond, ...) ((CONDITION(cond)) ? ((void) __ASSERT(FALSE, (const PCHAR) LOG_CLASS, ##__VA_ARGS__)) : (void) 0)
 #endif
 
 #ifndef LOG_ALWAYS_FATAL
-#define LOG_ALWAYS_FATAL(...) (((void) __ASSERT(FALSE, (PCHAR) LOG_CLASS, ##__VA_ARGS__)))
+#define LOG_ALWAYS_FATAL(...) (((void) __ASSERT(FALSE, (const PCHAR) LOG_CLASS, ##__VA_ARGS__)))
 #endif
 
 #ifndef SANITIZED_FILE
 #define SANITIZED_FILE (STRRCHR(__FILE__, '/') ? STRRCHR(__FILE__, '/') + 1 : __FILE__)
 #endif
 #ifndef CRASH
-#define CRASH(fmt, ...) LOG_ALWAYS_FATAL("%s::%s: " fmt, (PCHAR) LOG_CLASS, __FUNCTION__, ##__VA_ARGS__)
+#define CRASH(fmt, ...) LOG_ALWAYS_FATAL("%s::%s: " fmt, (const PCHAR) LOG_CLASS, __FUNCTION__, ##__VA_ARGS__)
 #endif
 #ifndef CHECK
-#define CHECK(x) LOG_ALWAYS_FATAL_IF(!(x), "%s::%s: ASSERTION FAILED at %s:%d: " #x, (PCHAR) LOG_CLASS, __FUNCTION__, SANITIZED_FILE, __LINE__)
+#define CHECK(x) LOG_ALWAYS_FATAL_IF(!(x), "%s::%s: ASSERTION FAILED at %s:%d: " #x, (const PCHAR) LOG_CLASS, __FUNCTION__, SANITIZED_FILE, __LINE__)
 #endif
 #ifndef CHECK_EXT
 #define CHECK_EXT(x, fmt, ...)                                                                                                                       \
-    LOG_ALWAYS_FATAL_IF(!(x), "%s::%s: ASSERTION FAILED at %s:%d: " fmt, (PCHAR) LOG_CLASS, __FUNCTION__, SANITIZED_FILE, __LINE__, ##__VA_ARGS__)
+    LOG_ALWAYS_FATAL_IF(!(x), "%s::%s: ASSERTION FAILED at %s:%d: " fmt, (const PCHAR) LOG_CLASS, __FUNCTION__, SANITIZED_FILE, __LINE__, ##__VA_ARGS__)
 #endif
 
 #ifndef LOG_GIT_HASH

--- a/src/utils/src/Logger.c
+++ b/src/utils/src/Logger.c
@@ -2,7 +2,7 @@
 
 static volatile SIZE_T gLoggerLogLevel = LOG_LEVEL_WARN;
 
-PCHAR getLogLevelStr(UINT32 loglevel)
+const PCHAR getLogLevelStr(UINT32 loglevel)
 {
     switch (loglevel) {
         case LOG_LEVEL_VERBOSE:
@@ -24,7 +24,7 @@ PCHAR getLogLevelStr(UINT32 loglevel)
     }
 }
 
-VOID addLogMetadata(PCHAR buffer, UINT32 bufferLen, PCHAR fmt, UINT32 logLevel)
+VOID addLogMetadata(const PCHAR buffer, UINT32 bufferLen, const PCHAR fmt, UINT32 logLevel)
 {
     UINT32 timeStrLen = 0;
     /* space for "yyyy-mm-dd HH:MM:SS.MMMMMM" + space + null */
@@ -56,7 +56,7 @@ VOID addLogMetadata(PCHAR buffer, UINT32 bufferLen, PCHAR fmt, UINT32 logLevel)
 //
 // Default logger function
 //
-VOID defaultLogPrint(UINT32 level, PCHAR tag, PCHAR fmt, ...)
+VOID defaultLogPrint(UINT32 level, const PCHAR tag, const PCHAR fmt, ...)
 {
     CHAR logFmtString[MAX_LOG_FORMAT_LENGTH + 1];
     UINT32 logLevel = GET_LOGGER_LOG_LEVEL();


### PR DESCRIPTION
C++ compilers complain about passing string constants to PCHAR so this adds `const` to those so the use of the value is explicit and avoids those issues

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
