### PR TITLE
Log line fix

### DIFF
--- a/src/client/src/Client.c
+++ b/src/client/src/Client.c
@@ -646,9 +646,9 @@ STATUS stopKinesisVideoStreamSync(STREAM_HANDLE streamHandle)
     BOOL releaseClientSemaphore = FALSE, releaseStreamSemaphore = FALSE, streamsListLock = FALSE;
     PKinesisVideoStream pKinesisVideoStream = FROM_STREAM_HANDLE(streamHandle);
 
-    DLOGI("Synchronously stopping Kinesis Video Stream %016" PRIx64 ".", streamHandle);
-
     CHK(pKinesisVideoStream != NULL && pKinesisVideoStream->pKinesisVideoClient != NULL, STATUS_NULL_ARG);
+
+    DLOGI("[%s] Synchronously stopping Kinesis Video Stream", pKinesisVideoStream->streamInfo.name);
 
     // Shutdown sequencer
     CHK_STATUS(semaphoreAcquire(pKinesisVideoStream->pKinesisVideoClient->base.shutdownSemaphore, INFINITE_TIME_VALUE));

--- a/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
+++ b/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
@@ -1103,8 +1103,8 @@ typedef SIZE_T ATOMIC_BOOL;
 //
 // Aligns an integer X value up or down to alignment A
 //
-#define ROUND_DOWN(X, A) ((X) & ~((A) -1))
-#define ROUND_UP(X, A)   (((X) + (A) -1) & ~((A) -1))
+#define ROUND_DOWN(X, A) ((X) & ~((A) - 1))
+#define ROUND_UP(X, A)   (((X) + (A) - 1) & ~((A) - 1))
 
 //
 // Macros to swap endinanness
@@ -1129,7 +1129,7 @@ typedef SIZE_T ATOMIC_BOOL;
 //
 // Check if at most 1 bit is set
 //
-#define CHECK_POWER_2(x) !((x) & ((x) -1))
+#define CHECK_POWER_2(x) !((x) & ((x) - 1))
 
 //
 // Checks if only 1 bit is set

--- a/src/heap/src/AivHeap.h
+++ b/src/heap/src/AivHeap.h
@@ -82,7 +82,7 @@ typedef struct {
 /**
  * Gets the allocation header
  */
-#define GET_AIV_ALLOCATION_HEADER(p) ((PAIV_ALLOCATION_HEADER) (p) -1)
+#define GET_AIV_ALLOCATION_HEADER(p) ((PAIV_ALLOCATION_HEADER) (p) - 1)
 
 /**
  * Retrieve the allocation size


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
- Include stream name in the log line while stopping stream instead of handle.

*Why was it changed?*
- Stream handle value is not informative. Stream name is

*How was it changed?*

- `stopKinesisVideoStreamSync(): [test] Synchronously stopping Kinesis Video Stream` -> this is how it looks now. 
- Earlier: Synchronously stopping Kinesis Video Stream 123345353

*What testing was done for the changes?*
- Tested with samples to confirm the change works.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.