### PR TITLE
State machine name for logs

### DIFF
--- a/src/client/src/Client.c
+++ b/src/client/src/Client.c
@@ -286,9 +286,9 @@ STATUS createKinesisVideoClient(PDeviceInfo pDeviceInfo, PClientCallbacks pClien
         pKinesisVideoClient->clientCallbacks.createMutexFn(pKinesisVideoClient->clientCallbacks.customData, TRUE);
 
     // Create the state machine and step it
-    CHK_STATUS(createStateMachineWithTag(CLIENT_STATE_MACHINE_STATES, CLIENT_STATE_MACHINE_STATE_COUNT, TO_CUSTOM_DATA(pKinesisVideoClient),
-                                         pKinesisVideoClient->clientCallbacks.getCurrentTimeFn, pKinesisVideoClient->clientCallbacks.customData,
-                                         CLIENT_STATE_MACHINE_TAG, &pStateMachine));
+    CHK_STATUS(createStateMachineWithName(CLIENT_STATE_MACHINE_STATES, CLIENT_STATE_MACHINE_STATE_COUNT, TO_CUSTOM_DATA(pKinesisVideoClient),
+                                          pKinesisVideoClient->clientCallbacks.getCurrentTimeFn, pKinesisVideoClient->clientCallbacks.customData,
+                                          CLIENT_STATE_MACHINE_NAME, &pStateMachine));
     pKinesisVideoClient->base.pStateMachine = pStateMachine;
 
     if (pKinesisVideoClient->deviceInfo.clientInfo.automaticStreamingFlags == AUTOMATIC_STREAMING_INTERMITTENT_PRODUCER) {

--- a/src/client/src/Client.c
+++ b/src/client/src/Client.c
@@ -289,7 +289,7 @@ STATUS createKinesisVideoClient(PDeviceInfo pDeviceInfo, PClientCallbacks pClien
     CHK_STATUS(createStateMachine(CLIENT_STATE_MACHINE_STATES, CLIENT_STATE_MACHINE_STATE_COUNT, TO_CUSTOM_DATA(pKinesisVideoClient),
                                   pKinesisVideoClient->clientCallbacks.getCurrentTimeFn, pKinesisVideoClient->clientCallbacks.customData,
                                   &pStateMachine));
-    setStateMachineTag(pStateMachine, "CLIENT");
+    setStateMachineTag(pStateMachine, CLIENT_STATE_MACHINE_TAG);
     pKinesisVideoClient->base.pStateMachine = pStateMachine;
 
     if (pKinesisVideoClient->deviceInfo.clientInfo.automaticStreamingFlags == AUTOMATIC_STREAMING_INTERMITTENT_PRODUCER) {

--- a/src/client/src/Client.c
+++ b/src/client/src/Client.c
@@ -289,7 +289,7 @@ STATUS createKinesisVideoClient(PDeviceInfo pDeviceInfo, PClientCallbacks pClien
     CHK_STATUS(createStateMachine(CLIENT_STATE_MACHINE_STATES, CLIENT_STATE_MACHINE_STATE_COUNT, TO_CUSTOM_DATA(pKinesisVideoClient),
                                   pKinesisVideoClient->clientCallbacks.getCurrentTimeFn, pKinesisVideoClient->clientCallbacks.customData,
                                   &pStateMachine));
-
+    setStateMachineTag(pStateMachine, "Client");
     pKinesisVideoClient->base.pStateMachine = pStateMachine;
 
     if (pKinesisVideoClient->deviceInfo.clientInfo.automaticStreamingFlags == AUTOMATIC_STREAMING_INTERMITTENT_PRODUCER) {

--- a/src/client/src/Client.c
+++ b/src/client/src/Client.c
@@ -289,7 +289,7 @@ STATUS createKinesisVideoClient(PDeviceInfo pDeviceInfo, PClientCallbacks pClien
     CHK_STATUS(createStateMachine(CLIENT_STATE_MACHINE_STATES, CLIENT_STATE_MACHINE_STATE_COUNT, TO_CUSTOM_DATA(pKinesisVideoClient),
                                   pKinesisVideoClient->clientCallbacks.getCurrentTimeFn, pKinesisVideoClient->clientCallbacks.customData,
                                   &pStateMachine));
-    setStateMachineTag(pStateMachine, "Client");
+    setStateMachineTag(pStateMachine, "CLIENT");
     pKinesisVideoClient->base.pStateMachine = pStateMachine;
 
     if (pKinesisVideoClient->deviceInfo.clientInfo.automaticStreamingFlags == AUTOMATIC_STREAMING_INTERMITTENT_PRODUCER) {

--- a/src/client/src/Client.c
+++ b/src/client/src/Client.c
@@ -286,10 +286,9 @@ STATUS createKinesisVideoClient(PDeviceInfo pDeviceInfo, PClientCallbacks pClien
         pKinesisVideoClient->clientCallbacks.createMutexFn(pKinesisVideoClient->clientCallbacks.customData, TRUE);
 
     // Create the state machine and step it
-    CHK_STATUS(createStateMachine(CLIENT_STATE_MACHINE_STATES, CLIENT_STATE_MACHINE_STATE_COUNT, TO_CUSTOM_DATA(pKinesisVideoClient),
-                                  pKinesisVideoClient->clientCallbacks.getCurrentTimeFn, pKinesisVideoClient->clientCallbacks.customData,
-                                  &pStateMachine));
-    setStateMachineTag(pStateMachine, CLIENT_STATE_MACHINE_TAG);
+    CHK_STATUS(createStateMachineWithTag(CLIENT_STATE_MACHINE_STATES, CLIENT_STATE_MACHINE_STATE_COUNT, TO_CUSTOM_DATA(pKinesisVideoClient),
+                                         pKinesisVideoClient->clientCallbacks.getCurrentTimeFn, pKinesisVideoClient->clientCallbacks.customData,
+                                         CLIENT_STATE_MACHINE_TAG, &pStateMachine));
     pKinesisVideoClient->base.pStateMachine = pStateMachine;
 
     if (pKinesisVideoClient->deviceInfo.clientInfo.automaticStreamingFlags == AUTOMATIC_STREAMING_INTERMITTENT_PRODUCER) {

--- a/src/client/src/Include_i.h
+++ b/src/client/src/Include_i.h
@@ -108,7 +108,7 @@ typedef STATUS (*KinesisVideoClientCallbackHookFunc)(UINT64);
  */
 #define KINESIS_VIDEO_CLIENT_CURRENT_VERSION 0
 
-#define CLIENT_STATE_MACHINE_TAG (PCHAR) "wbrHJpxXZKAlXWPJzEEDUFlxeQOLAzjw"
+#define CLIENT_STATE_MACHINE_TAG (PCHAR) "CLIENT"
 #define STREAM_STATE_MACHINE_TAG (PCHAR) "STREAM"
 /**
  * Kinesis Video client states definitions

--- a/src/client/src/Include_i.h
+++ b/src/client/src/Include_i.h
@@ -108,6 +108,8 @@ typedef STATUS (*KinesisVideoClientCallbackHookFunc)(UINT64);
  */
 #define KINESIS_VIDEO_CLIENT_CURRENT_VERSION 0
 
+#define CLIENT_STATE_MACHINE_TAG (PCHAR) "wbrHJpxXZKAlXWPJzEEDUFlxeQOLAzjw"
+#define STREAM_STATE_MACHINE_TAG (PCHAR) "STREAM"
 /**
  * Kinesis Video client states definitions
  */

--- a/src/client/src/Include_i.h
+++ b/src/client/src/Include_i.h
@@ -108,8 +108,8 @@ typedef STATUS (*KinesisVideoClientCallbackHookFunc)(UINT64);
  */
 #define KINESIS_VIDEO_CLIENT_CURRENT_VERSION 0
 
-#define CLIENT_STATE_MACHINE_TAG (PCHAR) "CLIENT"
-#define STREAM_STATE_MACHINE_TAG (PCHAR) "STREAM"
+#define CLIENT_STATE_MACHINE_NAME (PCHAR) "CLIENT"
+#define STREAM_STATE_MACHINE_NAME (PCHAR) "STREAM"
 /**
  * Kinesis Video client states definitions
  */

--- a/src/client/src/Stream.c
+++ b/src/client/src/Stream.c
@@ -246,9 +246,9 @@ STATUS createStream(PKinesisVideoClient pKinesisVideoClient, PStreamInfo pStream
     CHK_STATUS(generateEosMetadata(pKinesisVideoStream));
 
     // Create the state machine
-    CHK_STATUS(createStateMachineWithTag(STREAM_STATE_MACHINE_STATES, STREAM_STATE_MACHINE_STATE_COUNT, TO_CUSTOM_DATA(pKinesisVideoStream),
-                                         pKinesisVideoClient->clientCallbacks.getCurrentTimeFn, pKinesisVideoClient->clientCallbacks.customData,
-                                         STREAM_STATE_MACHINE_TAG, &pStateMachine));
+    CHK_STATUS(createStateMachineWithName(STREAM_STATE_MACHINE_STATES, STREAM_STATE_MACHINE_STATE_COUNT, TO_CUSTOM_DATA(pKinesisVideoStream),
+                                          pKinesisVideoClient->clientCallbacks.getCurrentTimeFn, pKinesisVideoClient->clientCallbacks.customData,
+                                          STREAM_STATE_MACHINE_NAME, &pStateMachine));
     pKinesisVideoStream->base.pStateMachine = pStateMachine;
 
     // Create the stream upload handle queue

--- a/src/client/src/Stream.c
+++ b/src/client/src/Stream.c
@@ -246,10 +246,9 @@ STATUS createStream(PKinesisVideoClient pKinesisVideoClient, PStreamInfo pStream
     CHK_STATUS(generateEosMetadata(pKinesisVideoStream));
 
     // Create the state machine
-    CHK_STATUS(createStateMachine(STREAM_STATE_MACHINE_STATES, STREAM_STATE_MACHINE_STATE_COUNT, TO_CUSTOM_DATA(pKinesisVideoStream),
-                                  pKinesisVideoClient->clientCallbacks.getCurrentTimeFn, pKinesisVideoClient->clientCallbacks.customData,
-                                  &pStateMachine));
-    setStateMachineTag(pStateMachine, STREAM_STATE_MACHINE_TAG);
+    CHK_STATUS(createStateMachineWithTag(STREAM_STATE_MACHINE_STATES, STREAM_STATE_MACHINE_STATE_COUNT, TO_CUSTOM_DATA(pKinesisVideoStream),
+                                         pKinesisVideoClient->clientCallbacks.getCurrentTimeFn, pKinesisVideoClient->clientCallbacks.customData,
+                                         STREAM_STATE_MACHINE_TAG, &pStateMachine));
     pKinesisVideoStream->base.pStateMachine = pStateMachine;
 
     // Create the stream upload handle queue

--- a/src/client/src/Stream.c
+++ b/src/client/src/Stream.c
@@ -249,6 +249,7 @@ STATUS createStream(PKinesisVideoClient pKinesisVideoClient, PStreamInfo pStream
     CHK_STATUS(createStateMachine(STREAM_STATE_MACHINE_STATES, STREAM_STATE_MACHINE_STATE_COUNT, TO_CUSTOM_DATA(pKinesisVideoStream),
                                   pKinesisVideoClient->clientCallbacks.getCurrentTimeFn, pKinesisVideoClient->clientCallbacks.customData,
                                   &pStateMachine));
+    setStateMachineTag(pStateMachine, STREAM_STATE_MACHINE_TAG);
     pKinesisVideoStream->base.pStateMachine = pStateMachine;
 
     // Create the stream upload handle queue

--- a/src/state/include/com/amazonaws/kinesis/video/state/Include.h
+++ b/src/state/include/com/amazonaws/kinesis/video/state/Include.h
@@ -25,6 +25,7 @@ extern "C" {
 #define STATUS_STATE_BASE                    0x52000000
 #define STATUS_INVALID_STREAM_STATE          STATUS_STATE_BASE + 0x0000000e
 #define STATUS_STATE_MACHINE_STATE_NOT_FOUND STATUS_STATE_BASE + 0x00000056
+#define STATUS_STATE_MACHINE_TAG_NAME_LEN    STATUS_STATE_BASE + 0x0000009a // 0x00000057 to 0x0000008f used with STATUS_CLIENT_BASE
 
 ////////////////////////////////////////////////////
 // Main structure declarations
@@ -43,11 +44,6 @@ extern "C" {
  * State machine current version
  */
 #define STATE_MACHINE_CURRENT_VERSION 0
-
-/**
- * Default state machine tag
- */
-#define DEFAULT_STATE_MACHINE_TAG (PCHAR) "KVS_STATE"
 
 /**
  * Maximum state tag length
@@ -115,6 +111,7 @@ typedef struct __StateMachine* PStateMachine;
 ////////////////////////////////////////////////////
 
 PUBLIC_API STATUS createStateMachine(PStateMachineState, UINT32, UINT64, GetCurrentTimeFunc, UINT64, PStateMachine*);
+PUBLIC_API STATUS createStateMachineWithTag(PStateMachineState, UINT32, UINT64, GetCurrentTimeFunc, UINT64, PCHAR, PStateMachine*);
 PUBLIC_API STATUS freeStateMachine(PStateMachine);
 PUBLIC_API STATUS stepStateMachine(PStateMachine);
 PUBLIC_API STATUS acceptStateMachineState(PStateMachine, UINT64);
@@ -123,7 +120,6 @@ PUBLIC_API STATUS getStateMachineCurrentState(PStateMachine, PStateMachineState*
 PUBLIC_API STATUS setStateMachineCurrentState(PStateMachine, UINT64);
 PUBLIC_API STATUS resetStateMachineRetryCount(PStateMachine);
 PUBLIC_API STATUS checkForStateTransition(PStateMachine, PBOOL);
-PUBLIC_API STATUS setStateMachineTag(PStateMachine, PCHAR);
 PUBLIC_API PCHAR getStateMachineTag(PStateMachine);
 
 static const ExponentialBackoffRetryStrategyConfig DEFAULT_STATE_MACHINE_EXPONENTIAL_BACKOFF_RETRY_CONFIGURATION = {

--- a/src/state/include/com/amazonaws/kinesis/video/state/Include.h
+++ b/src/state/include/com/amazonaws/kinesis/video/state/Include.h
@@ -25,7 +25,7 @@ extern "C" {
 #define STATUS_STATE_BASE                    0x52000000
 #define STATUS_INVALID_STREAM_STATE          STATUS_STATE_BASE + 0x0000000e
 #define STATUS_STATE_MACHINE_STATE_NOT_FOUND STATUS_STATE_BASE + 0x00000056
-#define STATUS_STATE_MACHINE_TAG_NAME_LEN    STATUS_STATE_BASE + 0x0000009a // 0x00000057 to 0x0000008f used with STATUS_CLIENT_BASE
+#define STATUS_STATE_MACHINE_NAME_LEN        STATUS_STATE_BASE + 0x0000009a // 0x00000057 to 0x0000008f used with STATUS_CLIENT_BASE
 
 ////////////////////////////////////////////////////
 // Main structure declarations
@@ -46,9 +46,9 @@ extern "C" {
 #define STATE_MACHINE_CURRENT_VERSION 0
 
 /**
- * Maximum state tag length
+ * Maximum state machine name length
  */
-#define MAX_STATE_TAG_LENGTH 32
+#define MAX_STATE_MACHINE_NAME_LENGTH 32
 
 /**
  * State transition function definitions
@@ -110,17 +110,114 @@ typedef struct __StateMachine* PStateMachine;
 // Public functions
 ////////////////////////////////////////////////////
 
+/**
+ * Creates the state machine object
+ *
+ * @param 1 PStateMachineState - IN - List of state machine details on states, state transition functions and valid state transition list (mandatory)
+ * @param 2 UINT32 - IN - stateCount - Number of entries in the PStateMachineState list (mandatory)
+ * @param 3 UINT64 - IN - customData - application specific data that needs to be passed around (optional)
+ * @param 4 GetCurrentTimeFunc - IN - custom get time function that the state machine should use to state transition wait time (optional)
+ * @param 5 UINT64 - IN - getCurrentTimeFuncCustomData - custom data for getCurrentTimeFunc (optional)
+ * @param 6 PStateMachine - OUT - Allocated state machine object
+ *
+ * @return - STATUS code of the execution
+ */
 PUBLIC_API STATUS createStateMachine(PStateMachineState, UINT32, UINT64, GetCurrentTimeFunc, UINT64, PStateMachine*);
-PUBLIC_API STATUS createStateMachineWithTag(PStateMachineState, UINT32, UINT64, GetCurrentTimeFunc, UINT64, PCHAR, PStateMachine*);
+
+/**
+ * Creates a state machine with a state machine name string to identify the state machine. State machine name is mandatory
+ * if using this API and cannot exceed 32 characters
+ *
+ * @param 1 PStateMachineState - IN - List of state machine details on states, state transition functions and valid state transition list (mandatory)
+ * @param 2 UINT32 - IN - stateCount - Number of entries in the PStateMachineState list (mandatory)
+ * @param 3 UINT64 - IN - customData - application specific data that needs to be passed around (optional)
+ * @param 4 GetCurrentTimeFunc - IN - custom get time function that the state machine should use to state transition wait time (optional)
+ * @param 5 UINT64 - IN - getCurrentTimeFuncCustomData - custom data for getCurrentTimeFunc (optional)
+ * @param 6 PCHAR - IN - pStateMachineName - name for the state machine. This will be used in the logs to uniquely identify a state machine (useful
+ * when there are multiple state machines running simultaneously
+ * @param 6 PStateMachine - OUT - Allocated state machine object
+ *
+ * @return - STATUS code of the execution
+ */
+PUBLIC_API STATUS createStateMachineWithName(PStateMachineState, UINT32, UINT64, GetCurrentTimeFunc, UINT64, PCHAR, PStateMachine*);
+
+/**
+ * Free the state machine object
+ * @param 1 PStateMachine - IN - State machine object to be deallocated
+ *
+ * @return - STATUS code of the execution
+ */
 PUBLIC_API STATUS freeStateMachine(PStateMachine);
+
+/**
+ * Step to next valid state in a state machine.
+ * @param 1 PStateMachine - IN - State machine object
+ *
+ * @return - STATUS code of the execution
+ */
 PUBLIC_API STATUS stepStateMachine(PStateMachine);
+
+/**
+ * Checks whether the next state machine state is in the list of accepted states
+ * @param 1 PStateMachine - IN - State machine object
+ * @param 2 UINT64 - IN - requiredStates - ORed list of allowed states to transition to a particular state
+ *
+ * @return - STATUS code of the execution
+ */
 PUBLIC_API STATUS acceptStateMachineState(PStateMachine, UINT64);
+
+/**
+ * Validate if the next state can accept the current state before transitioning
+ * @param 1 PStateMachine - IN - State machine object
+ * @param 2 UINT64 - IN - state - The next state to transition to
+ * @param 3 PStateMachineState - OUT - Pointer to the state object given it's state
+ *
+ * @return - STATUS code of the execution
+ */
 PUBLIC_API STATUS getStateMachineState(PStateMachine, UINT64, PStateMachineState*);
+
+/**
+ * Gets a pointer to the current state object
+ * @param 1 PStateMachine - IN - State machine object
+ * @param 3 PStateMachineState - OUT - Pointer to the state object for the current state
+ *
+ * @return - STATUS code of the execution
+ */
 PUBLIC_API STATUS getStateMachineCurrentState(PStateMachine, PStateMachineState*);
+
+/**
+ * Force sets a pointer to the current state object
+ * @param 1 PStateMachine - IN - State machine object
+ * @param 3 UINT64 - IN - state - Set state machine to a particular state
+ *
+ * @return - STATUS code of the execution
+ */
 PUBLIC_API STATUS setStateMachineCurrentState(PStateMachine, UINT64);
+
+/**
+ * Resets the state machine retry count
+ * @param 1 PStateMachine - IN - State machine object to be deallocated
+ *
+ * @return - STATUS code of the execution
+ */
 PUBLIC_API STATUS resetStateMachineRetryCount(PStateMachine);
+
+/**
+ * Calls the from function of the current state to determine if the state machine is ready to
+ * move on to another state.
+ * @param 1 PStateMachine - IN - State machine object to be deallocated
+ * @param 2 PBOOL - OUT - Returns TRUE if state machine is ready to transition, else false
+ *
+ * @return - STATUS code of the execution
+ */
 PUBLIC_API STATUS checkForStateTransition(PStateMachine, PBOOL);
-PUBLIC_API PCHAR getStateMachineTag(PStateMachine);
+
+/**
+ * Return state machine name set up
+ * @param 1 PStateMachine - IN - State machine object to be deallocated
+ * @return - Returns the name set for the state machine
+ */
+PUBLIC_API const PCHAR getStateMachineName(PStateMachine);
 
 static const ExponentialBackoffRetryStrategyConfig DEFAULT_STATE_MACHINE_EXPONENTIAL_BACKOFF_RETRY_CONFIGURATION = {
     /* Exponential wait times with this config will look like following -

--- a/src/state/include/com/amazonaws/kinesis/video/state/Include.h
+++ b/src/state/include/com/amazonaws/kinesis/video/state/Include.h
@@ -113,6 +113,7 @@ PUBLIC_API STATUS getStateMachineCurrentState(PStateMachine, PStateMachineState*
 PUBLIC_API STATUS setStateMachineCurrentState(PStateMachine, UINT64);
 PUBLIC_API STATUS resetStateMachineRetryCount(PStateMachine);
 PUBLIC_API STATUS checkForStateTransition(PStateMachine, PBOOL);
+PUBLIC_API STATUS setStateMachineTag(PStateMachine, PCHAR);
 
 static const ExponentialBackoffRetryStrategyConfig DEFAULT_STATE_MACHINE_EXPONENTIAL_BACKOFF_RETRY_CONFIGURATION = {
     /* Exponential wait times with this config will look like following -

--- a/src/state/include/com/amazonaws/kinesis/video/state/Include.h
+++ b/src/state/include/com/amazonaws/kinesis/video/state/Include.h
@@ -45,6 +45,16 @@ extern "C" {
 #define STATE_MACHINE_CURRENT_VERSION 0
 
 /**
+ * Default state machine tag
+ */
+#define DEFAULT_STATE_MACHINE_TAG (PCHAR) "KVS_STATE"
+
+/**
+ * Maximum state tag length
+ */
+#define MAX_STATE_TAG_LENGTH 32
+
+/**
  * State transition function definitions
  *
  * @param 1 UINT64 - IN - Custom data passed in
@@ -114,6 +124,7 @@ PUBLIC_API STATUS setStateMachineCurrentState(PStateMachine, UINT64);
 PUBLIC_API STATUS resetStateMachineRetryCount(PStateMachine);
 PUBLIC_API STATUS checkForStateTransition(PStateMachine, PBOOL);
 PUBLIC_API STATUS setStateMachineTag(PStateMachine, PCHAR);
+PUBLIC_API PCHAR getStateMachineTag(PStateMachine);
 
 static const ExponentialBackoffRetryStrategyConfig DEFAULT_STATE_MACHINE_EXPONENTIAL_BACKOFF_RETRY_CONFIGURATION = {
     /* Exponential wait times with this config will look like following -

--- a/src/state/include/com/amazonaws/kinesis/video/state/Include.h
+++ b/src/state/include/com/amazonaws/kinesis/video/state/Include.h
@@ -22,10 +22,10 @@ extern "C" {
 ////////////////////////////////////////////////////
 // Status return codes
 ////////////////////////////////////////////////////
-#define STATUS_STATE_BASE                    0x52000000
-#define STATUS_INVALID_STREAM_STATE          STATUS_STATE_BASE + 0x0000000e
-#define STATUS_STATE_MACHINE_STATE_NOT_FOUND STATUS_STATE_BASE + 0x00000056
-#define STATUS_STATE_MACHINE_NAME_LEN        STATUS_STATE_BASE + 0x0000009a // 0x00000057 to 0x0000008f used with STATUS_CLIENT_BASE
+#define STATUS_STATE_BASE                     0x52000000
+#define STATUS_INVALID_STREAM_STATE           STATUS_STATE_BASE + 0x0000000e
+#define STATUS_STATE_MACHINE_STATE_NOT_FOUND  STATUS_STATE_BASE + 0x00000056
+#define STATUS_STATE_MACHINE_NAME_LEN_INVALID STATUS_STATE_BASE + 0x0000009a // 0x00000057 to 0x0000008f used with STATUS_CLIENT_BASE
 
 ////////////////////////////////////////////////////
 // Main structure declarations
@@ -126,7 +126,7 @@ PUBLIC_API STATUS createStateMachine(PStateMachineState, UINT32, UINT64, GetCurr
 
 /**
  * Creates a state machine with a state machine name string to identify the state machine. State machine name is mandatory
- * if using this API and cannot exceed 32 characters
+ * if using this API and cannot exceed 32 characters and cannot be an empty string
  *
  * @param 1 PStateMachineState - IN - List of state machine details on states, state transition functions and valid state transition list (mandatory)
  * @param 2 UINT32 - IN - stateCount - Number of entries in the PStateMachineState list (mandatory)

--- a/src/state/src/Include_i.h
+++ b/src/state/src/Include_i.h
@@ -62,7 +62,7 @@ struct __StateMachineImpl {
     // State machine state count
     UINT32 stateCount;
 
-    PCHAR stateTag;
+    CHAR stateTag[32];
 
     // State machine states following the main structure
     PStateMachineState states;

--- a/src/state/src/Include_i.h
+++ b/src/state/src/Include_i.h
@@ -23,8 +23,8 @@ extern "C" {
  */
 #define NEXT_SERVICE_CALL_RETRY_DELAY(r) (((UINT64) 1 << (r)) * SERVICE_CALL_RETRY_TIMEOUT)
 
-#define DEFAULT_STATE_MACHINE_TAG   (PCHAR) "KVS_STATE"
-#define MAX_STATE_TAG_LENGTH        32
+#define DEFAULT_STATE_MACHINE_TAG (PCHAR) "KVS_STATE"
+#define MAX_STATE_TAG_LENGTH      32
 /**
  * State Machine context
  */

--- a/src/state/src/Include_i.h
+++ b/src/state/src/Include_i.h
@@ -62,6 +62,8 @@ struct __StateMachineImpl {
     // State machine state count
     UINT32 stateCount;
 
+    PCHAR stateTag;
+
     // State machine states following the main structure
     PStateMachineState states;
 };

--- a/src/state/src/Include_i.h
+++ b/src/state/src/Include_i.h
@@ -62,7 +62,7 @@ struct __StateMachineImpl {
     // State machine state count
     UINT32 stateCount;
 
-    CHAR stateTag[32];
+    CHAR stateTag[MAX_STATE_TAG_LENGTH + 1];
 
     // State machine states following the main structure
     PStateMachineState states;

--- a/src/state/src/Include_i.h
+++ b/src/state/src/Include_i.h
@@ -62,7 +62,7 @@ struct __StateMachineImpl {
     // State machine state count
     UINT32 stateCount;
 
-    CHAR stateTag[MAX_STATE_TAG_LENGTH + 1];
+    CHAR stateMachineName[MAX_STATE_MACHINE_NAME_LENGTH + 1];
 
     // State machine states following the main structure
     PStateMachineState states;

--- a/src/state/src/Include_i.h
+++ b/src/state/src/Include_i.h
@@ -23,6 +23,8 @@ extern "C" {
  */
 #define NEXT_SERVICE_CALL_RETRY_DELAY(r) (((UINT64) 1 << (r)) * SERVICE_CALL_RETRY_TIMEOUT)
 
+#define DEFAULT_STATE_MACHINE_TAG   (PCHAR) "KVS_STATE"
+#define MAX_STATE_TAG_LENGTH        32
 /**
  * State Machine context
  */

--- a/src/state/src/Include_i.h
+++ b/src/state/src/Include_i.h
@@ -23,8 +23,6 @@ extern "C" {
  */
 #define NEXT_SERVICE_CALL_RETRY_DELAY(r) (((UINT64) 1 << (r)) * SERVICE_CALL_RETRY_TIMEOUT)
 
-#define DEFAULT_STATE_MACHINE_TAG (PCHAR) "KVS_STATE"
-#define MAX_STATE_TAG_LENGTH      32
 /**
  * State Machine context
  */

--- a/src/state/src/State.c
+++ b/src/state/src/State.c
@@ -302,7 +302,8 @@ CleanUp:
     return retStatus;
 }
 
-STATUS setStateMachineTag(PStateMachine pStateMachine, PCHAR stateTag) {
+STATUS setStateMachineTag(PStateMachine pStateMachine, PCHAR stateTag)
+{
     STATUS retStatus = STATUS_SUCCESS;
     PStateMachineImpl pStateMachineImpl = (PStateMachineImpl) pStateMachine;
     CHK_WARN(pStateMachineImpl != NULL, STATUS_NULL_ARG, "State machine object not created. Cannot set tag");

--- a/src/state/src/State.c
+++ b/src/state/src/State.c
@@ -171,7 +171,7 @@ STATUS stepStateMachine(PStateMachine pStateMachine)
         pStateMachineImpl->context.localStateRetryCount++;
     }
 
-    DLOGD("[%s] State Machine - Current state: 0x%016" PRIx64 ", Next state: 0x%016" PRIx64 ", "
+    DLOGV("[%s] State Machine - Current state: 0x%016" PRIx64 ", Next state: 0x%016" PRIx64 ", "
           "Current local state retry count [%u], Max local state retry count [%u], State transition wait time [%u] ms",
           pStateMachineImpl->stateTag, pStateMachineImpl->context.pCurrentState->state, nextState, pStateMachineImpl->context.localStateRetryCount,
           pState->maxLocalStateRetryCount, errorStateTransitionWaitTime / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
@@ -311,4 +311,16 @@ STATUS setStateMachineTag(PStateMachine pStateMachine, PCHAR stateTag)
     pStateMachineImpl->stateTag[MAX_STATE_TAG_LENGTH - 1] = '\0';
 CleanUp:
     return retStatus;
+}
+
+// This function is useful for unit tests
+PCHAR getStateMachineTag(PStateMachine pStateMachine)
+{
+    PStateMachineImpl pStateMachineImpl = (PStateMachineImpl) pStateMachine;
+    if (pStateMachineImpl != NULL) {
+        return pStateMachineImpl->stateTag;
+    } else {
+        DLOGW("State machine object not created. Cannot retrieve tag");
+        return NULL;
+    }
 }

--- a/src/state/src/State.c
+++ b/src/state/src/State.c
@@ -31,6 +31,8 @@ STATUS createStateMachine(PStateMachineState pStates, UINT32 stateCount, UINT64 
     pStateMachine->getCurrentTimeFuncCustomData = getCurrentTimeFuncCustomData;
     pStateMachine->stateCount = stateCount;
     pStateMachine->customData = customData;
+    STRNCPY(pStateMachine->stateTag, DEFAULT_STATE_MACHINE_TAG, MAX_STATE_TAG_LENGTH - 1);
+    pStateMachine->stateTag[MAX_STATE_TAG_LENGTH - 1] = '\0';
 
     // Set the states pointer and copy the globals
     pStateMachine->states = (PStateMachineState) (pStateMachine + 1);
@@ -303,9 +305,9 @@ CleanUp:
 STATUS setStateMachineTag(PStateMachine pStateMachine, PCHAR stateTag) {
     STATUS retStatus = STATUS_SUCCESS;
     PStateMachineImpl pStateMachineImpl = (PStateMachineImpl) pStateMachine;
-    DLOGI("Here");
     CHK_WARN(pStateMachineImpl != NULL, STATUS_NULL_ARG, "State machine object not created. Cannot set tag");
-    STRCPY(pStateMachineImpl->stateTag, stateTag);
+    STRNCPY(pStateMachineImpl->stateTag, stateTag, MAX_STATE_TAG_LENGTH - 1);
+    pStateMachineImpl->stateTag[MAX_STATE_TAG_LENGTH - 1] = '\0';
 CleanUp:
     return retStatus;
 }

--- a/src/state/src/State.c
+++ b/src/state/src/State.c
@@ -303,6 +303,7 @@ CleanUp:
 STATUS setStateMachineTag(PStateMachine pStateMachine, PCHAR stateTag) {
     STATUS retStatus = STATUS_SUCCESS;
     PStateMachineImpl pStateMachineImpl = (PStateMachineImpl) pStateMachine;
+    DLOGI("Here");
     CHK_WARN(pStateMachineImpl != NULL, STATUS_NULL_ARG, "State machine object not created. Cannot set tag");
     STRCPY(pStateMachineImpl->stateTag, stateTag);
 CleanUp:

--- a/src/state/src/State.c
+++ b/src/state/src/State.c
@@ -169,9 +169,9 @@ STATUS stepStateMachine(PStateMachine pStateMachine)
         pStateMachineImpl->context.localStateRetryCount++;
     }
 
-    DLOGV("State Machine - Current state: 0x%016" PRIx64 ", Next state: 0x%016" PRIx64 ", "
+    DLOGD("[%s] State Machine - Current state: 0x%016" PRIx64 ", Next state: 0x%016" PRIx64 ", "
           "Current local state retry count [%u], Max local state retry count [%u], State transition wait time [%u] ms",
-          pStateMachineImpl->context.pCurrentState->state, nextState, pStateMachineImpl->context.localStateRetryCount,
+          pStateMachineImpl->stateTag, pStateMachineImpl->context.pCurrentState->state, nextState, pStateMachineImpl->context.localStateRetryCount,
           pState->maxLocalStateRetryCount, errorStateTransitionWaitTime / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
 
     // Check if we have tried enough times within the same state
@@ -297,5 +297,14 @@ STATUS checkForStateTransition(PStateMachine pStateMachine, PBOOL pTransitionRea
 CleanUp:
 
     LEAVES();
+    return retStatus;
+}
+
+STATUS setStateMachineTag(PStateMachine pStateMachine, PCHAR stateTag) {
+    STATUS retStatus = STATUS_SUCCESS;
+    PStateMachineImpl pStateMachineImpl = (PStateMachineImpl) pStateMachine;
+    CHK_WARN(pStateMachineImpl != NULL, STATUS_NULL_ARG, "State machine object not created. Cannot set tag");
+    STRCPY(pStateMachineImpl->stateTag, stateTag);
+CleanUp:
     return retStatus;
 }

--- a/tst/state/StateApiTest.cpp
+++ b/tst/state/StateApiTest.cpp
@@ -90,7 +90,11 @@ TEST_F(StateApiTest, createStateMachineWithName_InvalidArg)
                                                         (UINT64) this, kinesisVideoStreamDefaultGetCurrentTime,
                                                         (UINT64) this, NULL, &pStateMachine));
     EXPECT_EQ(NULL, getStateMachineName(pStateMachine));
-    EXPECT_EQ(STATUS_STATE_MACHINE_NAME_LEN, createStateMachineWithName(TEST_STATE_MACHINE_STATES, TEST_STATE_MACHINE_STATE_COUNT,
+    EXPECT_EQ(STATUS_STATE_MACHINE_NAME_LEN_INVALID, createStateMachineWithName(TEST_STATE_MACHINE_STATES, TEST_STATE_MACHINE_STATE_COUNT,
+                                                          (UINT64) this, kinesisVideoStreamDefaultGetCurrentTime,
+                                                          (UINT64) this, (PCHAR)"", &pStateMachine));
+    EXPECT_EQ(NULL, getStateMachineName(pStateMachine));
+    EXPECT_EQ(STATUS_STATE_MACHINE_NAME_LEN_INVALID, createStateMachineWithName(TEST_STATE_MACHINE_STATES, TEST_STATE_MACHINE_STATE_COUNT,
                                                                            (UINT64) this, kinesisVideoStreamDefaultGetCurrentTime,
                                                                            (UINT64) this, longRandomName, &pStateMachine));
     EXPECT_EQ(STATUS_SUCCESS, freeStateMachine(pStateMachine));

--- a/tst/state/StateApiTest.cpp
+++ b/tst/state/StateApiTest.cpp
@@ -82,23 +82,32 @@ TEST_F(StateApiTest, checkForStateTransition_InvalidInput)
     EXPECT_EQ(STATUS_SUCCESS, checkForStateTransition(mStateMachine, &testBool));
 }
 
-TEST_F(StateApiTest, setStateMachineTag_NullArg)
+TEST_F(StateApiTest, createStateMachineWithTag_InvalidArg)
 {
     PStateMachine pStateMachine = NULL;
-    EXPECT_EQ(STATUS_NULL_ARG, setStateMachineTag(pStateMachine, (PCHAR) "Test"));
+    CHAR longRandomTag[34] = "abcdefghijklmnopqrstuvwxyzABCDEFG";
+    EXPECT_EQ(STATUS_NULL_ARG, createStateMachineWithTag(TEST_STATE_MACHINE_STATES, TEST_STATE_MACHINE_STATE_COUNT,
+                                                        (UINT64) this, kinesisVideoStreamDefaultGetCurrentTime,
+                                                        (UINT64) this, NULL, &pStateMachine));
+    EXPECT_EQ(NULL, getStateMachineTag(pStateMachine));
+    EXPECT_EQ(STATUS_STATE_MACHINE_TAG_NAME_LEN, createStateMachineWithTag(TEST_STATE_MACHINE_STATES, TEST_STATE_MACHINE_STATE_COUNT,
+                                                                           (UINT64) this, kinesisVideoStreamDefaultGetCurrentTime,
+                                                                           (UINT64) this, longRandomTag, &pStateMachine));
+    EXPECT_EQ(STATUS_SUCCESS, freeStateMachine(pStateMachine));
 }
 
-TEST_F(StateApiTest, setStateMachineTag_ValidArg)
+TEST_F(StateApiTest, createStateMachineWithTag_ValidArg)
 {
     PStateMachine pStateMachine;
-    CHAR longRandomTag[33] = "abcdefghijklmnopqrstuvwxyzABCDEF";
-    EXPECT_EQ(STATUS_SUCCESS, createStateMachine(TEST_STATE_MACHINE_STATES, TEST_STATE_MACHINE_STATE_COUNT,
+    CHAR maxLengthRandomTag[33] = "abcdefghijklmnopqrstuvwxyzABCDEF";
+    EXPECT_EQ(STATUS_SUCCESS, createStateMachineWithTag(TEST_STATE_MACHINE_STATES, TEST_STATE_MACHINE_STATE_COUNT,
                                                  (UINT64) this, kinesisVideoStreamDefaultGetCurrentTime,
-                                                 (UINT64) this, &pStateMachine));
-    EXPECT_STREQ(DEFAULT_STATE_MACHINE_TAG, getStateMachineTag(pStateMachine));
-    EXPECT_EQ(STATUS_SUCCESS, setStateMachineTag(pStateMachine, (PCHAR) "Test"));
+                                                 (UINT64) this, (PCHAR) "Test", &pStateMachine));
     EXPECT_STREQ("Test", getStateMachineTag(pStateMachine));
-    EXPECT_EQ(STATUS_SUCCESS, setStateMachineTag(pStateMachine, longRandomTag));
-    EXPECT_STRNE(longRandomTag, getStateMachineTag(pStateMachine));
+    EXPECT_EQ(STATUS_SUCCESS, freeStateMachine(pStateMachine));
+    EXPECT_EQ(STATUS_SUCCESS, createStateMachineWithTag(TEST_STATE_MACHINE_STATES, TEST_STATE_MACHINE_STATE_COUNT,
+                                                        (UINT64) this, kinesisVideoStreamDefaultGetCurrentTime,
+                                                        (UINT64) this, maxLengthRandomTag, &pStateMachine));
+    EXPECT_STREQ(maxLengthRandomTag, getStateMachineTag(pStateMachine));
     EXPECT_EQ(STATUS_SUCCESS, freeStateMachine(pStateMachine));
 }

--- a/tst/state/StateApiTest.cpp
+++ b/tst/state/StateApiTest.cpp
@@ -100,4 +100,5 @@ TEST_F(StateApiTest, setStateMachineTag_ValidArg)
     EXPECT_STREQ("Test", getStateMachineTag(pStateMachine));
     EXPECT_EQ(STATUS_SUCCESS, setStateMachineTag(pStateMachine, longRandomTag));
     EXPECT_STRNE(longRandomTag, getStateMachineTag(pStateMachine));
+    EXPECT_EQ(STATUS_SUCCESS, freeStateMachine(pStateMachine));
 }

--- a/tst/state/StateApiTest.cpp
+++ b/tst/state/StateApiTest.cpp
@@ -82,32 +82,32 @@ TEST_F(StateApiTest, checkForStateTransition_InvalidInput)
     EXPECT_EQ(STATUS_SUCCESS, checkForStateTransition(mStateMachine, &testBool));
 }
 
-TEST_F(StateApiTest, createStateMachineWithTag_InvalidArg)
+TEST_F(StateApiTest, createStateMachineWithName_InvalidArg)
 {
     PStateMachine pStateMachine = NULL;
-    CHAR longRandomTag[34] = "abcdefghijklmnopqrstuvwxyzABCDEFG";
-    EXPECT_EQ(STATUS_NULL_ARG, createStateMachineWithTag(TEST_STATE_MACHINE_STATES, TEST_STATE_MACHINE_STATE_COUNT,
+    CHAR longRandomName[34] = "abcdefghijklmnopqrstuvwxyzABCDEFG";
+    EXPECT_EQ(STATUS_NULL_ARG, createStateMachineWithName(TEST_STATE_MACHINE_STATES, TEST_STATE_MACHINE_STATE_COUNT,
                                                         (UINT64) this, kinesisVideoStreamDefaultGetCurrentTime,
                                                         (UINT64) this, NULL, &pStateMachine));
-    EXPECT_EQ(NULL, getStateMachineTag(pStateMachine));
-    EXPECT_EQ(STATUS_STATE_MACHINE_TAG_NAME_LEN, createStateMachineWithTag(TEST_STATE_MACHINE_STATES, TEST_STATE_MACHINE_STATE_COUNT,
+    EXPECT_EQ(NULL, getStateMachineName(pStateMachine));
+    EXPECT_EQ(STATUS_STATE_MACHINE_NAME_LEN, createStateMachineWithName(TEST_STATE_MACHINE_STATES, TEST_STATE_MACHINE_STATE_COUNT,
                                                                            (UINT64) this, kinesisVideoStreamDefaultGetCurrentTime,
-                                                                           (UINT64) this, longRandomTag, &pStateMachine));
+                                                                           (UINT64) this, longRandomName, &pStateMachine));
     EXPECT_EQ(STATUS_SUCCESS, freeStateMachine(pStateMachine));
 }
 
-TEST_F(StateApiTest, createStateMachineWithTag_ValidArg)
+TEST_F(StateApiTest, createStateMachineWithName_ValidArg)
 {
     PStateMachine pStateMachine;
-    CHAR maxLengthRandomTag[33] = "abcdefghijklmnopqrstuvwxyzABCDEF";
-    EXPECT_EQ(STATUS_SUCCESS, createStateMachineWithTag(TEST_STATE_MACHINE_STATES, TEST_STATE_MACHINE_STATE_COUNT,
+    CHAR maxLengthRandomName[33] = "abcdefghijklmnopqrstuvwxyzABCDEF";
+    EXPECT_EQ(STATUS_SUCCESS, createStateMachineWithName(TEST_STATE_MACHINE_STATES, TEST_STATE_MACHINE_STATE_COUNT,
                                                  (UINT64) this, kinesisVideoStreamDefaultGetCurrentTime,
                                                  (UINT64) this, (PCHAR) "Test", &pStateMachine));
-    EXPECT_STREQ("Test", getStateMachineTag(pStateMachine));
+    EXPECT_STREQ("Test", getStateMachineName(pStateMachine));
     EXPECT_EQ(STATUS_SUCCESS, freeStateMachine(pStateMachine));
-    EXPECT_EQ(STATUS_SUCCESS, createStateMachineWithTag(TEST_STATE_MACHINE_STATES, TEST_STATE_MACHINE_STATE_COUNT,
+    EXPECT_EQ(STATUS_SUCCESS, createStateMachineWithName(TEST_STATE_MACHINE_STATES, TEST_STATE_MACHINE_STATE_COUNT,
                                                         (UINT64) this, kinesisVideoStreamDefaultGetCurrentTime,
-                                                        (UINT64) this, maxLengthRandomTag, &pStateMachine));
-    EXPECT_STREQ(maxLengthRandomTag, getStateMachineTag(pStateMachine));
+                                                        (UINT64) this, maxLengthRandomName, &pStateMachine));
+    EXPECT_STREQ(maxLengthRandomName, getStateMachineName(pStateMachine));
     EXPECT_EQ(STATUS_SUCCESS, freeStateMachine(pStateMachine));
 }

--- a/tst/state/StateApiTest.cpp
+++ b/tst/state/StateApiTest.cpp
@@ -81,3 +81,23 @@ TEST_F(StateApiTest, checkForStateTransition_InvalidInput)
 
     EXPECT_EQ(STATUS_SUCCESS, checkForStateTransition(mStateMachine, &testBool));
 }
+
+TEST_F(StateApiTest, setStateMachineTag_NullArg)
+{
+    PStateMachine pStateMachine = NULL;
+    EXPECT_EQ(STATUS_NULL_ARG, setStateMachineTag(pStateMachine, (PCHAR) "Test"));
+}
+
+TEST_F(StateApiTest, setStateMachineTag_ValidArg)
+{
+    PStateMachine pStateMachine;
+    CHAR longRandomTag[33] = "abcdefghijklmnopqrstuvwxyzABCDEF";
+    EXPECT_EQ(STATUS_SUCCESS, createStateMachine(TEST_STATE_MACHINE_STATES, TEST_STATE_MACHINE_STATE_COUNT,
+                                                 (UINT64) this, kinesisVideoStreamDefaultGetCurrentTime,
+                                                 (UINT64) this, &pStateMachine));
+    EXPECT_STREQ(DEFAULT_STATE_MACHINE_TAG, getStateMachineTag(pStateMachine));
+    EXPECT_EQ(STATUS_SUCCESS, setStateMachineTag(pStateMachine, (PCHAR) "Test"));
+    EXPECT_STREQ("Test", getStateMachineTag(pStateMachine));
+    EXPECT_EQ(STATUS_SUCCESS, setStateMachineTag(pStateMachine, longRandomTag));
+    EXPECT_STRNE(longRandomTag, getStateMachineTag(pStateMachine));
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*What was changed?*

- Added a new API to allow setting tags for state machine logs.

*Why was it changed?*

Our SDKs have multiple state machines running at once and it only logs the state in hex, which makes it confusing to understand which state machine transitions are being tracked while debugging. This PR introduces addition of tags when logging state machine transitions in VERBOSE mode to make it easy to understand which state machine transition the logs belong to.

*How was it changed?*
Introduced a new API `createStateMachineWithTag` to pass in a tag. This is mandatory. if not provided the API call would fail.

Earlier:

```
2023-12-28 18:42:08.694 VERBOSE stepStateMachine(): State Machine - Current state: 0x0000000000000001, Next state: 0x0000000000000002, Current local state retry count [0], Max local state retry count [5], State transition wait time [0] ms
```

After this change:

```
2023-12-28 18:40:18.229 VERBOSE   stepStateMachine(): [STREAM] State Machine - Current state: 0x0000000000000010, Next state: 0x0000000000000040, Current local state retry count [0], Max local state retry count [5], State transition wait time [0] ms
```

*Testing`*
Included API unit tests to confirm positive and negative test cases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
