### PR TITLE
Add is null or empty

### DIFF
--- a/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
+++ b/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
@@ -866,6 +866,11 @@ extern PUBLIC_API atomicXor globalAtomicXor;
 #define IS_EMPTY_STRING(str) ((str)[0] == '\0')
 
 //
+// Check if string is null or empty
+//
+#define IS_NULL_OR_EMPTY_STRING(str) (str == NULL || IS_EMPTY_STRING(str))
+
+//
 // Pseudo-random functionality
 //
 #ifndef SRAND


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* Add a new macro to check for null string or empty string. For readability purposes,
```
if (!IS_NULL_OR_EMPTY(str)) {
```
is better than these two
```
if (!(str == NULL || str[0] == '\0')) {
if (str != NULL && str[0] != '\0') {
```

*Other considerations*

Why don't we just use `strlen(str) > 0`?

1. `strlen` has to traverse the entire string, so it's less efficient than a comparison with the null termination character.
2. If `str` is NULL, using strlen directly may result in undefined behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
