### PR TITLE
Add LOG_LEVEL_SILENT explicitly to avoid PROFILE logs from getting displayed when setting log level to SILENT

### DIFF
--- a/src/common/include/com/amazonaws/kinesis/video/common/PlatformUtils.h
+++ b/src/common/include/com/amazonaws/kinesis/video/common/PlatformUtils.h
@@ -52,6 +52,8 @@ extern logPrintFunc globalCustomLogPrintFn;
 #define LOG_LEVEL_ERROR   5
 #define LOG_LEVEL_FATAL   6
 #define LOG_LEVEL_SILENT  7
+
+// Adding this after LOG_LEVEL_SILENT to ensure we do not break backward compat
 #define LOG_LEVEL_PROFILE 8
 
 #define LOG_LEVEL_VERBOSE_STR (const PCHAR) "VERBOSE"

--- a/src/utils/src/FileLogger.c
+++ b/src/utils/src/FileLogger.c
@@ -57,14 +57,15 @@ CleanUp:
 
 VOID fileLoggerLogPrintFn(UINT32 level, PCHAR tag, PCHAR fmt, ...)
 {
+    UNUSED_PARAM(tag);
     CHAR logFmtString[MAX_LOG_FORMAT_LENGTH + 1];
     INT32 offset = 0;
     STATUS status = STATUS_SUCCESS;
     FileLoggerParameters* levelLoggerParameters = NULL;
     va_list valist;
+    UINT32 logLevel = GET_LOGGER_LOG_LEVEL();
 
-    UNUSED_PARAM(tag);
-    if (level >= GET_LOGGER_LOG_LEVEL() && gFileLogger != NULL) {
+    if (logLevel != LOG_LEVEL_SILENT && level >= logLevel && gFileLogger != NULL) {
         MUTEX_LOCK(gFileLogger->lock);
         addLogMetadata(logFmtString, (UINT32) ARRAY_SIZE(logFmtString), fmt, level);
 

--- a/src/utils/src/Logger.c
+++ b/src/utils/src/Logger.c
@@ -61,7 +61,7 @@ VOID defaultLogPrint(UINT32 level, const PCHAR tag, const PCHAR fmt, ...)
     CHAR logFmtString[MAX_LOG_FORMAT_LENGTH + 1];
     UINT32 logLevel = GET_LOGGER_LOG_LEVEL();
     UNUSED_PARAM(tag);
-    if (level >= logLevel) {
+    if (logLevel != LOG_LEVEL_SILENT && level >= logLevel) {
         addLogMetadata(logFmtString, (UINT32) ARRAY_SIZE(logFmtString), fmt, level);
 
         va_list valist;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

A new log level was introduced in previous version where the value of the level is set to `LOG_LEVEL_PROFILE` (8). LOG_LEVEL_SILENT is set to 7. The SDK has a filtering logic where we log messages with log level greater than the set logLevel. This means, with `LOG_LEVEL_SILENT`, no log messages should be displayed. However, with the new added `LOG_LEVEL_PROFILE`, this breaks when setting log level to `LOG_LEVEL_SILENT` since PROFILE logs would get displayed. This PR fixes the issue.

Testing:

- Tested with WebRTC C sample (which uses PROFILE log level) by setting LOG_LEVEL_SILENT to confirm no logs get displayed if log level is set to 7. Also tested setting every other level.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
