### PR TITLE
Add API for specifying thread stack size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ function(enableSanitizer SANITIZER)
 endfunction()
 
 if(KVS_DEFAULT_STACK_SIZE)
-  message(STATUS "@@@@@@@@@@@@@@@@@@@@Building with default stack size")
+  message(STATUS "Building with default stack size")
   add_compile_definitions(KVS_DEFAULT_STACK_SIZE=${KVS_DEFAULT_STACK_SIZE})
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,10 @@ function(enableSanitizer SANITIZER)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=${SANITIZER}" PARENT_SCOPE)
 endfunction()
 
+if(KVS_DEFAULT_STACK_SIZE)
+  add_compile_definitions(KVS_DEFAULT_STACK_SIZE=${KVS_DEFAULT_STACK_SIZE})
+endif()
+
 if(ADDRESS_SANITIZER)
   enableSanitizer("address")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ function(enableSanitizer SANITIZER)
 endfunction()
 
 if(KVS_DEFAULT_STACK_SIZE)
+  message(STATUS "@@@@@@@@@@@@@@@@@@@@Building with default stack size")
   add_compile_definitions(KVS_DEFAULT_STACK_SIZE=${KVS_DEFAULT_STACK_SIZE})
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ endfunction()
 
 if(KVS_DEFAULT_STACK_SIZE)
   message(STATUS "Building with default stack size")
-  add_compile_definitions(KVS_DEFAULT_STACK_SIZE=${KVS_DEFAULT_STACK_SIZE})
+  add_compile_definitions(KVS_DEFAULT_STACK_SIZE_BYTES=${KVS_DEFAULT_STACK_SIZE})
 endif()
 
 if(ADDRESS_SANITIZER)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ You can pass the following options to `cmake ..`
 * `-DUNDEFINED_BEHAVIOR_SANITIZER` Build with UndefinedBehaviorSanitizer
 * `-DBUILD_DEBUG_HEAP` Build debug heap with guard bands and validation. This is ONLY intended for low-level debugging purposes. Default is OFF
 * `-DALIGNED_MEMORY_MODEL` Build for aligned memory model only devices. Default is OFF.
-* `-DKVS_DEFAULT_STACK_SIZE` -- Value in bytes for default stack size of threads. Pthread minimum for Unix applications is 16kb
+* `-DKVS_DEFAULT_STACK_SIZE` -- Value in bytes for default stack size of threads. Pthread minimum for Unix applications is 16 Kib
 
 ### Build
 To build the library run make in the build directory you executed CMake.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ You can pass the following options to `cmake ..`
 * `-DUNDEFINED_BEHAVIOR_SANITIZER` Build with UndefinedBehaviorSanitizer
 * `-DBUILD_DEBUG_HEAP` Build debug heap with guard bands and validation. This is ONLY intended for low-level debugging purposes. Default is OFF
 * `-DALIGNED_MEMORY_MODEL` Build for aligned memory model only devices. Default is OFF.
+* `-DKVS_DEFAULT_STACK_SIZE` -- Value in bytes for default stack size of threads. Pthread minimum for Unix applications is 16kb
 
 ### Build
 To build the library run make in the build directory you executed CMake.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ You can pass the following options to `cmake ..`
 * `-DUNDEFINED_BEHAVIOR_SANITIZER` Build with UndefinedBehaviorSanitizer
 * `-DBUILD_DEBUG_HEAP` Build debug heap with guard bands and validation. This is ONLY intended for low-level debugging purposes. Default is OFF
 * `-DALIGNED_MEMORY_MODEL` Build for aligned memory model only devices. Default is OFF.
-* `-DKVS_DEFAULT_STACK_SIZE` -- Value in bytes for default stack size of threads. Pthread minimum for Unix applications is 16 Kib
+* `-DKVS_DEFAULT_STACK_SIZE` -- Value in bytes for default stack size of threads. Pthread minimum for Unix applications is 16 Kib.
 
 ### Build
 To build the library run make in the build directory you executed CMake.

--- a/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
+++ b/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
@@ -721,6 +721,7 @@ typedef VOID (*unlockMutex)(MUTEX);
 typedef BOOL (*tryLockMutex)(MUTEX);
 typedef VOID (*freeMutex)(MUTEX);
 typedef STATUS (*createThread)(PTID, startRoutine, PVOID);
+typedef STATUS (*createThreadWithParams)(PTID, startRoutine, SIZE_T, PVOID);
 typedef STATUS (*joinThread)(TID, PVOID*);
 typedef VOID (*threadSleep)(UINT64);
 typedef VOID (*threadSleepUntil)(UINT64);
@@ -763,6 +764,7 @@ extern unlockMutex globalUnlockMutex;
 extern tryLockMutex globalTryLockMutex;
 extern freeMutex globalFreeMutex;
 extern createThread globalCreateThread;
+extern createThreadWithParams globalCreateThreadWithParams;
 extern joinThread globalJoinThread;
 extern threadSleep globalThreadSleep;
 extern threadSleepUntil globalThreadSleepUntil;
@@ -1032,12 +1034,13 @@ extern PUBLIC_API atomicXor globalAtomicXor;
 //
 // Thread functionality
 //
-#define THREAD_CREATE      globalCreateThread
-#define THREAD_JOIN        globalJoinThread
-#define THREAD_SLEEP       globalThreadSleep
-#define THREAD_SLEEP_UNTIL globalThreadSleepUntil
-#define THREAD_CANCEL      globalCancelThread
-#define THREAD_DETACH      globalDetachThread
+#define THREAD_CREATE             globalCreateThread
+#define THREAD_CREATE_WITH_PARAMS globalCreateThreadWithParams
+#define THREAD_JOIN               globalJoinThread
+#define THREAD_SLEEP              globalThreadSleep
+#define THREAD_SLEEP_UNTIL        globalThreadSleepUntil
+#define THREAD_CANCEL             globalCancelThread
+#define THREAD_DETACH             globalDetachThread
 
 //
 // Static initializers

--- a/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
+++ b/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
@@ -1034,7 +1034,7 @@ extern PUBLIC_API atomicXor globalAtomicXor;
 //
 // Thread functionality
 //
-//Wrappers around OS specific utilities for threads. Takes arguments as given.
+// Wrappers around OS specific utilities for threads. Takes arguments as given.
 #define THREAD_CREATE             globalCreateThread
 #define THREAD_CREATE_WITH_PARAMS globalCreateThreadWithParams
 #define THREAD_JOIN               globalJoinThread

--- a/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
+++ b/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
@@ -1034,6 +1034,7 @@ extern PUBLIC_API atomicXor globalAtomicXor;
 //
 // Thread functionality
 //
+//Wrappers around OS specific utilities for threads. Takes arguments as given.
 #define THREAD_CREATE             globalCreateThread
 #define THREAD_CREATE_WITH_PARAMS globalCreateThreadWithParams
 #define THREAD_JOIN               globalJoinThread

--- a/src/utils/src/Thread.c
+++ b/src/utils/src/Thread.c
@@ -69,7 +69,7 @@ PUBLIC_API STATUS defaultCreateThread(PTID pThreadId, startRoutine start, PVOID 
     STATUS retStatus = STATUS_SUCCESS;
 
 #if defined(KVS_DEFAULT_STACK_SIZE)
-    CHK_STATUS(defaultCreateThreadWithParams(pThreadId, start, KVS_DEFAULT_STACK_SIZE, args);
+    CHK_STATUS(defaultCreateThreadWithParams(pThreadId, start, (SIZE_T)KVS_DEFAULT_STACK_SIZE, args);
 #else
     CHK_STATUS(defaultCreateThreadWithParams(pThreadId, start, 0, args);
 #endif
@@ -218,9 +218,9 @@ PUBLIC_API STATUS defaultCreateThread(PTID pThreadId, startRoutine start, PVOID 
     STATUS retStatus = STATUS_SUCCESS;
 
 #if defined(KVS_DEFAULT_STACK_SIZE)
-    CHK_STATUS(defaultCreateThreadWithParams(pThreadId, start, KVS_DEFAULT_STACK_SIZE, args));
+    CHK_STATUS(defaultCreateThreadWithParams(pThreadId, start, (SIZE_T) KVS_DEFAULT_STACK_SIZE, args));
 #elif defined(CONSTRAINED_DEVICE)
-    CHK_STATUS(defaultCreateThreadWithParams(pThreadId, start, THREAD_STACK_SIZE_ON_CONSTRAINED_DEVICE, args));
+    CHK_STATUS(defaultCreateThreadWithParams(pThreadId, start, (SIZE_T) THREAD_STACK_SIZE_ON_CONSTRAINED_DEVICE, args));
 #else
     CHK_STATUS(defaultCreateThreadWithParams(pThreadId, start, 0, args);
 #endif

--- a/src/utils/src/Thread.c
+++ b/src/utils/src/Thread.c
@@ -232,7 +232,14 @@ PUBLIC_API STATUS defaultCreateThread(PTID pThreadId, startRoutine start, PVOID 
 
     CHK(pThreadId != NULL, STATUS_NULL_ARG);
 
-#ifdef CONSTRAINED_DEVICE
+#if defined(KVS_DEFAULT_STACK_SIZE)
+    pthread_attr_t attr;
+    pAttr = &attr;
+    result = pthread_attr_init(pAttr);
+    CHK_ERR(result == 0, STATUS_THREAD_ATTR_INIT_FAILED, "pthread_attr_init failed with %d", result);
+    result = pthread_attr_setstacksize(&attr, KVS_DEFAULT_STACK_SIZE);
+    CHK_ERR(result == 0, STATUS_THREAD_ATTR_SET_STACK_SIZE_FAILED, "pthread_attr_setstacksize failed with %d", result);
+#elif defined(CONSTRAINED_DEVICE)
     pthread_attr_t attr;
     pAttr = &attr;
     result = pthread_attr_init(pAttr);

--- a/src/utils/src/Thread.c
+++ b/src/utils/src/Thread.c
@@ -229,6 +229,7 @@ PUBLIC_API STATUS defaultCreateThread(PTID pThreadId, startRoutine start, PVOID 
     pthread_t threadId;
     INT32 result;
     pthread_attr_t* pAttr = NULL;
+    SIZE_T stackSize = 0;
 
     CHK(pThreadId != NULL, STATUS_NULL_ARG);
 
@@ -237,7 +238,8 @@ PUBLIC_API STATUS defaultCreateThread(PTID pThreadId, startRoutine start, PVOID 
     pAttr = &attr;
     result = pthread_attr_init(pAttr);
     CHK_ERR(result == 0, STATUS_THREAD_ATTR_INIT_FAILED, "pthread_attr_init failed with %d", result);
-    result = pthread_attr_setstacksize(&attr, KVS_DEFAULT_STACK_SIZE);
+    stackSize = KVS_DEFAULT_STACK_SIZE;
+    result = pthread_attr_setstacksize(&attr, stackSize);
     CHK_ERR(result == 0, STATUS_THREAD_ATTR_SET_STACK_SIZE_FAILED, "pthread_attr_setstacksize failed with %d", result);
 #elif defined(CONSTRAINED_DEVICE)
     pthread_attr_t attr;

--- a/src/utils/src/Thread.c
+++ b/src/utils/src/Thread.c
@@ -69,9 +69,9 @@ PUBLIC_API STATUS defaultCreateThread(PTID pThreadId, startRoutine start, PVOID 
     STATUS retStatus = STATUS_SUCCESS;
 
 #if defined(KVS_DEFAULT_STACK_SIZE)
-    CHK_STATUS(defaultCreateThreadWithParams(pThreadId, start, (SIZE_T)KVS_DEFAULT_STACK_SIZE, args);
+    CHK_STATUS(defaultCreateThreadWithParams(pThreadId, start, (SIZE_T) KVS_DEFAULT_STACK_SIZE, args));
 #else
-    CHK_STATUS(defaultCreateThreadWithParams(pThreadId, start, 0, args);
+    CHK_STATUS(defaultCreateThreadWithParams(pThreadId, start, 0, args));
 #endif
 
 CleanUp:
@@ -222,7 +222,7 @@ PUBLIC_API STATUS defaultCreateThread(PTID pThreadId, startRoutine start, PVOID 
 #elif defined(CONSTRAINED_DEVICE)
     CHK_STATUS(defaultCreateThreadWithParams(pThreadId, start, (SIZE_T) THREAD_STACK_SIZE_ON_CONSTRAINED_DEVICE, args));
 #else
-    CHK_STATUS(defaultCreateThreadWithParams(pThreadId, start, 0, args);
+    CHK_STATUS(defaultCreateThreadWithParams(pThreadId, start, 0, args));
 #endif
 
 CleanUp:

--- a/src/utils/src/Thread.c
+++ b/src/utils/src/Thread.c
@@ -68,8 +68,8 @@ PUBLIC_API STATUS defaultCreateThread(PTID pThreadId, startRoutine start, PVOID 
 {
     STATUS retStatus = STATUS_SUCCESS;
 
-#if defined(KVS_DEFAULT_STACK_SIZE)
-    CHK_STATUS(defaultCreateThreadWithParams(pThreadId, start, (SIZE_T) KVS_DEFAULT_STACK_SIZE, args));
+#if defined(KVS_DEFAULT_STACK_SIZE_BYTES)
+    CHK_STATUS(defaultCreateThreadWithParams(pThreadId, start, (SIZE_T) KVS_DEFAULT_STACK_SIZE_BYTES, args));
 #else
     CHK_STATUS(defaultCreateThreadWithParams(pThreadId, start, 0, args));
 #endif
@@ -222,8 +222,8 @@ PUBLIC_API STATUS defaultCreateThread(PTID pThreadId, startRoutine start, PVOID 
 {
     STATUS retStatus = STATUS_SUCCESS;
 
-#if defined(KVS_DEFAULT_STACK_SIZE)
-    CHK_STATUS(defaultCreateThreadWithParams(pThreadId, start, (SIZE_T) KVS_DEFAULT_STACK_SIZE, args));
+#if defined(KVS_DEFAULT_STACK_SIZE_BYTES)
+    CHK_STATUS(defaultCreateThreadWithParams(pThreadId, start, (SIZE_T) KVS_DEFAULT_STACK_SIZE_BYTES, args));
 #elif defined(CONSTRAINED_DEVICE)
     CHK_STATUS(defaultCreateThreadWithParams(pThreadId, start, (SIZE_T) THREAD_STACK_SIZE_ON_CONSTRAINED_DEVICE, args));
 #else

--- a/src/utils/src/Thread.c
+++ b/src/utils/src/Thread.c
@@ -165,6 +165,8 @@ PUBLIC_API TID defaultGetThreadId()
     return (TID) pthread_self();
 }
 
+#define PTHREAD_MIN_STACK_SIZE 16 * 1024
+
 PUBLIC_API STATUS defaultCreateThreadWithParams(PTID pThreadId, startRoutine start, SIZE_T stackSize, PVOID args)
 {
     STATUS retStatus = STATUS_SUCCESS;
@@ -176,6 +178,9 @@ PUBLIC_API STATUS defaultCreateThreadWithParams(PTID pThreadId, startRoutine sta
 
     pthread_attr_t attr;
     if (stackSize != 0) {
+        if (stackSize < (SIZE_T) PTHREAD_MIN_STACK_SIZE) {
+            stackSize = (SIZE_T) PTHREAD_MIN_STACK_SIZE;
+        }
         pAttr = &attr;
         result = pthread_attr_init(pAttr);
         CHK_ERR(result == 0, STATUS_THREAD_ATTR_INIT_FAILED, "pthread_attr_init failed with %d", result);

--- a/src/utils/src/Thread.c
+++ b/src/utils/src/Thread.c
@@ -165,8 +165,6 @@ PUBLIC_API TID defaultGetThreadId()
     return (TID) pthread_self();
 }
 
-#define PTHREAD_MIN_STACK_SIZE 16 * 1024
-
 PUBLIC_API STATUS defaultCreateThreadWithParams(PTID pThreadId, startRoutine start, SIZE_T stackSize, PVOID args)
 {
     STATUS retStatus = STATUS_SUCCESS;
@@ -178,9 +176,6 @@ PUBLIC_API STATUS defaultCreateThreadWithParams(PTID pThreadId, startRoutine sta
 
     pthread_attr_t attr;
     if (stackSize != 0) {
-        if (stackSize < (SIZE_T) PTHREAD_MIN_STACK_SIZE) {
-            stackSize = (SIZE_T) PTHREAD_MIN_STACK_SIZE;
-        }
         pAttr = &attr;
         result = pthread_attr_init(pAttr);
         CHK_ERR(result == 0, STATUS_THREAD_ATTR_INIT_FAILED, "pthread_attr_init failed with %d", result);

--- a/tst/utils/Thread.cpp
+++ b/tst/utils/Thread.cpp
@@ -124,7 +124,7 @@ TEST_F(ThreadFunctionalityTest, ThreadCreateAndReleaseSimpleCheckWithStack)
     TID threads[TEST_THREAD_COUNT];
     gThreadMutex = MUTEX_CREATE(FALSE);
     srand(GETTIME());
-    SIZE_T threadStack = 16 * 1024 + rand()%(500 * 1024);
+    SIZE_T threadStack = 16 * 1024 + rand()%(200 * 1024);
     struct sleep_times st[TEST_THREAD_COUNT];
 
     gThreadCount = 0;

--- a/tst/utils/Thread.cpp
+++ b/tst/utils/Thread.cpp
@@ -117,3 +117,36 @@ TEST_F(ThreadFunctionalityTest, ThreadCreateAndCancel)
 
     MUTEX_FREE(gThreadMutex);
 }
+
+TEST_F(ThreadFunctionalityTest, ThreadCreateAndReleaseSimpleCheckWithStack)
+{
+    UINT64 index;
+    TID threads[TEST_THREAD_COUNT];
+    gThreadMutex = MUTEX_CREATE(FALSE);
+    SIZE_T threadStack = 16 * 1024;
+    struct sleep_times st[TEST_THREAD_COUNT];
+
+    // Create the threads
+    for (index = 0; index < TEST_THREAD_COUNT; index++) {
+        st[index].threadVisited = FALSE;
+        st[index].threadCleared = FALSE;
+        st[index].threadSleepTime = index * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+        EXPECT_EQ(STATUS_SUCCESS, THREAD_CREATE_WITH_PARAMS(&threads[index], testThreadRoutine, threadStack, (PVOID)&st[index]));
+    }
+
+    // Await for the threads to finish
+    for (index = 0; index < TEST_THREAD_COUNT; index++) {
+        EXPECT_EQ(STATUS_SUCCESS, THREAD_JOIN(threads[index], NULL));
+    }
+
+    MUTEX_LOCK(gThreadMutex);
+    EXPECT_EQ(0, gThreadCount);
+    MUTEX_UNLOCK(gThreadMutex);
+
+    for (index = 0; index < TEST_THREAD_COUNT; index++) {
+        EXPECT_TRUE(st[index].threadVisited) << "Thread didn't visit index " << index;
+        EXPECT_TRUE(st[index].threadCleared) << "Thread didn't clear index " << index;
+    }
+
+    MUTEX_FREE(gThreadMutex);
+}

--- a/tst/utils/Thread.cpp
+++ b/tst/utils/Thread.cpp
@@ -126,6 +126,8 @@ TEST_F(ThreadFunctionalityTest, ThreadCreateAndReleaseSimpleCheckWithStack)
     SIZE_T threadStack = 16 * 1024;
     struct sleep_times st[TEST_THREAD_COUNT];
 
+    gThreadCount = 0;
+
     // Create the threads
     for (index = 0; index < TEST_THREAD_COUNT; index++) {
         st[index].threadVisited = FALSE;

--- a/tst/utils/Thread.cpp
+++ b/tst/utils/Thread.cpp
@@ -124,7 +124,7 @@ TEST_F(ThreadFunctionalityTest, ThreadCreateAndReleaseSimpleCheckWithStack)
     TID threads[TEST_THREAD_COUNT];
     gThreadMutex = MUTEX_CREATE(FALSE);
     srand(GETTIME());
-    SIZE_T threadStack = 16 * 1024 + rand()%(200 * 1024);
+    SIZE_T threadStack = 64 * 1024;
     struct sleep_times st[TEST_THREAD_COUNT];
 
     gThreadCount = 0;

--- a/tst/utils/Thread.cpp
+++ b/tst/utils/Thread.cpp
@@ -123,7 +123,8 @@ TEST_F(ThreadFunctionalityTest, ThreadCreateAndReleaseSimpleCheckWithStack)
     UINT64 index;
     TID threads[TEST_THREAD_COUNT];
     gThreadMutex = MUTEX_CREATE(FALSE);
-    SIZE_T threadStack = 16 * 1024;
+    srand(GETTIME());
+    SIZE_T threadStack = 16 * 1024 + rand()%(500 * 1024);
     struct sleep_times st[TEST_THREAD_COUNT];
 
     gThreadCount = 0;
@@ -149,6 +150,25 @@ TEST_F(ThreadFunctionalityTest, ThreadCreateAndReleaseSimpleCheckWithStack)
         EXPECT_TRUE(st[index].threadVisited) << "Thread didn't visit index " << index;
         EXPECT_TRUE(st[index].threadCleared) << "Thread didn't clear index " << index;
     }
+
+    MUTEX_FREE(gThreadMutex);
+}
+
+TEST_F(ThreadFunctionalityTest, NegativeTest)
+{
+    UINT64 index;
+    TID threads[TEST_THREAD_COUNT];
+    gThreadMutex = MUTEX_CREATE(FALSE);
+    SIZE_T threadStack = 16 * 1024;
+    struct sleep_times st[TEST_THREAD_COUNT];
+
+    gThreadCount = 0;
+    EXPECT_NE(STATUS_SUCCESS, THREAD_CREATE_WITH_PARAMS(NULL, testThreadRoutine, threadStack, NULL));
+    EXPECT_NE(STATUS_SUCCESS, THREAD_CREATE(NULL, testThreadRoutine, NULL));
+
+    MUTEX_LOCK(gThreadMutex);
+    EXPECT_EQ(0, gThreadCount);
+    MUTEX_UNLOCK(gThreadMutex);
 
     MUTEX_FREE(gThreadMutex);
 }


### PR DESCRIPTION
Issue #, if available:

*What was changed?*
Added API to support specifying stack size of threads at time of creation.
Added an ability to specify default stack sizes at compile time.

*Why was it changed?*
Libraries that use this asset as a dependency needed to be able to customize their thread stack sizes

*How was it changed?*
New API added, check for default compile time variable.

*What testing was done for the changes?*
Old tests passing, new tests added. Additional changes made in upstream libraries using this change that also have tests passing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
