### PR TITLE
Change fragment metadata count from 25 to 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-11
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install clang-format
         run: |
           brew install clang-format
@@ -30,7 +30,7 @@ jobs:
       AWS_KVS_LOG_LEVEL: 2
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build repository
         run: |
           mkdir build && cd build
@@ -56,7 +56,7 @@ jobs:
       AWS_KVS_LOG_LEVEL: 2
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build repository
         run: |
           mkdir build && cd build
@@ -82,7 +82,7 @@ jobs:
       AWS_KVS_LOG_LEVEL: 2
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build repository
         run: |
           brew unlink openssl
@@ -115,7 +115,7 @@ jobs:
         with:
           xcode-version: '15.2'    
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build repository
         run: |
           brew unlink openssl
@@ -142,7 +142,7 @@ jobs:
       AWS_KVS_LOG_LEVEL: 2
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build repository
         run: |
           mkdir build && cd build
@@ -174,7 +174,7 @@ jobs:
       AWS_KVS_LOG_LEVEL: 2
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build repository
         run: |
           mkdir build && cd build
@@ -204,7 +204,7 @@ jobs:
       AWS_KVS_LOG_LEVEL: 2
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -236,7 +236,7 @@ jobs:
       CC: gcc-4.4
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install deps
         run: |
           sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
@@ -274,7 +274,7 @@ jobs:
   #     AWS_KVS_LOG_LEVEL: 2
   #   steps:
   #     - name: Clone repository
-  #       uses: actions/checkout@v2
+  #       uses: actions/checkout@v4
   #     - name: Install dependencies
   #       run: |
   #         sudo apt-get update
@@ -295,7 +295,7 @@ jobs:
       AWS_KVS_LOG_LEVEL: 2
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -326,7 +326,7 @@ jobs:
       AWS_KVS_LOG_LEVEL: 7
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build and run
         run: |
           .github/build_windows.bat
@@ -344,7 +344,7 @@ jobs:
           sudo apt update
           sudo apt-get -y install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build Repository
         run: |
           sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
@@ -362,7 +362,7 @@ jobs:
           sudo apt update
           sudo apt-get -y install gcc-arm-linux-gnueabi g++-arm-linux-gnueabi binutils-arm-linux-gnueabi
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build Repository
         run: |
           sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
       - master
 jobs:
   clang-format-check:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - name: Clone repository
         uses: actions/checkout@v4

--- a/src/client/include/com/amazonaws/kinesis/video/client/Include.h
+++ b/src/client/include/com/amazonaws/kinesis/video/client/Include.h
@@ -272,7 +272,7 @@ extern "C" {
 /**
  * Maximal size of the metadata queue for a fragment
  */
-#define MAX_FRAGMENT_METADATA_COUNT 25
+#define MAX_FRAGMENT_METADATA_COUNT 10
 
 /**
  * Maximum amount of the "tags" element metadata for a fragment

--- a/src/client/include/com/amazonaws/kinesis/video/client/Include.h
+++ b/src/client/include/com/amazonaws/kinesis/video/client/Include.h
@@ -277,7 +277,7 @@ extern "C" {
 /**
  * Maximum amount of the "tags" element metadata for a fragment
  */
-#define MAX_FRAGMENT_METADATA_TAGS 10
+#define MAX_FRAGMENT_METADATA_TAGS MAX_FRAGMENT_METADATA_COUNT
 
 /**
  * Max name/value pairs for custom event metadata

--- a/tst/client/StreamPutGetTest.cpp
+++ b/tst/client/StreamPutGetTest.cpp
@@ -1427,8 +1427,8 @@ TEST_F(StreamPutGetTest, putFrame_PutGetNotifyAndTagsStoreData)
         // Set the frame bits
         MEMSET(frame.frameData, (BYTE) i, SIZEOF(tempBuffer));
 
-        // Key frame every 10th
-        frame.flags = i % 10 == 0 ? FRAME_FLAG_KEY_FRAME : FRAME_FLAG_NONE;
+        // Key frame every 8th
+        frame.flags = i % 8 == 0 ? FRAME_FLAG_KEY_FRAME : FRAME_FLAG_NONE;
 
         EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(mStreamHandle, &frame)) << "Iteration " << i;
         EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFragmentMetadata(mStreamHandle, (PCHAR) "postTagName", (PCHAR) "postTagValue", FALSE)) << i;
@@ -1449,7 +1449,7 @@ TEST_F(StreamPutGetTest, putFrame_PutGetNotifyAndTagsStoreData)
     ASSERT_TRUE(retStatus == STATUS_SUCCESS || retStatus == STATUS_NO_MORE_DATA_AVAILABLE);
 
     // Manually pre-validated data file size
-    EXPECT_EQ(18646, filledSize);
+    EXPECT_EQ(19150, filledSize);
 
     // Store the data in a file
     EXPECT_EQ(STATUS_SUCCESS, writeFile((PCHAR) "test_put_get_tags.mkv", TRUE, FALSE, getDataBuffer, filledSize));


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
- Modified `MAX_FRAGMENT_METADATA_COUNT` to 10 
- Modified actions/checkout@v2 to v4
- Moved from macos-11 to macos-12 as the former has been deprecated

*Why was it changed?*
- Changed because that is the limit from the backend
- v2 is an older version and v4 is the latest

*How was it changed?*
- Updated the `MAX_FRAGMENT_METADATA_COUNT`
- Updated the ci.yml

*What testing was done for the changes?*
- The CI tests cover this change

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
