### PR TITLE
Fix readFile on Windows

### DIFF
--- a/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
+++ b/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
@@ -922,6 +922,9 @@ extern PUBLIC_API atomicXor globalAtomicXor;
 #ifndef FREAD
 #define FREAD fread
 #endif
+#ifndef FEOF
+#define FEOF feof
+#endif
 #ifndef FSEEK
 #define FSEEK fseek
 #endif

--- a/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
+++ b/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
@@ -926,10 +926,18 @@ extern PUBLIC_API atomicXor globalAtomicXor;
 #define FEOF feof
 #endif
 #ifndef FSEEK
+#if defined _WIN32 || defined _WIN64
+#define FSEEK _fseeki64
+#else
 #define FSEEK fseek
 #endif
+#endif
 #ifndef FTELL
+#if defined _WIN32 || defined _WIN64
+#define FTELL _ftelli64
+#else
 #define FTELL ftell
+#endif
 #endif
 #ifndef FREMOVE
 #define FREMOVE remove

--- a/src/utils/src/FileIo.c
+++ b/src/utils/src/FileIo.c
@@ -23,8 +23,13 @@ STATUS readFile(PCHAR filePath, BOOL binMode, PBYTE pBuffer, PUINT64 pSize)
     CHK(fp != NULL, STATUS_OPEN_FILE_FAILED);
 
     // Get the size of the file
+#if defined _WIN32 || defined _WIN64
+    _fseeki64(fp, 0, SEEK_END);
+    fileLen = _ftelli64(fp);
+#else
     FSEEK(fp, 0, SEEK_END);
     fileLen = FTELL(fp);
+#endif
 
     if (pBuffer == NULL) {
         // requested the length - set and early return
@@ -75,8 +80,13 @@ STATUS readFileSegment(PCHAR filePath, BOOL binMode, PBYTE pBuffer, UINT64 offse
     CHK(fp != NULL, STATUS_OPEN_FILE_FAILED);
 
     // Get the size of the file
+#if defined _WIN32 || defined _WIN64
+    _fseeki64(fp, 0, SEEK_END);
+    fileLen = _ftelli64(fp);
+#else
     FSEEK(fp, 0, SEEK_END);
     fileLen = FTELL(fp);
+#endif
 
     // Check if we are trying to read past the end of the file
     CHK(offset + readSize <= fileLen, STATUS_READ_FILE_FAILED);

--- a/src/utils/src/FileIo.c
+++ b/src/utils/src/FileIo.c
@@ -80,7 +80,7 @@ STATUS readFileSegment(PCHAR filePath, BOOL binMode, PBYTE pBuffer, UINT64 offse
     CHK(fp != NULL, STATUS_OPEN_FILE_FAILED);
 
     // Get the size of the file
-#if defined _WIN32 || defined _WIN64
+#ifdef _WIN32
     _fseeki64(fp, 0, SEEK_END);
     fileLen = _ftelli64(fp);
 #else

--- a/src/utils/src/FileIo.c
+++ b/src/utils/src/FileIo.c
@@ -28,13 +28,8 @@ STATUS readFile(PCHAR filePath, BOOL binMode, PBYTE pBuffer, PUINT64 pSize)
     // the same guarantees as POSIX. On these systems, setting the file position indicator to the
     // end of the file using fseek() is not guaranteed to work for a binary stream, and consequently,
     // the amount of memory allocated may be incorrect, leading to a potential vulnerability.
-#if defined _WIN32 || defined _WIN64
-    _fseeki64(fp, 0, SEEK_END);
-    fileLen = _ftelli64(fp);
-#else
     FSEEK(fp, 0, SEEK_END);
     fileLen = FTELL(fp);
-#endif
 
     if (pBuffer == NULL) {
         // requested the length - set and early return
@@ -97,13 +92,8 @@ STATUS readFileSegment(PCHAR filePath, BOOL binMode, PBYTE pBuffer, UINT64 offse
     // the same guarantees as POSIX. On these systems, setting the file position indicator to the
     // end of the file using fseek() is not guaranteed to work for a binary stream, and consequently,
     // the amount of memory allocated may be incorrect, leading to a potential vulnerability.
-#if defined _WIN32 || defined _WIN64
-    _fseeki64(fp, 0, SEEK_END);
-    fileLen = _ftelli64(fp);
-#else
     FSEEK(fp, 0, SEEK_END);
     fileLen = FTELL(fp);
-#endif
 
     // Check if we are trying to read past the end of the file
     CHK(offset + readSize <= fileLen, STATUS_READ_FILE_FAILED);

--- a/src/utils/src/FileIo.c
+++ b/src/utils/src/FileIo.c
@@ -23,7 +23,7 @@ STATUS readFile(PCHAR filePath, BOOL binMode, PBYTE pBuffer, PUINT64 pSize)
     CHK(fp != NULL, STATUS_OPEN_FILE_FAILED);
 
     // Get the size of the file
-#if defined _WIN32 || defined _WIN64
+#ifdef _WIN32
     _fseeki64(fp, 0, SEEK_END);
     fileLen = _ftelli64(fp);
 #else

--- a/src/utils/src/FileIo.c
+++ b/src/utils/src/FileIo.c
@@ -23,7 +23,12 @@ STATUS readFile(PCHAR filePath, BOOL binMode, PBYTE pBuffer, PUINT64 pSize)
     CHK(fp != NULL, STATUS_OPEN_FILE_FAILED);
 
     // Get the size of the file
-#ifdef _WIN32
+
+    // Use Windows-specific _fseeki64 and _ftelli64 as the traditional fseek and ftell are non-compliant on systems that do not provide 
+    // the same guarantees as POSIX. On these systems, setting the file position indicator to the 
+    // end of the file using fseek() is not guaranteed to work for a binary stream, and consequently, 
+    // the amount of memory allocated may be incorrect, leading to a potential vulnerability. 
+#if defined _WIN32 || defined _WIN64
     _fseeki64(fp, 0, SEEK_END);
     fileLen = _ftelli64(fp);
 #else
@@ -42,7 +47,14 @@ STATUS readFile(PCHAR filePath, BOOL binMode, PBYTE pBuffer, PUINT64 pSize)
 
     // Read the file into memory buffer
     FSEEK(fp, 0, SEEK_SET);
-    CHK(FREAD(pBuffer, (SIZE_T) fileLen, 1, fp) == 1, STATUS_READ_FILE_FAILED);
+
+    // fread would either return 1, i.e, the number of objects we've requested it to read
+    // or it would run into end-of-file / error.
+    // fread does not distinguish between end-of-file and error, 
+    // and callers must use feof and ferror to determine which occurred.
+    if (FREAD(pBuffer, (SIZE_T) fileLen, 1, fp) != 1) {
+        CHK(FEOF(fp), STATUS_READ_FILE_FAILED);   
+    }
 
 CleanUp:
 
@@ -80,7 +92,12 @@ STATUS readFileSegment(PCHAR filePath, BOOL binMode, PBYTE pBuffer, UINT64 offse
     CHK(fp != NULL, STATUS_OPEN_FILE_FAILED);
 
     // Get the size of the file
-#ifdef _WIN32
+
+    // Use Windows-specific _fseeki64 and _ftelli64 as the traditional fseek and ftell are non-compliant on systems that do not provide 
+    // the same guarantees as POSIX. On these systems, setting the file position indicator to the 
+    // end of the file using fseek() is not guaranteed to work for a binary stream, and consequently, 
+    // the amount of memory allocated may be incorrect, leading to a potential vulnerability. 
+#if defined _WIN32 || defined _WIN64
     _fseeki64(fp, 0, SEEK_END);
     fileLen = _ftelli64(fp);
 #else
@@ -93,7 +110,16 @@ STATUS readFileSegment(PCHAR filePath, BOOL binMode, PBYTE pBuffer, UINT64 offse
 
     // Set the offset and read the file content
     result = FSEEK(fp, (UINT32) offset, SEEK_SET);
-    CHK(result == 0 && (FREAD(pBuffer, (SIZE_T) readSize, 1, fp) == 1), STATUS_READ_FILE_FAILED);
+
+    CHK(result == 0, STATUS_READ_FILE_FAILED);
+
+    // fread would either return 1, i.e, the number of objects we've requested it to read
+    // or it would run into end-of-file / error.
+    // fread does not distinguish between end-of-file and error, 
+    // and callers must use feof and ferror to determine which occurred.
+    if (FREAD(pBuffer, (SIZE_T) readSize, 1, fp) != 1) {
+        CHK(FEOF(fp), STATUS_READ_FILE_FAILED); 
+    }
 
 CleanUp:
 

--- a/src/utils/src/FileIo.c
+++ b/src/utils/src/FileIo.c
@@ -24,10 +24,10 @@ STATUS readFile(PCHAR filePath, BOOL binMode, PBYTE pBuffer, PUINT64 pSize)
 
     // Get the size of the file
 
-    // Use Windows-specific _fseeki64 and _ftelli64 as the traditional fseek and ftell are non-compliant on systems that do not provide 
-    // the same guarantees as POSIX. On these systems, setting the file position indicator to the 
-    // end of the file using fseek() is not guaranteed to work for a binary stream, and consequently, 
-    // the amount of memory allocated may be incorrect, leading to a potential vulnerability. 
+    // Use Windows-specific _fseeki64 and _ftelli64 as the traditional fseek and ftell are non-compliant on systems that do not provide
+    // the same guarantees as POSIX. On these systems, setting the file position indicator to the
+    // end of the file using fseek() is not guaranteed to work for a binary stream, and consequently,
+    // the amount of memory allocated may be incorrect, leading to a potential vulnerability.
 #if defined _WIN32 || defined _WIN64
     _fseeki64(fp, 0, SEEK_END);
     fileLen = _ftelli64(fp);
@@ -50,10 +50,10 @@ STATUS readFile(PCHAR filePath, BOOL binMode, PBYTE pBuffer, PUINT64 pSize)
 
     // fread would either return 1, i.e, the number of objects we've requested it to read
     // or it would run into end-of-file / error.
-    // fread does not distinguish between end-of-file and error, 
+    // fread does not distinguish between end-of-file and error,
     // and callers must use feof and ferror to determine which occurred.
     if (FREAD(pBuffer, (SIZE_T) fileLen, 1, fp) != 1) {
-        CHK(FEOF(fp), STATUS_READ_FILE_FAILED);   
+        CHK(FEOF(fp), STATUS_READ_FILE_FAILED);
     }
 
 CleanUp:
@@ -93,10 +93,10 @@ STATUS readFileSegment(PCHAR filePath, BOOL binMode, PBYTE pBuffer, UINT64 offse
 
     // Get the size of the file
 
-    // Use Windows-specific _fseeki64 and _ftelli64 as the traditional fseek and ftell are non-compliant on systems that do not provide 
-    // the same guarantees as POSIX. On these systems, setting the file position indicator to the 
-    // end of the file using fseek() is not guaranteed to work for a binary stream, and consequently, 
-    // the amount of memory allocated may be incorrect, leading to a potential vulnerability. 
+    // Use Windows-specific _fseeki64 and _ftelli64 as the traditional fseek and ftell are non-compliant on systems that do not provide
+    // the same guarantees as POSIX. On these systems, setting the file position indicator to the
+    // end of the file using fseek() is not guaranteed to work for a binary stream, and consequently,
+    // the amount of memory allocated may be incorrect, leading to a potential vulnerability.
 #if defined _WIN32 || defined _WIN64
     _fseeki64(fp, 0, SEEK_END);
     fileLen = _ftelli64(fp);
@@ -115,10 +115,10 @@ STATUS readFileSegment(PCHAR filePath, BOOL binMode, PBYTE pBuffer, UINT64 offse
 
     // fread would either return 1, i.e, the number of objects we've requested it to read
     // or it would run into end-of-file / error.
-    // fread does not distinguish between end-of-file and error, 
+    // fread does not distinguish between end-of-file and error,
     // and callers must use feof and ferror to determine which occurred.
     if (FREAD(pBuffer, (SIZE_T) readSize, 1, fp) != 1) {
-        CHK(FEOF(fp), STATUS_READ_FILE_FAILED); 
+        CHK(FEOF(fp), STATUS_READ_FILE_FAILED);
     }
 
 CleanUp:

--- a/tst/client/ClientTestFixture.h
+++ b/tst/client/ClientTestFixture.h
@@ -72,7 +72,6 @@
 #define TEST_DEFAULT_PRODUCER_CONFIG_FRAME_SIZE 50000
 #define TEST_DEFAULT_PRODUCER_CONFIG_FRAME_RATE 20
 
-
 #define PASS_TEST_FOR_ZERO_RETENTION_AND_OFFLINE()                                                                                                   \
     if ((mStreamInfo.retention == 0 || !mStreamInfo.streamCaps.fragmentAcks) && mStreamInfo.streamCaps.streamingType == STREAMING_TYPE_OFFLINE) {    \
         EXPECT_EQ(STATUS_OFFLINE_MODE_WITH_ZERO_RETENTION, createKinesisVideoStreamSync(mClientHandle, &mStreamInfo, &mStreamHandle));               \

--- a/tst/utils/FileIo.cpp
+++ b/tst/utils/FileIo.cpp
@@ -33,7 +33,15 @@ TEST_F(FileIoUnitTest, readFile_asciiBufferTooSmall) {
     FCLOSE(file);
 
     EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH "asciitest"), FALSE, NULL, &fileSize));
+
+// In Windows systems, the newline character is represented by a combination of 
+// two characters: Carriage Return (CR) followed by Line Feed (LF), written as \r\n. 
+// So, each newline character in a text file on Windows contributes two bytes to the file size.
+#if defined _WIN32 || defined _WIN64    
+    EXPECT_EQ(48, fileSize);
+#else
     EXPECT_EQ(45, fileSize);
+#endif
 
     fileSize = 43;
 
@@ -74,7 +82,15 @@ TEST_F(FileIoFunctionalityTest, readFile_asciiFileSize) {
     FCLOSE(file);
 
     EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH "asciitest"), FALSE, NULL, &fileSize));
+
+// In Windows systems, the newline character is represented by a combination of 
+// two characters: Carriage Return (CR) followed by Line Feed (LF), written as \r\n. 
+// So, each newline character in a text file on Windows contributes two bytes to the file size.
+#if defined _WIN32 || defined _WIN64    
+    EXPECT_EQ(48, fileSize);
+#else
     EXPECT_EQ(45, fileSize);
+#endif
 
     remove((PCHAR) (TEST_TEMP_DIR_PATH "asciitest"));
 }
@@ -124,7 +140,15 @@ TEST_F(FileIoFunctionalityTest, readFile_ascii) {
     FCLOSE(file);
 
     EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH "asciitest"), FALSE, NULL, &fileSize));
+
+// In Windows systems, the newline character is represented by a combination of 
+// two characters: Carriage Return (CR) followed by Line Feed (LF), written as \r\n. 
+// So, each newline character in a text file on Windows contributes two bytes to the file size.
+#if defined _WIN32 || defined _WIN64    
+    EXPECT_EQ(48, fileSize);
+#else
     EXPECT_EQ(45, fileSize);
+#endif
 
     fileBuffer = (PCHAR) MEMCALLOC(1, (fileSize + 1) * SIZEOF(CHAR));
     EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH "asciitest"), FALSE, (PBYTE) fileBuffer, &fileSize));

--- a/tst/utils/FileIo.cpp
+++ b/tst/utils/FileIo.cpp
@@ -1,0 +1,135 @@
+#include "UtilTestFixture.h"
+
+#ifdef _WIN32
+#define TEST_TEMP_DIR_PATH                                      (PCHAR) "C:\\Windows\\Temp\\"
+#define TEST_TEMP_DIR_PATH_NO_ENDING_SEPARTOR                   (PCHAR) "C:\\Windows\\Temp"
+#else
+#define TEST_TEMP_DIR_PATH                                      (PCHAR) "/tmp/"
+#define TEST_TEMP_DIR_PATH_NO_ENDING_SEPARTOR                   (PCHAR) "/tmp"
+#endif
+
+class FileIoFunctionalityTest : public UtilTestBase {
+};
+
+class FileIoUnitTest : public UtilTestBase {
+};
+
+TEST_F(FileIoUnitTest, readFile_filePathNull) {
+    EXPECT_EQ(STATUS_NULL_ARG, readFile(NULL, TRUE, NULL, NULL));
+    EXPECT_EQ(STATUS_NULL_ARG, readFile(NULL, FALSE, NULL, NULL));
+}
+
+TEST_F(FileIoUnitTest, readFile_sizeNull) {
+    EXPECT_EQ(STATUS_NULL_ARG, readFile((PCHAR) (TEST_TEMP_DIR_PATH "test"), TRUE, NULL, NULL));
+    EXPECT_EQ(STATUS_NULL_ARG, readFile((PCHAR) (TEST_TEMP_DIR_PATH "test"), FALSE, NULL, NULL));
+}
+
+TEST_F(FileIoUnitTest, readFile_asciiBufferTooSmall) {
+    FILE *file = FOPEN((PCHAR) (TEST_TEMP_DIR_PATH "asciitest"), "w");
+    UINT64 fileSize = 43;
+    PCHAR fileBuffer = NULL;
+
+    fprintf(file, "This is line 1\nThis is line 2\nThis is line 3\n");
+    FCLOSE(file);
+
+    EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH "asciitest"), FALSE, NULL, &fileSize));
+    EXPECT_EQ(45, fileSize);
+
+    fileSize = 43;
+
+    fileBuffer = (PCHAR) MEMCALLOC(1, (fileSize + 1) * SIZEOF(CHAR));
+    EXPECT_EQ(STATUS_BUFFER_TOO_SMALL, readFile((PCHAR) (TEST_TEMP_DIR_PATH "asciitest"), FALSE, (PBYTE) fileBuffer, &fileSize));
+
+    remove((PCHAR) (TEST_TEMP_DIR_PATH "asciitest"));
+    SAFE_MEMFREE(fileBuffer);
+}
+
+TEST_F(FileIoUnitTest, readFile_binaryBufferTooSmall) {
+    FILE *file = fopen((PCHAR) (TEST_TEMP_DIR_PATH "binarytest"), "wb");
+    UINT64 fileSize = 43;
+    PCHAR fileBuffer = NULL;
+    CHAR data[100] = "This is line 1\nThis is line 2\nThis is line 3\n";
+   
+    FWRITE(data, SIZEOF(CHAR), STRLEN(data), file);
+    FCLOSE(file);
+
+    EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH "binarytest"), TRUE, NULL, &fileSize));
+    EXPECT_EQ(45, fileSize);
+
+    fileSize = 43;
+
+    fileBuffer = (PCHAR) MEMCALLOC(1, (fileSize + 1) * SIZEOF(CHAR));
+    EXPECT_EQ(STATUS_BUFFER_TOO_SMALL, readFile((PCHAR) (TEST_TEMP_DIR_PATH "binarytest"), TRUE, (PBYTE) fileBuffer, &fileSize));
+
+    remove((PCHAR) (TEST_TEMP_DIR_PATH "binarytest"));
+    SAFE_MEMFREE(fileBuffer);
+}
+
+TEST_F(FileIoFunctionalityTest, readFile_asciiFileSize) {
+    FILE *file = FOPEN((PCHAR) (TEST_TEMP_DIR_PATH "asciitest"), "w");
+    CHAR fileBuffer[256];
+    UINT64 fileSize = ARRAY_SIZE(fileBuffer);
+
+    fprintf(file, "This is line 1\nThis is line 2\nThis is line 3\n");
+    FCLOSE(file);
+
+    EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH "asciitest"), FALSE, NULL, &fileSize));
+    EXPECT_EQ(45, fileSize);
+
+    remove((PCHAR) (TEST_TEMP_DIR_PATH "asciitest"));
+}
+
+TEST_F(FileIoFunctionalityTest, readFile_binaryFileSize) {
+    FILE *file = fopen((PCHAR) (TEST_TEMP_DIR_PATH "binarytest"), "wb");
+    CHAR fileBuffer[256];
+    CHAR data[100] = "This is line 1\nThis is line 2\nThis is line 3\n";
+    UINT64 fileSize = ARRAY_SIZE(fileBuffer);
+
+    FWRITE(data, SIZEOF(CHAR), STRLEN(data), file);
+    FCLOSE(file);
+
+    EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR)(TEST_TEMP_DIR_PATH "binarytest"), TRUE, NULL, &fileSize));
+    EXPECT_EQ(45, fileSize);
+
+    remove((PCHAR) (TEST_TEMP_DIR_PATH "binarytest"));
+}
+
+TEST_F(FileIoFunctionalityTest, readFile_binary) {
+    FILE *file = fopen((PCHAR) (TEST_TEMP_DIR_PATH "binarytest"), "wb");
+    UINT64 fileSize;
+    PCHAR fileBuffer = NULL;
+    CHAR data[100] = "This is line 1\nThis is line 2\nThis is line 3\n";
+   
+    FWRITE(data, SIZEOF(CHAR), STRLEN(data), file);
+    FCLOSE(file);
+
+    EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH "binarytest"), TRUE, NULL, &fileSize));
+    EXPECT_EQ(45, fileSize);
+
+    fileBuffer = (PCHAR) MEMCALLOC(1, (fileSize + 1) * SIZEOF(CHAR));
+    EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH "binarytest"), TRUE, (PBYTE) fileBuffer, &fileSize));
+    EXPECT_STREQ(data, fileBuffer);
+
+    remove((PCHAR) (TEST_TEMP_DIR_PATH "binarytest"));
+    SAFE_MEMFREE(fileBuffer);
+}
+
+TEST_F(FileIoFunctionalityTest, readFile_ascii) {
+    FILE *file = fopen((PCHAR) (TEST_TEMP_DIR_PATH "asciitest"), "w");
+    UINT64 fileSize;
+    PCHAR fileBuffer = NULL;
+    CHAR data[100] = "This is line 1\nThis is line 2\nThis is line 3\n";
+   
+    FWRITE(data, SIZEOF(CHAR), STRLEN(data), file);
+    FCLOSE(file);
+
+    EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH "asciitest"), FALSE, NULL, &fileSize));
+    EXPECT_EQ(45, fileSize);
+
+    fileBuffer = (PCHAR) MEMCALLOC(1, (fileSize + 1) * SIZEOF(CHAR));
+    EXPECT_EQ(STATUS_SUCCESS, readFile((PCHAR) (TEST_TEMP_DIR_PATH "asciitest"), FALSE, (PBYTE) fileBuffer, &fileSize));
+    EXPECT_STREQ(data, fileBuffer);
+
+    remove((PCHAR) (TEST_TEMP_DIR_PATH "asciitest"));
+    SAFE_MEMFREE(fileBuffer);
+}


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
- Fix readFile to work properly for multiline files on Windows

*Why was it changed?*
- The readFile was not working as expected from WebRTC C SDK in ASCII mode. To ensure that fread, fseek and ftell works on Windows as expected, compatible functions with expected return values are evaluated and used.

*How was it changed?*
- Use Windows-specific _fseeki64 and _ftelli64 as the traditional fseek and ftell are non-compliant on systems that do not provide the same guarantees as POSIX. On these systems, setting the file position indicator to the end of the file using fseek() is not guaranteed to work for a binary stream, and consequently, the amount of memory allocated may be incorrect, leading to a potential vulnerability ([Reference](https://wiki.sei.cmu.edu/confluence/display/c/FIO19-C.+Do+not+use+fseek()+and+ftell()+to+compute+the+size+of+a+regular+file))
- fread would either return 1, i.e, the number of objects we've requested it to read or it would run into end-of-file / error. fread does not distinguish between end-of-file and error, so I used feof to determine it is indeed end-of-file and not an error. ([Reference](https://en.cppreference.com/w/c/io/fread))

*What testing was done for the changes?*
- Wrote unit and functionality tests
- Tested manually on Windows
![Screenshot 2024-02-22 at 8 58 01 AM](https://github.com/awslabs/amazon-kinesis-video-streams-pic/assets/27426488/045e6831-5e4e-4196-9c5f-341c4bb8cda4)
![Screenshot 2024-02-22 at 8 57 47 AM](https://github.com/awslabs/amazon-kinesis-video-streams-pic/assets/27426488/119ca281-7981-4ab3-8d29-2f5ed4f6e410)
![Screenshot 2024-02-22 at 8 57 25 AM](https://github.com/awslabs/amazon-kinesis-video-streams-pic/assets/27426488/255ba8ed-e54d-4535-b662-bacc230746e3)

- Tested manually on MacOS
<img width="729" alt="Screenshot 2024-02-22 at 1 43 25 PM" src="https://github.com/awslabs/amazon-kinesis-video-streams-pic/assets/27426488/ebc852aa-4753-4336-9a9b-88dbca6b0e8a">

![Screenshot 2024-02-22 at 8 54 11 AM](https://github.com/awslabs/amazon-kinesis-video-streams-pic/assets/27426488/502881be-3677-42cc-8d79-8c5b7c3a79b6)

![Screenshot 2024-02-22 at 8 53 52 AM](https://github.com/awslabs/amazon-kinesis-video-streams-pic/assets/27426488/4410505e-3748-423c-9b5c-1989dcfc2dae)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
