### PR TITLE
Fix 32 bit crash issue

### DIFF
--- a/src/utils/src/Threadpool.c
+++ b/src/utils/src/Threadpool.c
@@ -325,7 +325,7 @@ STATUS threadpoolFree(PThreadpool pThreadpool)
             CHK_STATUS(stackQueueIteratorGetItem(iterator, &data));
             item = (PThreadData) data;
             CHK(item != NULL, STATUS_INTERNAL_ERROR);
-            
+
             // attempt to lock mutex of item
             if (MUTEX_TRYLOCK(item->dataMutex)) {
                 // set terminate flag of item
@@ -361,12 +361,10 @@ STATUS threadpoolFree(PThreadpool pThreadpool)
         }
     }
 
-
 CleanUp:
 
     if (listMutedLocked) {
         MUTEX_UNLOCK(pThreadpool->listMutex);
-
     }
 
     // now free all the memory

--- a/src/utils/src/Threadpool.c
+++ b/src/utils/src/Threadpool.c
@@ -324,10 +324,14 @@ STATUS threadpoolFree(PThreadpool pThreadpool)
 
             CHK_STATUS(stackQueueIteratorGetItem(iterator, &data));
             item = (PThreadData) data;
-            CHK(item != NULL, STATUS_INTERNAL_ERROR);
 
-            // attempt to lock mutex of item
-            if (MUTEX_TRYLOCK(item->dataMutex)) {
+            if (item == NULL) {
+                DLOGW("NULL thread data present on threadpool.");
+                if (stackQueueRemoveItem(pThreadpool->threadList, data) != STATUS_SUCCESS) {
+                    DLOGE("Failed to remove NULL thread data from threadpool");
+                }
+                // attempt to lock mutex of item
+            } else if (MUTEX_TRYLOCK(item->dataMutex)) {
                 // set terminate flag of item
                 ATOMIC_STORE_BOOL(&item->terminate, TRUE);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In `threadpoolFree` there is a call made to `stackQueueIteratorGetItem` which pass the address of a pointer, but the API expected and returns a UINT64 in this field, this will cause a crash on 32 bit platforms.  For reference similar issue's have been fixed and proper usage can be found elsewhere in PIC:  https://github.com/awslabs/amazon-kinesis-video-streams-pic/blob/57637ea593f4b43c509413a44d993ed08d7f2616/src/client/src/Stream.c#L2059-L2062

I've modified this to follow the same pattern.  The CHK for NULL was missing as well if it's null we will seg fault when we try to access `item->dataMutex`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
