### PR TITLE
Update CommonDefs.h

### DIFF
--- a/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
+++ b/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
@@ -74,7 +74,7 @@ extern "C" {
 // 64/32 bit check on GCC
 //
 #if defined __GNUC__ || defined __GNUG__
-#if defined __x86_64__ || defined __ppc64__
+#if defined __x86_64__ || defined __ppc64__ || __aarch64__
 #define SIZE_64
 #if defined __APPLE__
 #define __LLP64__


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
The way the PIC layer decides whether a platform is 64 or 32 bit is by examining some pre-defined compiler macros.  For 64 bad sadly we had a big miss that arm64 was entirely omitted, i.e. `__aarch64__` as specified here:  https://sourceforge.net/p/predef/wiki/Architectures/

This is pretty bad because this maps our SIZE_T macro to a 32 bit value instead of 64 bit as the native `size_t` on the platform.  This PR resolves that issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
