### PR TITLE
Add stream state machine iterator

### DIFF
--- a/src/client/src/Stream.c
+++ b/src/client/src/Stream.c
@@ -297,7 +297,7 @@ STATUS createStream(PKinesisVideoClient pKinesisVideoClient, PStreamInfo pStream
         pKinesisVideoStream->diagnostics.createTime + pKinesisVideoClient->deviceInfo.clientInfo.metricLoggingPeriod;
 
     // Call to transition the state machine
-    CHK_STATUS(stepStateMachine(pKinesisVideoStream->base.pStateMachine));
+    CHK_STATUS(iterateStreamStateMachine(pKinesisVideoStream));
 
 CleanUp:
 
@@ -809,7 +809,7 @@ STATUS putFrame(PKinesisVideoStream pKinesisVideoStream, PFrame pFrame)
     // NOTE: If the connection has been reset we need to start from a new header
     if (pKinesisVideoStream->streamState == STREAM_STATE_NEW && pKinesisVideoStream->streamReady) {
         // Step the state machine once to get out of the Ready state
-        CHK_STATUS(stepStateMachine(pKinesisVideoStream->base.pStateMachine));
+        CHK_STATUS(iterateStreamStateMachine(pKinesisVideoStream));
     }
 
     // if we need to reset the generator on the next key frame (during the rotation only)
@@ -3544,7 +3544,7 @@ STATUS resetStream(PKinesisVideoStream pKinesisVideoStream)
     }
 
     // step out of stopped state
-    CHK_STATUS(stepStateMachine(pKinesisVideoStream->base.pStateMachine));
+    CHK_STATUS(iterateStreamStateMachine(pKinesisVideoStream));
 
     // Unlock the stream
     pKinesisVideoClient->clientCallbacks.unlockMutexFn(pKinesisVideoClient->clientCallbacks.customData, pKinesisVideoStream->base.lock);

--- a/src/client/src/Stream.h
+++ b/src/client/src/Stream.h
@@ -377,6 +377,9 @@ struct __KinesisVideoStream {
     // Stream state for running/stopping
     UINT64 streamState;
 
+    // Whether to continue iterating the stream state machine
+    BOOL keepIterating;
+
     // Fragment ACK parser for streaming ACKs
     FragmentAckParser fragmentAckParser;
 
@@ -840,6 +843,11 @@ STATUS streamFragmentErrorAck(PKinesisVideoStream, UINT64, UINT64, SERVICE_CALL_
 // Streaming event functions
 ///////////////////////////////////////////////////////////////////////////
 STATUS getStreamData(PKinesisVideoStream, UPLOAD_HANDLE, PBYTE, UINT32, PUINT32);
+
+///////////////////////////////////////////////////////////////////////////
+// State machine iterator
+///////////////////////////////////////////////////////////////////////////
+STATUS iterateStreamStateMachine(PKinesisVideoStream pKinesisVideoStream);
 
 ///////////////////////////////////////////////////////////////////////////
 // State machine callback functionality

--- a/src/client/src/Stream.h
+++ b/src/client/src/Stream.h
@@ -378,7 +378,7 @@ struct __KinesisVideoStream {
     UINT64 streamState;
 
     // Whether to continue iterating the stream state machine
-    BOOL keepIterating;
+    BOOL keepIteratingStateMachine;
 
     // Fragment ACK parser for streaming ACKs
     FragmentAckParser fragmentAckParser;

--- a/src/client/src/StreamEvent.c
+++ b/src/client/src/StreamEvent.c
@@ -286,7 +286,7 @@ STATUS describeStreamResult(PKinesisVideoStream pKinesisVideoStream, SERVICE_CAL
     }
 
     // Step the machine
-    CHK_STATUS(stepStateMachine(pKinesisVideoStream->base.pStateMachine));
+    CHK_STATUS(iterateStreamStateMachine(pKinesisVideoStream));
 
 CleanUp:
 
@@ -347,7 +347,7 @@ STATUS createStreamResult(PKinesisVideoStream pKinesisVideoStream, SERVICE_CALL_
     }
 
     // Step the machine
-    CHK_STATUS(stepStateMachine(pKinesisVideoStream->base.pStateMachine));
+    CHK_STATUS(iterateStreamStateMachine(pKinesisVideoStream));
 
 CleanUp:
 
@@ -432,7 +432,7 @@ STATUS getStreamingTokenResult(PKinesisVideoStream pKinesisVideoStream, SERVICE_
     }
 
     // Step the machine
-    CHK_STATUS(stepStateMachine(pKinesisVideoStream->base.pStateMachine));
+    CHK_STATUS(iterateStreamStateMachine(pKinesisVideoStream));
 
 CleanUp:
 
@@ -493,7 +493,7 @@ STATUS getStreamingEndpointResult(PKinesisVideoStream pKinesisVideoStream, SERVI
     }
 
     // Step the machine
-    CHK_STATUS(stepStateMachine(pKinesisVideoStream->base.pStateMachine));
+    CHK_STATUS(iterateStreamStateMachine(pKinesisVideoStream));
 
 CleanUp:
 
@@ -568,7 +568,7 @@ STATUS putStreamResult(PKinesisVideoStream pKinesisVideoStream, SERVICE_CALL_RES
     CHK_STATUS(stackQueueEnqueue(pKinesisVideoStream->pUploadInfoQueue, (UINT64) pUploadHandleInfo));
 
     // Step the machine
-    CHK_STATUS(stepStateMachine(pKinesisVideoStream->base.pStateMachine));
+    CHK_STATUS(iterateStreamStateMachine(pKinesisVideoStream));
 
 CleanUp:
 
@@ -625,7 +625,7 @@ STATUS tagStreamResult(PKinesisVideoStream pKinesisVideoStream, SERVICE_CALL_RES
     pKinesisVideoStream->base.result = callResult;
 
     // Step the machine
-    retStatus = stepStateMachine(pKinesisVideoStream->base.pStateMachine);
+    retStatus = iterateStreamStateMachine(pKinesisVideoStream);
     CHK(retStatus == STATUS_SUCCESS || retStatus == STATUS_TAG_STREAM_CALL_FAILED, retStatus);
 
     // Override tagStream failure because it is not critical to streaming.
@@ -637,7 +637,7 @@ STATUS tagStreamResult(PKinesisVideoStream pKinesisVideoStream, SERVICE_CALL_RES
                                                                  INVALID_TIMESTAMP_VALUE, STATUS_TAG_STREAM_CALL_FAILED);
 
         pKinesisVideoStream->base.result = SERVICE_CALL_RESULT_OK;
-        retStatus = stepStateMachine(pKinesisVideoStream->base.pStateMachine);
+        retStatus = iterateStreamStateMachine(pKinesisVideoStream);
     }
 
 CleanUp:
@@ -783,7 +783,7 @@ STATUS streamTerminatedEvent(PKinesisVideoStream pKinesisVideoStream, UPLOAD_HAN
         pKinesisVideoStream->base.result = callResult;
 
         // Step the machine
-        CHK_STATUS(stepStateMachine(pKinesisVideoStream->base.pStateMachine));
+        CHK_STATUS(iterateStreamStateMachine(pKinesisVideoStream));
     }
 
 CleanUp:

--- a/src/client/src/StreamState.c
+++ b/src/client/src/StreamState.c
@@ -50,7 +50,7 @@ STATUS iterateStreamStateMachine(PKinesisVideoStream pKinesisVideoStream)
     PStateMachine pStateMachine = NULL;
 
     CHK(pKinesisVideoStream != NULL, STATUS_NULL_ARG);
-    
+
     pStateMachine = pKinesisVideoStream->base.pStateMachine;
     CHK(pStateMachine != NULL, STATUS_NULL_ARG);
 

--- a/src/client/src/StreamState.c
+++ b/src/client/src/StreamState.c
@@ -56,7 +56,7 @@ STATUS iterateStreamStateMachine(PKinesisVideoStream pKinesisVideoStream)
     do {
         pKinesisVideoStream->keepIteratingStateMachine = FALSE;
         CHK_STATUS(stepStateMachine(pStateMachine));
-        CHK(pKinesisVideoStream != NULL && pStateMachine != NULL, STATUS_NULL_ARG);
+        CHK(pKinesisVideoStream != NULL, STATUS_NULL_ARG);
     } while (pKinesisVideoStream->keepIteratingStateMachine);
 
 CleanUp:

--- a/src/client/src/StreamState.c
+++ b/src/client/src/StreamState.c
@@ -50,9 +50,9 @@ STATUS iterateStreamStateMachine(PKinesisVideoStream pKinesisVideoStream)
     PStateMachine pStateMachine = pKinesisVideoStream->base.pStateMachine;
 
     do {
-        pKinesisVideoStream->keepIterating = FALSE;
+        pKinesisVideoStream->keepIteratingStateMachine = FALSE;
         CHK_STATUS(stepStateMachine(pStateMachine));
-    } while (pKinesisVideoStream->keepIterating);
+    } while (pKinesisVideoStream->keepIteratingStateMachine);
 
 CleanUp:
 
@@ -147,7 +147,7 @@ STATUS executeNewStreamState(UINT64 customData, UINT64 time)
     CHK(pKinesisVideoStream != NULL, STATUS_NULL_ARG);
 
     // Step the state machine to automatically invoke the Describe API
-    pKinesisVideoStream->keepIterating = TRUE;
+    pKinesisVideoStream->keepIteratingStateMachine = TRUE;
 
 CleanUp:
 
@@ -741,7 +741,7 @@ STATUS executeReadyStreamState(UINT64 customData, UINT64 time)
     // Check if we need to also call put stream API
     if (pKinesisVideoStream->streamState == STREAM_STATE_READY || pKinesisVideoStream->streamState == STREAM_STATE_STOPPED || viewByteSize != 0) {
         // Step the state machine to automatically invoke the PutStream API
-        pKinesisVideoStream->keepIterating = TRUE;
+        pKinesisVideoStream->keepIteratingStateMachine = TRUE;
     }
 
 CleanUp:
@@ -846,7 +846,7 @@ STATUS executeStoppedStreamState(UINT64 customData, UINT64 time)
     }
 
     // Auto-prime the state machine
-    pKinesisVideoStream->keepIterating = TRUE;
+    pKinesisVideoStream->keepIteratingStateMachine = TRUE;
 
 CleanUp:
 

--- a/src/client/src/StreamState.c
+++ b/src/client/src/StreamState.c
@@ -49,16 +49,15 @@ STATUS iterateStreamStateMachine(PKinesisVideoStream pKinesisVideoStream)
     STATUS retStatus = STATUS_SUCCESS;
     PStateMachine pStateMachine = pKinesisVideoStream->base.pStateMachine;
 
-    do
-    {
+    do {
         pKinesisVideoStream->keepIterating = FALSE;
-        CHK_STATUS(stepStateMachine(pStateMachine));    
-    } while(pKinesisVideoStream->keepIterating);
+        CHK_STATUS(stepStateMachine(pStateMachine));
+    } while (pKinesisVideoStream->keepIterating);
 
-    CleanUp:
+CleanUp:
 
-        LEAVES();
-        return retStatus;
+    LEAVES();
+    return retStatus;
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/src/client/src/StreamState.c
+++ b/src/client/src/StreamState.c
@@ -47,11 +47,17 @@ STATUS iterateStreamStateMachine(PKinesisVideoStream pKinesisVideoStream)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
-    PStateMachine pStateMachine = pKinesisVideoStream->base.pStateMachine;
+    PStateMachine pStateMachine = NULL;
+
+    CHK(pKinesisVideoStream != NULL, STATUS_NULL_ARG);
+    
+    pStateMachine = pKinesisVideoStream->base.pStateMachine;
+    CHK(pStateMachine != NULL, STATUS_NULL_ARG);
 
     do {
         pKinesisVideoStream->keepIteratingStateMachine = FALSE;
         CHK_STATUS(stepStateMachine(pStateMachine));
+        CHK(pKinesisVideoStream != NULL && pStateMachine != NULL, STATUS_NULL_ARG);
     } while (pKinesisVideoStream->keepIteratingStateMachine);
 
 CleanUp:

--- a/src/client/src/StreamState.c
+++ b/src/client/src/StreamState.c
@@ -51,11 +51,11 @@ STATUS iterateStreamStateMachine(PKinesisVideoStream pKinesisVideoStream)
 
     CHK(pKinesisVideoStream != NULL, STATUS_NULL_ARG);
     pStateMachine = pKinesisVideoStream->base.pStateMachine;
+    CHK(pStateMachine != NULL, STATUS_NULL_ARG);
 
     do {
         pKinesisVideoStream->keepIteratingStateMachine = FALSE;
         CHK_STATUS(stepStateMachine(pStateMachine));
-        CHK(pKinesisVideoStream != NULL, STATUS_NULL_ARG);
     } while (pKinesisVideoStream->keepIteratingStateMachine);
 
 CleanUp:

--- a/src/client/src/StreamState.c
+++ b/src/client/src/StreamState.c
@@ -40,6 +40,28 @@ StateMachineState STREAM_STATE_MACHINE_STATES[] = {
 UINT32 STREAM_STATE_MACHINE_STATE_COUNT = SIZEOF(STREAM_STATE_MACHINE_STATES) / SIZEOF(StateMachineState);
 
 ///////////////////////////////////////////////////////////////////////////
+// State machine transition iterator
+///////////////////////////////////////////////////////////////////////////
+
+STATUS iterateStreamStateMachine(PKinesisVideoStream pKinesisVideoStream)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    PStateMachine pStateMachine = pKinesisVideoStream->base.pStateMachine;
+
+    do
+    {
+        pKinesisVideoStream->keepIterating = FALSE;
+        CHK_STATUS(stepStateMachine(pStateMachine));    
+    } while(pKinesisVideoStream->keepIterating);
+
+    CleanUp:
+
+        LEAVES();
+        return retStatus;
+}
+
+///////////////////////////////////////////////////////////////////////////
 // State machine callback functions
 ///////////////////////////////////////////////////////////////////////////
 

--- a/src/client/src/StreamState.c
+++ b/src/client/src/StreamState.c
@@ -50,7 +50,6 @@ STATUS iterateStreamStateMachine(PKinesisVideoStream pKinesisVideoStream)
     PStateMachine pStateMachine = NULL;
 
     CHK(pKinesisVideoStream != NULL, STATUS_NULL_ARG);
-
     pStateMachine = pKinesisVideoStream->base.pStateMachine;
     CHK(pStateMachine != NULL, STATUS_NULL_ARG);
 

--- a/src/client/src/StreamState.c
+++ b/src/client/src/StreamState.c
@@ -51,7 +51,6 @@ STATUS iterateStreamStateMachine(PKinesisVideoStream pKinesisVideoStream)
 
     CHK(pKinesisVideoStream != NULL, STATUS_NULL_ARG);
     pStateMachine = pKinesisVideoStream->base.pStateMachine;
-    CHK(pStateMachine != NULL, STATUS_NULL_ARG);
 
     do {
         pKinesisVideoStream->keepIteratingStateMachine = FALSE;

--- a/src/client/src/StreamState.c
+++ b/src/client/src/StreamState.c
@@ -148,7 +148,7 @@ STATUS executeNewStreamState(UINT64 customData, UINT64 time)
     CHK(pKinesisVideoStream != NULL, STATUS_NULL_ARG);
 
     // Step the state machine to automatically invoke the Describe API
-    CHK_STATUS(stepStateMachine(pKinesisVideoStream->base.pStateMachine));
+    pKinesisVideoStream->keepIterating = TRUE;
 
 CleanUp:
 
@@ -742,7 +742,7 @@ STATUS executeReadyStreamState(UINT64 customData, UINT64 time)
     // Check if we need to also call put stream API
     if (pKinesisVideoStream->streamState == STREAM_STATE_READY || pKinesisVideoStream->streamState == STREAM_STATE_STOPPED || viewByteSize != 0) {
         // Step the state machine to automatically invoke the PutStream API
-        CHK_STATUS(stepStateMachine(pKinesisVideoStream->base.pStateMachine));
+        pKinesisVideoStream->keepIterating = TRUE;
     }
 
 CleanUp:
@@ -847,7 +847,7 @@ STATUS executeStoppedStreamState(UINT64 customData, UINT64 time)
     }
 
     // Auto-prime the state machine
-    CHK_STATUS(stepStateMachine(pKinesisVideoStream->base.pStateMachine));
+    pKinesisVideoStream->keepIterating = TRUE;
 
 CleanUp:
 

--- a/src/state/src/State.c
+++ b/src/state/src/State.c
@@ -126,7 +126,7 @@ CleanUp:
 }
 
 /**
- * Transition the state machine given it's context
+ * Transition the state machine given its context
  */
 STATUS stepStateMachine(PStateMachine pStateMachine)
 {
@@ -161,7 +161,7 @@ STATUS stepStateMachine(PStateMachine pStateMachine)
 
     // Check if we are changing the state
     if (pState->state != pStateMachineImpl->context.pCurrentState->state) {
-        // Since we're transitioning to a different state from this state, reset the local state retry count to0
+        // Since we're transitioning to a different state from this state, reset the local state retry count to 0
         pStateMachineImpl->context.localStateRetryCount = 0;
     } else {
         // Increment the local state retry count.


### PR DESCRIPTION
## Overview
Removes the possibility of segfault errors occurring from stack overflows caused by recursive `stepStateMachine()` calls made internally by the stream pointer functions passed as `executeStateFn` to the stream state machine. Implements the following changes:

- Iterating function `iterateStreamStateMachine()` added to the **StreamState** file
- Boolean member `keepIteratingStateMachine` added to the **KinesisVideoStream** struct to track when to keep calling `stepStateMachine()`
- All `stepStateMachine()` calls removed from `executeStateFn` functions
- `iterateStreamStateMachine()` makes `stepStateMachine()` calls as needed based on how was done in the `executeStateFn` functions
- All `stepStateMachine()` calls upon the stream state machine that are outside of `iterateStreamStateMachine()` replaced by `iterateStreamStateMachine()` calls

The functionality of the internal stepping of the state machine remains similar to the existing functionality, but the `executeStateFn` functions now set the `keepIteratingStateMachine` member to TRUE rather than calling `stepStateMachine()`.

### Stream State Behavior for Reference
- **1** state that _always_ internally calls `stepStateMachine()`: NEW
- **2** states that _sometimes_ internally call `stepStateMachine()`: READY, STOPPED
- **7** states that _never_ internally call `stepStateMachine()`: DESCRIBE, CREATE, TAG_STREAM, GET_ENDPOINT, GET_TOKEN, PUT_STREAM, STREAMING

## Testing
To test these changes' success in preventing the state transition segfaults, the state machine was forced into an endless loop by commenting out the following line in `fromNewStreamState()`:
```
state = STREAM_STATE_DESCRIBE;
```
The state machine would then endlessly transition from and to STREAM_STATE_NEW.

Without the iterator, this almost immediately caused a segfault, not even reaching 40,000 recursive calls:
<img width="566" alt="Screenshot 2023-09-19 at 2 59 36 PM" src="https://github.com/awslabs/amazon-kinesis-video-streams-pic/assets/85728496/642c4159-a59a-4a08-bd37-28945190dfc0">

Using the iterator, the sate machine continues to transition, reaching over 4 million iterations in ~1min:
<img width="279" alt="Screenshot 2023-09-19 at 2 46 56 PM" src="https://github.com/awslabs/amazon-kinesis-video-streams-pic/assets/85728496/3face944-2c30-45e3-bc0b-e55b3acd728b">

<br>
<br>
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
