### PR TITLE
Utils - Remove duplicate error code

### DIFF
--- a/src/utils/include/com/amazonaws/kinesis/video/utils/Include.h
+++ b/src/utils/include/com/amazonaws/kinesis/video/utils/Include.h
@@ -1464,8 +1464,8 @@ PUBLIC_API SIZE_T getInstrumentedTotalAllocationSize();
 /**
  * File logger error values starting from 0x41300000
  */
-#define STATUS_FILE_LOGGER_BASE                    STATUS_UTILS_BASE + 0x01200000
-#define STATUS_FILE_LOGGER_INDEX_FILE_INVALID_SIZE STATUS_SEMAPHORE_BASE + 0x00000001
+#define STATUS_FILE_LOGGER_BASE                    STATUS_UTILS_BASE + 0x01300000
+#define STATUS_FILE_LOGGER_INDEX_FILE_INVALID_SIZE STATUS_FILE_LOGGER_BASE + 0x00000001
 
 /**
  * File based logger limit constants


### PR DESCRIPTION
*Description of changes:*
Utils Library

Some error codes are duplicated. Adjust the ones starting with `LOGGER_` so that they are not duplicate.
https://github.com/awslabs/amazon-kinesis-video-streams-pic/blob/57637ea593f4b43c509413a44d993ed08d7f2616/src/utils/include/com/amazonaws/kinesis/video/utils/Include.h#L1292-L1293

https://github.com/awslabs/amazon-kinesis-video-streams-pic/blob/57637ea593f4b43c509413a44d993ed08d7f2616/src/utils/include/com/amazonaws/kinesis/video/utils/Include.h#L1457-L1458




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
