### PR TITLE
Remove const in the api definition for getStateMachineName

### DIFF
--- a/src/state/include/com/amazonaws/kinesis/video/state/Include.h
+++ b/src/state/include/com/amazonaws/kinesis/video/state/Include.h
@@ -217,7 +217,7 @@ PUBLIC_API STATUS checkForStateTransition(PStateMachine, PBOOL);
  * @param 1 PStateMachine - IN - State machine object to be deallocated
  * @return - Returns the name set for the state machine
  */
-PUBLIC_API const PCHAR getStateMachineName(PStateMachine);
+PUBLIC_API const CHAR* getStateMachineName(PStateMachine);
 
 static const ExponentialBackoffRetryStrategyConfig DEFAULT_STATE_MACHINE_EXPONENTIAL_BACKOFF_RETRY_CONFIGURATION = {
     /* Exponential wait times with this config will look like following -

--- a/src/state/include/com/amazonaws/kinesis/video/state/Include.h
+++ b/src/state/include/com/amazonaws/kinesis/video/state/Include.h
@@ -217,7 +217,7 @@ PUBLIC_API STATUS checkForStateTransition(PStateMachine, PBOOL);
  * @param 1 PStateMachine - IN - State machine object to be deallocated
  * @return - Returns the name set for the state machine
  */
-PUBLIC_API const CHAR* getStateMachineName(PStateMachine);
+PUBLIC_API PCHAR getStateMachineName(PStateMachine);
 
 static const ExponentialBackoffRetryStrategyConfig DEFAULT_STATE_MACHINE_EXPONENTIAL_BACKOFF_RETRY_CONFIGURATION = {
     /* Exponential wait times with this config will look like following -

--- a/src/state/src/State.c
+++ b/src/state/src/State.c
@@ -329,7 +329,7 @@ CleanUp:
 }
 
 // This function is useful for unit tests
-const PCHAR getStateMachineName(PStateMachine pStateMachine)
+const CHAR* getStateMachineName(PStateMachine pStateMachine)
 {
     PStateMachineImpl pStateMachineImpl = (PStateMachineImpl) pStateMachine;
     if (pStateMachineImpl == NULL) {

--- a/src/state/src/State.c
+++ b/src/state/src/State.c
@@ -329,7 +329,7 @@ CleanUp:
 }
 
 // This function is useful for unit tests
-const CHAR* getStateMachineName(PStateMachine pStateMachine)
+PCHAR getStateMachineName(PStateMachine pStateMachine)
 {
     PStateMachineImpl pStateMachineImpl = (PStateMachineImpl) pStateMachine;
     if (pStateMachineImpl == NULL) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The intent of using const was to ensure the caller of the API cannot modify the string. However, given the name is set up when invoking `createStateMachineWithName`, even if the caller modifies the name, the state machine name would be unaffected. If invoking `createStateMachineWithName` again, it would create a new state machine object.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
