### PR TITLE
Threadpool tsan

### DIFF
--- a/src/utils/src/Threadpool.c
+++ b/src/utils/src/Threadpool.c
@@ -279,7 +279,7 @@ STATUS threadpoolFree(PThreadpool pThreadpool)
     StackQueueIterator iterator;
     PThreadData item = NULL;
     UINT64 data;
-    BOOL finished = FALSE, taskQueueEmpty = FALSE, listMutedLocked = FALSE;
+    BOOL finished = FALSE, taskQueueEmpty = FALSE, listMutexLocked = FALSE;
     SIZE_T threadCount = 0, i = 0;
     CHK(pThreadpool != NULL, STATUS_NULL_ARG);
 

--- a/src/utils/src/Threadpool.c
+++ b/src/utils/src/Threadpool.c
@@ -18,7 +18,7 @@ typedef struct TaskData {
 
 PVOID threadpoolTermination(PVOID data)
 {
-    THREAD_SLEEP(50 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+    THREAD_SLEEP(20 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
     return 0;
 }
 
@@ -358,7 +358,7 @@ STATUS threadpoolFree(PThreadpool pThreadpool)
         listMutexLocked = FALSE;
         if (!finished) {
             // the aforementioned sleep
-            THREAD_SLEEP(10 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+            THREAD_SLEEP(5 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
         }
     }
 

--- a/tst/utils/Threadpool.cpp
+++ b/tst/utils/Threadpool.cpp
@@ -61,6 +61,7 @@ TEST_F(ThreadpoolFunctionalityTest, BasicTryAddTest)
 {
     PThreadpool pThreadpool = NULL;
     BOOL terminate = FALSE;
+    auto count = 0;
     gTerminateCount = 0;
     gTerminateMutex = MUTEX_CREATE(FALSE);
     EXPECT_EQ(STATUS_SUCCESS, semaphoreEmptyCreate(10, &gTerminateSemaphore));
@@ -78,8 +79,12 @@ TEST_F(ThreadpoolFunctionalityTest, BasicTryAddTest)
     MUTEX_UNLOCK(gTerminateMutex);
     EXPECT_EQ(STATUS_SUCCESS, threadpoolFree(pThreadpool));
 
+    MUTEX_LOCK(gTerminateMutex);
+    count = gTerminateCount;
+    MUTEX_UNLOCK(gTerminateMutex);
+
     // wait for threads to exit before test ends
-    for(auto i = 0; i < gTerminateCount; i++) {
+    for(auto i = 0; i < count; i++) {
         EXPECT_EQ(STATUS_SUCCESS, semaphoreAcquire(gTerminateSemaphore, INFINITE_TIME_VALUE));
     }
     EXPECT_EQ(STATUS_SUCCESS, semaphoreFree(&gTerminateSemaphore));
@@ -107,8 +112,12 @@ TEST_F(ThreadpoolFunctionalityTest, BasicPushTest)
     MUTEX_UNLOCK(gTerminateMutex);
     EXPECT_EQ(STATUS_SUCCESS, threadpoolFree(pThreadpool));
 
+    MUTEX_LOCK(gTerminateMutex);
+    auto enteredThreadCount = gTerminateCount;
+    MUTEX_UNLOCK(gTerminateMutex);
+
     // wait for threads to exit before test ends
-    for(auto i = 0; i < gTerminateCount; i++) {
+    for(auto i = 0; i < enteredThreadCount; i++) {
         EXPECT_EQ(STATUS_SUCCESS, semaphoreAcquire(gTerminateSemaphore, INFINITE_TIME_VALUE));
     }
     EXPECT_EQ(STATUS_SUCCESS, semaphoreFree(&gTerminateSemaphore));
@@ -157,8 +166,12 @@ TEST_F(ThreadpoolFunctionalityTest, GetThreadCountTest)
 
     EXPECT_EQ(STATUS_SUCCESS, threadpoolFree(pThreadpool));
 
+    MUTEX_LOCK(gTerminateMutex);
+    auto enteredThreadCount = gTerminateCount;
+    MUTEX_UNLOCK(gTerminateMutex);
+
     // wait for threads to exit before test ends
-    for(auto i = 0; i < gTerminateCount; i++) {
+    for(auto i = 0; i < enteredThreadCount; i++) {
         EXPECT_EQ(STATUS_SUCCESS, semaphoreAcquire(gTerminateSemaphore, INFINITE_TIME_VALUE));
     }
     EXPECT_EQ(STATUS_SUCCESS, semaphoreFree(&gTerminateSemaphore));
@@ -191,8 +204,12 @@ TEST_F(ThreadpoolFunctionalityTest, ThreadsExitGracefullyAfterThreadpoolFreeTest
     terminate = TRUE;
     MUTEX_UNLOCK(gTerminateMutex);
 
+    MUTEX_LOCK(gTerminateMutex);
+    auto enteredThreadCount = gTerminateCount;
+    MUTEX_UNLOCK(gTerminateMutex);
+
     // wait for threads to exit before test ends
-    for(auto i = 0; i < gTerminateCount; i++) {
+    for(auto i = 0; i < enteredThreadCount; i++) {
         EXPECT_EQ(STATUS_SUCCESS, semaphoreAcquire(gTerminateSemaphore, INFINITE_TIME_VALUE));
     }
     EXPECT_EQ(STATUS_SUCCESS, semaphoreFree(&gTerminateSemaphore));

--- a/tst/utils/Threadpool.cpp
+++ b/tst/utils/Threadpool.cpp
@@ -54,7 +54,7 @@ TEST_F(ThreadpoolFunctionalityTest, CreateDestroyTest)
     EXPECT_EQ(STATUS_SUCCESS, threadpoolFree(pThreadpool));
 
     // wait for threads to exit before test ends
-    THREAD_SLEEP(10 * HUNDREDS_OF_NANOS_IN_A_SECOND);
+    THREAD_SLEEP(1 * HUNDREDS_OF_NANOS_IN_A_SECOND);
 }
 
 TEST_F(ThreadpoolFunctionalityTest, BasicTryAddTest)
@@ -89,7 +89,7 @@ TEST_F(ThreadpoolFunctionalityTest, BasicTryAddTest)
     }
     EXPECT_EQ(STATUS_SUCCESS, semaphoreFree(&gTerminateSemaphore));
     MUTEX_FREE(gTerminateMutex);
-    THREAD_SLEEP(10 * HUNDREDS_OF_NANOS_IN_A_SECOND);
+    THREAD_SLEEP(1 * HUNDREDS_OF_NANOS_IN_A_SECOND);
 }
 
 TEST_F(ThreadpoolFunctionalityTest, BasicPushTest)
@@ -122,7 +122,7 @@ TEST_F(ThreadpoolFunctionalityTest, BasicPushTest)
     }
     EXPECT_EQ(STATUS_SUCCESS, semaphoreFree(&gTerminateSemaphore));
     MUTEX_FREE(gTerminateMutex);
-    THREAD_SLEEP(10 * HUNDREDS_OF_NANOS_IN_A_SECOND);
+    THREAD_SLEEP(1 * HUNDREDS_OF_NANOS_IN_A_SECOND);
 }
 
 TEST_F(ThreadpoolFunctionalityTest, GetThreadCountTest)
@@ -176,7 +176,7 @@ TEST_F(ThreadpoolFunctionalityTest, GetThreadCountTest)
     }
     EXPECT_EQ(STATUS_SUCCESS, semaphoreFree(&gTerminateSemaphore));
     MUTEX_FREE(gTerminateMutex);
-    THREAD_SLEEP(10 * HUNDREDS_OF_NANOS_IN_A_SECOND);
+    THREAD_SLEEP(1 * HUNDREDS_OF_NANOS_IN_A_SECOND);
 }
 
 TEST_F(ThreadpoolFunctionalityTest, ThreadsExitGracefullyAfterThreadpoolFreeTest)
@@ -214,7 +214,7 @@ TEST_F(ThreadpoolFunctionalityTest, ThreadsExitGracefullyAfterThreadpoolFreeTest
     }
     EXPECT_EQ(STATUS_SUCCESS, semaphoreFree(&gTerminateSemaphore));
     MUTEX_FREE(gTerminateMutex);
-    THREAD_SLEEP(10 * HUNDREDS_OF_NANOS_IN_A_SECOND);
+    THREAD_SLEEP(1 * HUNDREDS_OF_NANOS_IN_A_SECOND);
 }
 
 
@@ -267,5 +267,5 @@ TEST_F(ThreadpoolFunctionalityTest, MultithreadUseTest)
     THREAD_JOIN(thread2, NULL);
 
     // wait for threads to exit before test ends to avoid false memory leak alarm
-    THREAD_SLEEP(10 * HUNDREDS_OF_NANOS_IN_A_SECOND);
+    THREAD_SLEEP(1 * HUNDREDS_OF_NANOS_IN_A_SECOND);
 }

--- a/tst/utils/Threadpool.cpp
+++ b/tst/utils/Threadpool.cpp
@@ -54,7 +54,7 @@ TEST_F(ThreadpoolFunctionalityTest, CreateDestroyTest)
     EXPECT_EQ(STATUS_SUCCESS, threadpoolFree(pThreadpool));
 
     // wait for threads to exit before test ends
-    THREAD_SLEEP(500 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+    THREAD_SLEEP(1 * HUNDREDS_OF_NANOS_IN_A_SECOND);
 }
 
 TEST_F(ThreadpoolFunctionalityTest, BasicTryAddTest)
@@ -89,7 +89,7 @@ TEST_F(ThreadpoolFunctionalityTest, BasicTryAddTest)
     }
     EXPECT_EQ(STATUS_SUCCESS, semaphoreFree(&gTerminateSemaphore));
     MUTEX_FREE(gTerminateMutex);
-    THREAD_SLEEP(500 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+    THREAD_SLEEP(1 * HUNDREDS_OF_NANOS_IN_A_SECOND);
 }
 
 TEST_F(ThreadpoolFunctionalityTest, BasicPushTest)
@@ -122,7 +122,7 @@ TEST_F(ThreadpoolFunctionalityTest, BasicPushTest)
     }
     EXPECT_EQ(STATUS_SUCCESS, semaphoreFree(&gTerminateSemaphore));
     MUTEX_FREE(gTerminateMutex);
-    THREAD_SLEEP(500 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+    THREAD_SLEEP(1 * HUNDREDS_OF_NANOS_IN_A_SECOND);
 }
 
 TEST_F(ThreadpoolFunctionalityTest, GetThreadCountTest)
@@ -176,7 +176,7 @@ TEST_F(ThreadpoolFunctionalityTest, GetThreadCountTest)
     }
     EXPECT_EQ(STATUS_SUCCESS, semaphoreFree(&gTerminateSemaphore));
     MUTEX_FREE(gTerminateMutex);
-    THREAD_SLEEP(500 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+    THREAD_SLEEP(1 * HUNDREDS_OF_NANOS_IN_A_SECOND);
 }
 
 TEST_F(ThreadpoolFunctionalityTest, ThreadsExitGracefullyAfterThreadpoolFreeTest)
@@ -214,7 +214,7 @@ TEST_F(ThreadpoolFunctionalityTest, ThreadsExitGracefullyAfterThreadpoolFreeTest
     }
     EXPECT_EQ(STATUS_SUCCESS, semaphoreFree(&gTerminateSemaphore));
     MUTEX_FREE(gTerminateMutex);
-    THREAD_SLEEP(500 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+    THREAD_SLEEP(1 * HUNDREDS_OF_NANOS_IN_A_SECOND);
 }
 
 
@@ -263,6 +263,9 @@ TEST_F(ThreadpoolFunctionalityTest, MultithreadUseTest)
     ATOMIC_STORE_BOOL(&user.usable, FALSE);
     EXPECT_EQ(STATUS_SUCCESS, threadpoolFree(pThreadpool));
 
+    THREAD_JOIN(thread1, NULL);
+    THREAD_JOIN(thread2, NULL);
+
     // wait for threads to exit before test ends to avoid false memory leak alarm
-    THREAD_SLEEP(500 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+    THREAD_SLEEP(1 * HUNDREDS_OF_NANOS_IN_A_SECOND);
 }

--- a/tst/utils/Threadpool.cpp
+++ b/tst/utils/Threadpool.cpp
@@ -54,7 +54,7 @@ TEST_F(ThreadpoolFunctionalityTest, CreateDestroyTest)
     EXPECT_EQ(STATUS_SUCCESS, threadpoolFree(pThreadpool));
 
     // wait for threads to exit before test ends
-    THREAD_SLEEP(1 * HUNDREDS_OF_NANOS_IN_A_SECOND);
+    THREAD_SLEEP(10 * HUNDREDS_OF_NANOS_IN_A_SECOND);
 }
 
 TEST_F(ThreadpoolFunctionalityTest, BasicTryAddTest)
@@ -89,7 +89,7 @@ TEST_F(ThreadpoolFunctionalityTest, BasicTryAddTest)
     }
     EXPECT_EQ(STATUS_SUCCESS, semaphoreFree(&gTerminateSemaphore));
     MUTEX_FREE(gTerminateMutex);
-    THREAD_SLEEP(1 * HUNDREDS_OF_NANOS_IN_A_SECOND);
+    THREAD_SLEEP(10 * HUNDREDS_OF_NANOS_IN_A_SECOND);
 }
 
 TEST_F(ThreadpoolFunctionalityTest, BasicPushTest)
@@ -122,7 +122,7 @@ TEST_F(ThreadpoolFunctionalityTest, BasicPushTest)
     }
     EXPECT_EQ(STATUS_SUCCESS, semaphoreFree(&gTerminateSemaphore));
     MUTEX_FREE(gTerminateMutex);
-    THREAD_SLEEP(1 * HUNDREDS_OF_NANOS_IN_A_SECOND);
+    THREAD_SLEEP(10 * HUNDREDS_OF_NANOS_IN_A_SECOND);
 }
 
 TEST_F(ThreadpoolFunctionalityTest, GetThreadCountTest)
@@ -176,7 +176,7 @@ TEST_F(ThreadpoolFunctionalityTest, GetThreadCountTest)
     }
     EXPECT_EQ(STATUS_SUCCESS, semaphoreFree(&gTerminateSemaphore));
     MUTEX_FREE(gTerminateMutex);
-    THREAD_SLEEP(1 * HUNDREDS_OF_NANOS_IN_A_SECOND);
+    THREAD_SLEEP(10 * HUNDREDS_OF_NANOS_IN_A_SECOND);
 }
 
 TEST_F(ThreadpoolFunctionalityTest, ThreadsExitGracefullyAfterThreadpoolFreeTest)
@@ -214,7 +214,7 @@ TEST_F(ThreadpoolFunctionalityTest, ThreadsExitGracefullyAfterThreadpoolFreeTest
     }
     EXPECT_EQ(STATUS_SUCCESS, semaphoreFree(&gTerminateSemaphore));
     MUTEX_FREE(gTerminateMutex);
-    THREAD_SLEEP(1 * HUNDREDS_OF_NANOS_IN_A_SECOND);
+    THREAD_SLEEP(10 * HUNDREDS_OF_NANOS_IN_A_SECOND);
 }
 
 
@@ -267,5 +267,5 @@ TEST_F(ThreadpoolFunctionalityTest, MultithreadUseTest)
     THREAD_JOIN(thread2, NULL);
 
     // wait for threads to exit before test ends to avoid false memory leak alarm
-    THREAD_SLEEP(1 * HUNDREDS_OF_NANOS_IN_A_SECOND);
+    THREAD_SLEEP(10 * HUNDREDS_OF_NANOS_IN_A_SECOND);
 }

--- a/tst/utils/UtilTestFixture.h
+++ b/tst/utils/UtilTestFixture.h
@@ -113,7 +113,7 @@ class UtilTestBase : public ::testing::Test {
         }
         DLOGI("Final remaining allocation size is %llu\n", gTotalUtilsMemoryUsage);
 
-        if (gTotalUtilsMemoryUsage != 0) {
+        while (gTotalUtilsMemoryUsage != 0) {
             if (allocatorsSet) {
                 MUTEX_UNLOCK(gUtilityMemMutex);
             }

--- a/tst/utils/UtilTestFixture.h
+++ b/tst/utils/UtilTestFixture.h
@@ -108,11 +108,15 @@ class UtilTestBase : public ::testing::Test {
         DLOGI("\nTearing down test: %s\n", GetTestName());
 
         // Validate the allocations cleanup
-        MUTEX_LOCK(gUtilityMemMutex);
+        if (allocatorsSet) {
+            MUTEX_LOCK(gUtilityMemMutex);
+        }
         DLOGI("Final remaining allocation size is %llu\n", gTotalUtilsMemoryUsage);
 
         EXPECT_EQ((UINT64) 0, gTotalUtilsMemoryUsage);
-        MUTEX_UNLOCK(gUtilityMemMutex);
+        if (allocatorsSet) {
+            MUTEX_UNLOCK(gUtilityMemMutex);
+        }
 
         if (allocatorsSet) {
             globalMemAlloc = storedMemAlloc;

--- a/tst/utils/UtilTestFixture.h
+++ b/tst/utils/UtilTestFixture.h
@@ -108,9 +108,11 @@ class UtilTestBase : public ::testing::Test {
         DLOGI("\nTearing down test: %s\n", GetTestName());
 
         // Validate the allocations cleanup
+        MUTEX_LOCK(gUtilityMemMutex);
         DLOGI("Final remaining allocation size is %llu\n", gTotalUtilsMemoryUsage);
 
         EXPECT_EQ((UINT64) 0, gTotalUtilsMemoryUsage);
+        MUTEX_UNLOCK(gUtilityMemMutex);
 
         if (allocatorsSet) {
             globalMemAlloc = storedMemAlloc;

--- a/tst/utils/UtilTestFixture.h
+++ b/tst/utils/UtilTestFixture.h
@@ -113,6 +113,16 @@ class UtilTestBase : public ::testing::Test {
         }
         DLOGI("Final remaining allocation size is %llu\n", gTotalUtilsMemoryUsage);
 
+        if (gTotalUtilsMemoryUsage != 0) {
+            if (allocatorsSet) {
+                MUTEX_UNLOCK(gUtilityMemMutex);
+            }
+            THREAD_SLEEP(1 * HUNDREDS_OF_NANOS_IN_A_SECOND);
+            if (allocatorsSet) {
+                MUTEX_LOCK(gUtilityMemMutex);
+            }
+        }
+
         EXPECT_EQ((UINT64) 0, gTotalUtilsMemoryUsage);
         if (allocatorsSet) {
             MUTEX_UNLOCK(gUtilityMemMutex);


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
ThreadData->mutex now wraps all interactions with any threadpool objects, this includes the queue.
As a consequence of having the data mutex locked while waiting on the queue, the threadpool couldn't teardown if an actor was waiting on the queue, so the teardown now pushes wait tasks to the queue in the event of that use case.

Additionally all utils tests were changed so that if a memory leak is detected, it will infinitely wait for the memory leak to end -- resulting in a GHA timeout or a loose actor cleaning up the memory (common race condition specific to tests only).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
