### PR TITLE
safe gmtime, guard with mutex since not thread safe on non windows pl…

### DIFF
--- a/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
+++ b/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
@@ -997,7 +997,7 @@ extern PUBLIC_API atomicXor globalAtomicXor;
 #define STRFTIME    strftime
 #define GMTIME      gmtime
 
-#if defined _WIN32 || defined _WIN64
+#if defined _WIN32 || defined _WIN64 || defined __CYGWIN__
 #define GMTIME_SAFE GMTIME
 #else
 #define GMTIME_SAFE globalGetTmTime

--- a/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
+++ b/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
@@ -694,7 +694,15 @@ typedef struct tm* (*getTmTime)(const time_t*);
 #define TIME_DIFF_UNIX_WINDOWS_TIME 116444736000000000ULL
 
 PUBLIC_API UINT64 defaultGetTime();
-PUBLIC_API struct tm* defaultGetTmTime(const time_t*);
+
+//
+// The C library function gmtime is not threadsafe, but we need a thread
+// safe impl.  This provides that by wrapping the gmtime call around
+// a global mutex specific for gmtime calls.  All instances of GMTIME
+// can be safely replaced with the new GMTIME_THREAD_SAFE.
+// On Windows gmtime is threadsafe so no impact there.
+//
+PUBLIC_API struct tm* defaultGetThreadSafeTmTime(const time_t*);
 
 //
 // Thread related functionality
@@ -998,9 +1006,9 @@ extern PUBLIC_API atomicXor globalAtomicXor;
 #define GMTIME      gmtime
 
 #if defined _WIN32 || defined _WIN64 || defined __CYGWIN__
-#define GMTIME_SAFE GMTIME
+#define GMTIME_THREAD_SAFE GMTIME
 #else
-#define GMTIME_SAFE globalGetTmTime
+#define GMTIME_THREAD_SAFE globalGetThreadSafeTmTime
 #endif
 
 //

--- a/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
+++ b/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
@@ -686,18 +686,22 @@ extern getTName globalGetThreadName;
 //
 typedef UINT64 (*getTime)();
 
+typedef struct tm* (*getTmTime)(const time_t*);
+
 //
 // Default time library functions
 //
 #define TIME_DIFF_UNIX_WINDOWS_TIME 116444736000000000ULL
 
 PUBLIC_API UINT64 defaultGetTime();
+PUBLIC_API struct tm* defaultGetTmTime(const time_t*);
 
 //
 // Thread related functionality
 //
 extern getTime globalGetTime;
 extern getTime globalGetRealTime;
+extern getTmTime globalGetTmTime;
 
 //
 // Thread library function definitions
@@ -992,6 +996,12 @@ extern PUBLIC_API atomicXor globalAtomicXor;
 #define GETREALTIME globalGetRealTime
 #define STRFTIME    strftime
 #define GMTIME      gmtime
+
+#if defined _WIN32 || defined _WIN64
+#define GMTIME_SAFE GMTIME
+#else
+#define GMTIME_SAFE globalGetTmTime
+#endif
 
 //
 // Mutex functionality

--- a/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
+++ b/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
@@ -709,7 +709,7 @@ PUBLIC_API struct tm* defaultGetThreadSafeTmTime(const time_t*);
 //
 extern getTime globalGetTime;
 extern getTime globalGetRealTime;
-extern getTmTime globalGetTmTime;
+extern getTmTime globalGetThreadSafeTmTime;
 
 //
 // Thread library function definitions

--- a/src/utils/src/Threadpool.c
+++ b/src/utils/src/Threadpool.c
@@ -306,8 +306,9 @@ STATUS threadpoolFree(PThreadpool pThreadpool)
     StackQueueIterator iterator;
     PThreadData item = NULL;
     UINT64 data;
+    UINT32 threadCount, i = 0;
     BOOL finished = FALSE, taskQueueEmpty = FALSE, listMutexLocked = FALSE, tempMutexLocked = FALSE;
-    SIZE_T threadCount = 0, i = 0, sentTerminationTasks = 0, finishedTerminationTasks = 0;
+    SIZE_T sentTerminationTasks = 0, finishedTerminationTasks = 0;
     MUTEX tempMutex;
     SEMAPHORE_HANDLE tempSemaphore;
     TerminationTask terminateTask;
@@ -389,6 +390,7 @@ STATUS threadpoolFree(PThreadpool pThreadpool)
                 //
                 // When we unlock and sleep we give them
                 CHK_STATUS(stackQueueGetCount(pThreadpool->threadList, &threadCount));
+
                 for (i = 0; i < threadCount; i++) {
                     CHK_STATUS(threadpoolInternalCreateTask(pThreadpool, threadpoolTermination, &terminateTask));
                     sentTerminationTasks++;

--- a/src/utils/src/Threadpool.c
+++ b/src/utils/src/Threadpool.c
@@ -307,7 +307,6 @@ STATUS threadpoolFree(PThreadpool pThreadpool)
     PThreadData item = NULL;
     UINT64 data;
     BOOL finished = FALSE, taskQueueEmpty = FALSE, listMutexLocked = FALSE, tempMutexLocked = FALSE;
-    ;
     SIZE_T threadCount = 0, i = 0, sentTerminationTasks = 0, finishedTerminationTasks = 0;
     MUTEX tempMutex;
     SEMAPHORE_HANDLE tempSemaphore;

--- a/src/utils/src/Time.c
+++ b/src/utils/src/Time.c
@@ -3,10 +3,11 @@
 getTime globalGetTime = defaultGetTime;
 getTime globalGetRealTime = defaultGetTime;
 
-#if !(defined _WIN32 || defined _WIN64)
-getTmTime globalGetTmTime = defaultGetTmTime;
+#if !(defined _WIN32 || defined _WIN64 || defined __CYGWIN__)
 
+getTmTime globalGetTmTime = defaultGetTmTime;
 pthread_mutex_t globalGmTimeMutex = PTHREAD_MUTEX_INITIALIZER;
+
 struct tm* defaultGetTmTime(const time_t* timer)
 {
     struct tm* retVal;

--- a/src/utils/src/Time.c
+++ b/src/utils/src/Time.c
@@ -5,10 +5,10 @@ getTime globalGetRealTime = defaultGetTime;
 
 #if !(defined _WIN32 || defined _WIN64 || defined __CYGWIN__)
 
-getTmTime globalGetTmTime = defaultGetTmTime;
+getTmTime globalGetThreadSafeTmTime = defaultGetThreadSafeTmTime;
 pthread_mutex_t globalGmTimeMutex = PTHREAD_MUTEX_INITIALIZER;
 
-struct tm* defaultGetTmTime(const time_t* timer)
+struct tm* defaultGetThreadSafeTmTime(const time_t* timer)
 {
     struct tm* retVal;
     pthread_mutex_lock(&globalGmTimeMutex);
@@ -46,7 +46,7 @@ STATUS generateTimestampStrInMilliseconds(PCHAR formatStr, PCHAR pDestBuffer, UI
     time_t seconds = milliseconds100ns / 1000;
 
     // Convert time_t to UTC tm struct
-    timeinfo = GMTIME_SAFE(&seconds);
+    timeinfo = GMTIME_THREAD_SAFE(&seconds);
 
     millisecondVal = milliseconds100ns % 1000;
 
@@ -54,7 +54,7 @@ STATUS generateTimestampStrInMilliseconds(PCHAR formatStr, PCHAR pDestBuffer, UI
     struct timeval tv;
     gettimeofday(&tv, NULL); // Get current time
 
-    timeinfo = GMTIME_SAFE(&(tv.tv_sec)); // Convert to broken-down time
+    timeinfo = GMTIME_THREAD_SAFE(&(tv.tv_sec)); // Convert to broken-down time
 
     millisecondVal = tv.tv_usec / 1000; // Convert microseconds to milliseconds
 
@@ -62,7 +62,7 @@ STATUS generateTimestampStrInMilliseconds(PCHAR formatStr, PCHAR pDestBuffer, UI
     struct timespec nowTime;
     clock_gettime(CLOCK_REALTIME, &nowTime);
 
-    timeinfo = GMTIME_SAFE(&(nowTime.tv_sec));
+    timeinfo = GMTIME_THREAD_SAFE(&(nowTime.tv_sec));
     millisecondVal = nowTime.tv_nsec / (HUNDREDS_OF_NANOS_IN_A_MILLISECOND * DEFAULT_TIME_UNIT_IN_NANOS); // Convert nanoseconds to milliseconds
 
 #endif
@@ -94,7 +94,7 @@ STATUS generateTimestampStr(UINT64 timestamp, PCHAR formatStr, PCHAR pDestBuffer
     formattedStrLen = 0;
     *pFormattedStrLen = 0;
 
-    formattedStrLen = (UINT32) STRFTIME(pDestBuffer, destBufferLen, formatStr, GMTIME_SAFE(&timestampSeconds));
+    formattedStrLen = (UINT32) STRFTIME(pDestBuffer, destBufferLen, formatStr, GMTIME_THREAD_SAFE(&timestampSeconds));
     CHK(formattedStrLen != 0, STATUS_STRFTIME_FALIED);
 
     pDestBuffer[formattedStrLen] = '\0';

--- a/src/utils/src/Time.c
+++ b/src/utils/src/Time.c
@@ -7,7 +7,8 @@ getTime globalGetRealTime = defaultGetTime;
 getTmTime globalGetTmTime = defaultGetTmTime;
 
 pthread_mutex_t globalGmTimeMutex = PTHREAD_MUTEX_INITIALIZER;
-struct tm* defaultGetTmTime(const time_t *timer) {
+struct tm* defaultGetTmTime(const time_t* timer)
+{
     struct tm* retVal;
     pthread_mutex_lock(&globalGmTimeMutex);
     retVal = GMTIME(timer);

--- a/tst/utils/ThreadsafeBlockingQueue.cpp
+++ b/tst/utils/ThreadsafeBlockingQueue.cpp
@@ -144,13 +144,13 @@ TEST_F(ThreadsafeBlockingQueueFunctionalityTest, multithreadQueueDequeueTest)
     user.pSafeQueue = pSafeQueue;
     ATOMIC_STORE_BOOL(&user.usable, TRUE);
     for(UINT64 i = 0; i < totalThreads/2; i++) {
-        THREAD_CREATE(&threads[threadCount++], readingThread, &user);
+        EXPECT_EQ(STATUS_SUCCESS, THREAD_CREATE(&threads[threadCount++], readingThread, &user));
     }
     for(UINT64 i = 0; i < totalThreads/2; i++) {
-        THREAD_CREATE(&threads[threadCount++], writingThread, &user);
+        EXPECT_EQ(STATUS_SUCCESS, THREAD_CREATE(&threads[threadCount++], writingThread, &user));
     }
     for(UINT64 i = 0; i < totalThreads; i++) {
-        THREAD_JOIN(threads[i], NULL);
+        EXPECT_EQ(STATUS_SUCCESS, THREAD_JOIN(threads[i], NULL));
     }
     ATOMIC_STORE_BOOL(&user.usable, FALSE);
     EXPECT_EQ(STATUS_SUCCESS, safeBlockingQueueFree(pSafeQueue));
@@ -171,12 +171,12 @@ TEST_F(ThreadsafeBlockingQueueFunctionalityTest, multithreadTeardownTest)
     user.pSafeQueue = pSafeQueue;
     ATOMIC_STORE_BOOL(&user.usable, TRUE);
     for(UINT64 i = 0; i < totalThreads; i++) {
-        THREAD_CREATE(&threads[threadCount++], readingThread, &user);
+        EXPECT_EQ(STATUS_SUCCESS, THREAD_CREATE(&threads[threadCount++], readingThread, &user));
     }
     THREAD_SLEEP(125 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
     ATOMIC_STORE_BOOL(&user.usable, FALSE);
     EXPECT_EQ(STATUS_SUCCESS, safeBlockingQueueFree(pSafeQueue));
     for(UINT64 i = 0; i < totalThreads; i++) {
-        THREAD_JOIN(threads[i], NULL);
+        EXPECT_EQ(STATUS_SUCCESS, THREAD_JOIN(threads[i], NULL));
     }
 }


### PR DESCRIPTION
*Issue #, if available:* Address TSAN failures in Producer C

*Description of changes:*
C function `gmtime` is not threadsafe on non-windows platforms.  Create a new `GMTIME_SAFE` macro which guards the gmtime call with a global mutex.

The if/def for this includes CYGWIN because I'm using pthread which our Thread platform dependent layer does not use for cygwin.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
