### PR TITLE
Modify threadpool teardown

### DIFF
--- a/src/utils/src/Threadpool.c
+++ b/src/utils/src/Threadpool.c
@@ -70,8 +70,7 @@ PVOID threadpoolActor(PVOID data)
             } else if (!ATOMIC_LOAD_BOOL(&pThreadData->terminate)) {
                 ATOMIC_DECREMENT(&pThreadData->pThreadpool->availableThreads);
             }
-        }
-        else {
+        } else {
             finished = TRUE;
             MUTEX_UNLOCK(pThreadData->dataMutex);
             break;
@@ -84,8 +83,7 @@ PVOID threadpoolActor(PVOID data)
         if (MUTEX_TRYLOCK(pThreadData->dataMutex)) {
             if (ATOMIC_LOAD_BOOL(&pThreadData->terminate)) {
                 MUTEX_UNLOCK(pThreadData->dataMutex);
-            }
-            else {
+            } else {
                 // Threadpool is active - lock its mutex
                 MUTEX_LOCK(pThreadpool->listMutex);
 

--- a/src/utils/src/Threadpool.c
+++ b/src/utils/src/Threadpool.c
@@ -48,11 +48,17 @@ PVOID threadpoolActor(PVOID data)
     // when the task is complete it will check if the we're beyond our min threshhold of threads
     // to determine whether it should exit or wait for another task.
     while (!finished) {
+        // This lock exists to protect the atomic increment after the terminate check.
+        // There is a data-race condition that can result in an increment after the Threadpool
+        // has been deleted
+        MUTEX_LOCK(pThreadData->dataMutex);
+
         // ThreadData is allocated separately from the Threadpool.
         // The Threadpool will set terminate to false before the threadpool is free.
         // This way the thread actors can avoid accessing the Threadpool after termination.
         if (!ATOMIC_LOAD_BOOL(&pThreadData->terminate)) {
             ATOMIC_INCREMENT(&pThreadData->pThreadpool->availableThreads);
+            MUTEX_UNLOCK(pThreadData->dataMutex);
             if (safeBlockingQueueDequeue(pQueue, &item) == STATUS_SUCCESS) {
                 pTask = (PTaskData) item;
                 ATOMIC_DECREMENT(&pThreadData->pThreadpool->availableThreads);
@@ -65,48 +71,64 @@ PVOID threadpoolActor(PVOID data)
                 ATOMIC_DECREMENT(&pThreadData->pThreadpool->availableThreads);
             }
         }
+        else {
+            finished = TRUE;
+            MUTEX_UNLOCK(pThreadData->dataMutex);
+            break;
+        }
 
+        // We use trylock to avoid a potential deadlock with the destructor. The destructor needs
+        // to lock listMutex and then dataMutex, but we're locking dataMutex and then listMutex.
+        //
+        // The destructor also uses trylock for the same reason.
         if (MUTEX_TRYLOCK(pThreadData->dataMutex)) {
-            // Threadpool is active - lock its mutex
-            MUTEX_LOCK(pThreadpool->listMutex);
+            if (ATOMIC_LOAD_BOOL(&pThreadData->terminate)) {
+                MUTEX_UNLOCK(pThreadData->dataMutex);
+            }
+            else {
+                // Threadpool is active - lock its mutex
+                MUTEX_LOCK(pThreadpool->listMutex);
 
-            // Check that there aren't any pending tasks.
-            if (safeBlockingQueueIsEmpty(pQueue, &taskQueueEmpty) == STATUS_SUCCESS) {
-                if (taskQueueEmpty) {
-                    // Check if this thread is needed to maintain minimum thread count
-                    // otherwise exit loop and remove it.
-                    if (stackQueueGetCount(pThreadpool->threadList, &count) == STATUS_SUCCESS) {
-                        if (count > pThreadpool->minThreads) {
-                            finished = TRUE;
-                            if (stackQueueRemoveItem(pThreadpool->threadList, pThreadData) != STATUS_SUCCESS) {
-                                DLOGE("Failed to remove thread data from threadpool");
+                // Check that there aren't any pending tasks.
+                if (safeBlockingQueueIsEmpty(pQueue, &taskQueueEmpty) == STATUS_SUCCESS) {
+                    if (taskQueueEmpty) {
+                        // Check if this thread is needed to maintain minimum thread count
+                        // otherwise exit loop and remove it.
+                        if (stackQueueGetCount(pThreadpool->threadList, &count) == STATUS_SUCCESS) {
+                            if (count > pThreadpool->minThreads) {
+                                finished = TRUE;
+                                if (stackQueueRemoveItem(pThreadpool->threadList, pThreadData) != STATUS_SUCCESS) {
+                                    DLOGE("Failed to remove thread data from threadpool");
+                                }
                             }
                         }
                     }
                 }
-            }
-            // this is a redundant safety check. To get here the threadpool must be being
-            // actively being destroyed, but it was unable to acquire our lock so entered a
-            // sleep spin check to allow this thread to finish. However somehow the task queue
-            // was not empty, so we ended up here. This check forces us to still exit gracefully
-            // in the event somehow the queue is not empty.
-            else if (ATOMIC_LOAD_BOOL(&pThreadData->terminate)) {
-                finished = TRUE;
-                if (stackQueueRemoveItem(pThreadpool->threadList, pThreadData) != STATUS_SUCCESS) {
-                    DLOGE("Failed to remove thread data from threadpool");
+                // this is a redundant safety check. To get here the threadpool must be being
+                // actively being destroyed, but it was unable to acquire our lock so entered a
+                // sleep spin check to allow this thread to finish. However somehow the task queue
+                // was not empty, so we ended up here. This check forces us to still exit gracefully
+                // in the event somehow the queue is not empty.
+                else if (ATOMIC_LOAD_BOOL(&pThreadData->terminate)) {
+                    finished = TRUE;
+                    if (stackQueueRemoveItem(pThreadpool->threadList, pThreadData) != STATUS_SUCCESS) {
+                        DLOGE("Failed to remove thread data from threadpool");
+                    }
                 }
+                MUTEX_UNLOCK(pThreadpool->listMutex);
+                MUTEX_UNLOCK(pThreadData->dataMutex);
             }
-            MUTEX_UNLOCK(pThreadpool->listMutex);
-            MUTEX_UNLOCK(pThreadData->dataMutex);
         } else {
             // couldn't lock our mutex, which means Threadpool locked this mutex to indicate
             // Threadpool has been deleted.
-            //
-            // Unlock mutex and free ThreadData
-            MUTEX_UNLOCK(pThreadData->dataMutex);
             finished = TRUE;
         }
     }
+    // now that we've released the listMutex, we can do an actual MUTEX_LOCK to ensure the
+    // threadpool has finished using pThreadData
+    MUTEX_LOCK(pThreadData->dataMutex);
+    MUTEX_UNLOCK(pThreadData->dataMutex);
+
     // we assume we've already been removed from the threadList
     MUTEX_FREE(pThreadData->dataMutex);
     SAFE_MEMFREE(pThreadData);
@@ -189,6 +211,7 @@ STATUS threadpoolInternalCreateThread(PThreadpool pThreadpool)
 
     data->dataMutex = MUTEX_CREATE(FALSE);
     data->pThreadpool = pThreadpool;
+    ATOMIC_STORE_BOOL(&data->terminate, FALSE);
 
     CHK_STATUS(stackQueueEnqueue(pThreadpool->threadList, (UINT64) data));
 
@@ -300,15 +323,16 @@ STATUS threadpoolFree(PThreadpool pThreadpool)
             }
             retStatus = stackQueueIteratorGetItem(iterator, &item);
 
-            // set terminate flag of item
-            ATOMIC_STORE_BOOL(&item->terminate, TRUE);
-
             // attempt to lock mutex of item
             if (MUTEX_TRYLOCK(item->dataMutex)) {
+                // set terminate flag of item
+                ATOMIC_STORE_BOOL(&item->terminate, TRUE);
+
                 // when we acquire the lock, remove the item from the list. Its thread will free it.
                 if (stackQueueRemoveItem(pThreadpool->threadList, item) != STATUS_SUCCESS) {
                     DLOGE("Failed to remove thread data from threadpool");
                 }
+                MUTEX_UNLOCK(item->dataMutex);
             } else {
                 // if the mutex is taken, unlock list mutex, sleep 10 ms and 'start over'
                 //

--- a/src/utils/tst/Threadpool.cpp
+++ b/src/utils/tst/Threadpool.cpp
@@ -6,7 +6,7 @@ class ThreadpoolFunctionalityTest : public UtilTestBase {
 };
 
 PVOID randomishTask(PVOID customData) {
-    THREAD_SLEEP((rand()%100 + 1) * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+    THREAD_SLEEP((rand()%20 + 100) * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
     return 0;
 }
 
@@ -49,7 +49,7 @@ TEST_F(ThreadpoolFunctionalityTest, BasicTryAddTest)
 
     //sleep for a little. Create asynchronously detaches threads, so using TryAdd too soon can
     //fail if the threads are not yet ready.
-    THREAD_SLEEP(10 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+    THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 
     EXPECT_EQ(STATUS_SUCCESS, threadpoolTryAdd(pThreadpool, exitOnTeardownTask, &terminate));
     EXPECT_EQ(STATUS_THREADPOOL_MAX_COUNT, threadpoolTryAdd(pThreadpool, exitOnTeardownTask, &terminate));
@@ -98,6 +98,10 @@ TEST_F(ThreadpoolFunctionalityTest, GetThreadCountTest)
     for(UINT32 i = 0; i < min; i++) {
         EXPECT_EQ(STATUS_SUCCESS, threadpoolPush(pThreadpool, exitOnTeardownTask, &terminate));
     }
+    //Threads have to wake up and accept tasks. Put a small sleep here so that we know the tasks
+    //have started before the next push.
+    THREAD_SLEEP(20 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+
     //no new threads created
     EXPECT_EQ(STATUS_SUCCESS, threadpoolTotalThreadCount(pThreadpool, &count));
     EXPECT_EQ(count, min);
@@ -129,6 +133,7 @@ TEST_F(ThreadpoolFunctionalityTest, ThreadsExitGracefullyAfterThreadpoolFreeTest
     for(UINT32 i = min; i < max; i++) {
         EXPECT_EQ(STATUS_SUCCESS, threadpoolPush(pThreadpool, randomishTask, NULL));
     }
+    THREAD_SLEEP(110 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
     EXPECT_EQ(STATUS_SUCCESS, threadpoolFree(pThreadpool));
     //now threads will exit after threadpoolFree
     terminate = TRUE;

--- a/src/utils/tst/Threadpool.cpp
+++ b/src/utils/tst/Threadpool.cpp
@@ -5,14 +5,16 @@
 class ThreadpoolFunctionalityTest : public UtilTestBase {
 };
 
-PVOID randomishTask(PVOID customData) {
-    THREAD_SLEEP((rand()%20 + 100) * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+PVOID randomishTask(PVOID customData)
+{
+    THREAD_SLEEP((rand() % 20 + 100) * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
     return 0;
 }
 
-PVOID exitOnTeardownTask(PVOID customData) {
-    BOOL * pTerminate = (BOOL*)customData;
-    while(!*pTerminate) {
+PVOID exitOnTeardownTask(PVOID customData)
+{
+    BOOL* pTerminate = (BOOL*) customData;
+    while (!*pTerminate) {
         THREAD_SLEEP(20 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
     }
     return 0;
@@ -24,19 +26,19 @@ TEST_F(ThreadpoolFunctionalityTest, CreateDestroyTest)
     EXPECT_EQ(STATUS_SUCCESS, threadpoolCreate(&pThreadpool, 1, 1));
     EXPECT_EQ(STATUS_SUCCESS, threadpoolFree(pThreadpool));
 
-    //wait for threads to exit before test ends
+    // wait for threads to exit before test ends
     THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 
     EXPECT_EQ(STATUS_SUCCESS, threadpoolCreate(&pThreadpool, 1, 2));
     EXPECT_EQ(STATUS_SUCCESS, threadpoolFree(pThreadpool));
 
-    //wait for threads to exit before test ends
+    // wait for threads to exit before test ends
     THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 
     EXPECT_EQ(STATUS_SUCCESS, threadpoolCreate(&pThreadpool, 1, 1));
     EXPECT_EQ(STATUS_SUCCESS, threadpoolFree(pThreadpool));
 
-    //wait for threads to exit before test ends
+    // wait for threads to exit before test ends
     THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
@@ -47,8 +49,8 @@ TEST_F(ThreadpoolFunctionalityTest, BasicTryAddTest)
     srand(GETTIME());
     EXPECT_EQ(STATUS_SUCCESS, threadpoolCreate(&pThreadpool, 1, 1));
 
-    //sleep for a little. Create asynchronously detaches threads, so using TryAdd too soon can
-    //fail if the threads are not yet ready.
+    // sleep for a little. Create asynchronously detaches threads, so using TryAdd too soon can
+    // fail if the threads are not yet ready.
     THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 
     EXPECT_EQ(STATUS_SUCCESS, threadpoolTryAdd(pThreadpool, exitOnTeardownTask, &terminate));
@@ -56,7 +58,7 @@ TEST_F(ThreadpoolFunctionalityTest, BasicTryAddTest)
     terminate = TRUE;
     EXPECT_EQ(STATUS_SUCCESS, threadpoolFree(pThreadpool));
 
-    //wait for threads to exit before test ends
+    // wait for threads to exit before test ends
     THREAD_SLEEP(300 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
@@ -75,7 +77,7 @@ TEST_F(ThreadpoolFunctionalityTest, BasicPushTest)
     terminate = TRUE;
     EXPECT_EQ(STATUS_SUCCESS, threadpoolFree(pThreadpool));
 
-    //wait for threads to exit before test ends
+    // wait for threads to exit before test ends
     THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
@@ -86,35 +88,35 @@ TEST_F(ThreadpoolFunctionalityTest, GetThreadCountTest)
     BOOL terminate = FALSE;
     srand(GETTIME());
     const UINT32 max = 10;
-    //accepted race condition where min is 1, threadpoolPush can create a new thread
-    //before the first thread is ready to accept tasks
-    UINT32 min = rand()%(max/2) + 2;
+    // accepted race condition where min is 1, threadpoolPush can create a new thread
+    // before the first thread is ready to accept tasks
+    UINT32 min = rand() % (max / 2) + 2;
     EXPECT_EQ(STATUS_SUCCESS, threadpoolCreate(&pThreadpool, min, max));
-    //let threads get ready so new threads aren't created for this task
+    // let threads get ready so new threads aren't created for this task
     THREAD_SLEEP(200 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
     EXPECT_EQ(STATUS_SUCCESS, threadpoolTotalThreadCount(pThreadpool, &count));
     EXPECT_EQ(count, min);
 
-    for(UINT32 i = 0; i < min; i++) {
+    for (UINT32 i = 0; i < min; i++) {
         EXPECT_EQ(STATUS_SUCCESS, threadpoolPush(pThreadpool, exitOnTeardownTask, &terminate));
     }
-    //Threads have to wake up and accept tasks. Put a small sleep here so that we know the tasks
-    //have started before the next push.
+    // Threads have to wake up and accept tasks. Put a small sleep here so that we know the tasks
+    // have started before the next push.
     THREAD_SLEEP(20 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 
-    //no new threads created
+    // no new threads created
     EXPECT_EQ(STATUS_SUCCESS, threadpoolTotalThreadCount(pThreadpool, &count));
     EXPECT_EQ(count, min);
 
-    //another thread needed
+    // another thread needed
     EXPECT_EQ(STATUS_SUCCESS, threadpoolPush(pThreadpool, exitOnTeardownTask, &terminate));
     EXPECT_EQ(STATUS_SUCCESS, threadpoolTotalThreadCount(pThreadpool, &count));
-    EXPECT_EQ(count, min+1);
+    EXPECT_EQ(count, min + 1);
 
     terminate = TRUE;
     EXPECT_EQ(STATUS_SUCCESS, threadpoolFree(pThreadpool));
 
-    //wait for threads to exit before test ends
+    // wait for threads to exit before test ends
     THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
@@ -125,20 +127,20 @@ TEST_F(ThreadpoolFunctionalityTest, ThreadsExitGracefullyAfterThreadpoolFreeTest
     BOOL terminate = FALSE;
     srand(GETTIME());
     const UINT32 max = 10;
-    UINT32 min = rand()%(max/2) + 2;
+    UINT32 min = rand() % (max / 2) + 2;
     EXPECT_EQ(STATUS_SUCCESS, threadpoolCreate(&pThreadpool, min, max));
-    for(UINT32 i = 0; i < min; i++) {
+    for (UINT32 i = 0; i < min; i++) {
         EXPECT_EQ(STATUS_SUCCESS, threadpoolPush(pThreadpool, exitOnTeardownTask, &terminate));
     }
-    for(UINT32 i = min; i < max; i++) {
+    for (UINT32 i = min; i < max; i++) {
         EXPECT_EQ(STATUS_SUCCESS, threadpoolPush(pThreadpool, randomishTask, NULL));
     }
     THREAD_SLEEP(110 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
     EXPECT_EQ(STATUS_SUCCESS, threadpoolFree(pThreadpool));
-    //now threads will exit after threadpoolFree
+    // now threads will exit after threadpoolFree
     terminate = TRUE;
 
-    //wait for threads to exit before test ends
+    // wait for threads to exit before test ends
     THREAD_SLEEP(150 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }
 
@@ -147,20 +149,20 @@ typedef struct ThreadpoolUser {
     volatile ATOMIC_BOOL usable;
 };
 
-PVOID createTasks(PVOID customData) {
-    ThreadpoolUser * user = (ThreadpoolUser*)customData;
+PVOID createTasks(PVOID customData)
+{
+    ThreadpoolUser* user = (ThreadpoolUser*) customData;
     PThreadpool pThreadpool = user->pThreadpool;
-    auto iterations = rand()%20;
+    auto iterations = rand() % 20;
 
-    for(auto i = 0; i < iterations; i++) {
-        THREAD_SLEEP((rand()%5 + 1) * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
-        //allowed to fail as we may delete the threadpool early
+    for (auto i = 0; i < iterations; i++) {
+        THREAD_SLEEP((rand() % 5 + 1) * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+        // allowed to fail as we may delete the threadpool early
         if (ATOMIC_LOAD_BOOL(&user->usable)) {
             if (threadpoolPush(pThreadpool, randomishTask, NULL) != STATUS_SUCCESS) {
                 break;
             }
-        }
-        else {
+        } else {
             break;
         }
     }
@@ -175,7 +177,7 @@ TEST_F(ThreadpoolFunctionalityTest, MultithreadUseTest)
     BOOL terminate = FALSE;
     srand(GETTIME());
     const UINT32 max = 10;
-    UINT32 min = rand()%(max/2) + 2;
+    UINT32 min = rand() % (max / 2) + 2;
     TID thread1, thread2;
     EXPECT_EQ(STATUS_SUCCESS, threadpoolCreate(&pThreadpool, min, max));
     user.pThreadpool = pThreadpool;
@@ -183,10 +185,10 @@ TEST_F(ThreadpoolFunctionalityTest, MultithreadUseTest)
     THREAD_CREATE(&thread1, createTasks, &user);
     THREAD_CREATE(&thread2, createTasks, &user);
 
-    THREAD_SLEEP((rand()%50 + 50) * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+    THREAD_SLEEP((rand() % 50 + 50) * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
     ATOMIC_STORE_BOOL(&user.usable, FALSE);
     EXPECT_EQ(STATUS_SUCCESS, threadpoolFree(pThreadpool));
 
-    //wait for threads to exit before test ends to avoid false memory leak alarm
+    // wait for threads to exit before test ends to avoid false memory leak alarm
     THREAD_SLEEP(250 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 }


### PR DESCRIPTION
Threadpool teardown has been changed so that the threads owned by the threadpool will not need to unlock the ThreadData mutex on teardown. This was accomplished by using the terminate atomic bool in place of the locked mutex to indicate that the threadpool has been destroyed.
