### PR TITLE
Enhance stream state recovery after interruptions

### DIFF
--- a/src/client/src/Stream.h
+++ b/src/client/src/Stream.h
@@ -92,6 +92,54 @@ extern "C" {
 #define KVSEVENT_IMAGE_PREFIX_STRING     "AWS_KINESISVIDEO_IMAGE_PREFIX"
 #define KVSEVENT_NOTIFICATION_STRING     "AWS_KINESISVIDEO_NOTIFICATION"
 
+
+#define RECOVERY_STATE_FILE_PATH "stream_recovery_state.bin"
+
+
+////////////////////////////////////////////////////
+// Stream Recovery Status Codes
+////////////////////////////////////////////////////
+#define STATUS_PERSISTENCE_ERROR 0x15000001         // Error status for persistence issues
+#define STATUS_RECOVERY_STATE_NOT_FOUND 0x15000002  // Recovery state not found in persistence storage
+#define STATUS_INVALID_RECOVERY_STATE 0x15000003    // Invalid recovery state
+
+////////////////////////////////////////////////////
+// StreamRecoveryState Structure Definition
+////////////////////////////////////////////////////
+typedef struct __StreamRecoveryState {
+    UINT64 viewItemIndex;           // Index of the current view item (key frame/fragment start).
+    UINT64 viewItemTimestamp;       // Timestamp of the current view item (PTS).
+    UINT64 viewItemAckTimestamp;    // Acknowledgment timestamp (for ACK tracking).
+    UINT64 viewItemDuration;        // Duration of the current view item.
+    UINT32 viewItemLength;          // Length of the data in bytes.
+    UINT64 sessionStartTimestamp;   // Timestamp of when the session started.
+    UINT64 bytesTransferred;        // Total bytes transferred so far in the session.
+    BOOL eosMetadataSendFlag;       // End-of-Stream (EOS) metadata send flag
+    BOOL lastReceivedAck;           // Whether the last received ACK was successfully processed.
+    BOOL streamStopped;             // Whether the stream was stopped or interrupted.
+} StreamRecoveryState, *PStreamRecoveryState;
+
+////////////////////////////////////////////////////
+// Function Definitions for Saving/Loading Stream Recovery State
+////////////////////////////////////////////////////
+/**
+ * Saves the StreamRecoveryState to persistent storage.
+ * 
+ * @param pState Pointer to the StreamRecoveryState to save.
+ * @return STATUS_SUCCESS if successful, STATUS_PERSISTENCE_ERROR if there's an error.
+ */
+STATUS saveStreamRecoveryStateToPersistence(PStreamRecoveryState pState);
+
+/**
+ * Loads the StreamRecoveryState from persistent storage.
+ * 
+ * @param pState Pointer to the StreamRecoveryState to load the data into.
+ * @return STATUS_SUCCESS if successful, STATUS_RECOVERY_STATE_NOT_FOUND if no state exists, 
+ *         STATUS_INVALID_RECOVERY_STATE if the state is invalid.
+ */
+STATUS loadStreamRecoveryStateFromPersistence(PStreamRecoveryState pState);
+
+
 /**
  * Kinesis Video stream diagnostics information accumulator
  */


### PR DESCRIPTION
Description of changes: This PR introduces improvements in the handling of stream state recovery in cases of interruptions, such as application crashes or connection drops, to prevent loss of important session data. Specifically, the changes include:

Stream Recovery State Structure: Added a new StreamRecoveryState structure to track essential stream properties like the current view item index, timestamps (PTS/DTS), transferred bytes, and flags indicating whether metadata is being sent (e.g., eosMetadataSendFlag). This allows for more precise recovery of the stream state after interruptions.

Improved State Persistence: The saveStreamRecoveryState and loadStreamRecoveryState functions have been updated to save the stream state at key frames (start of each fragment). This ensures that when an interruption occurs, the stream can resume from the last known good state.

Connection Failure Handling: Added better detection of interruptions using connectionDroppedResult and connectionState flags. If an error or crash is detected, the stream state is loaded from persistent storage and the streaming session resumes without losing critical session information.

Testing:

Verified the changes by simulating application crashes and connection drops. Ensured that streams recover and continue streaming from the last saved key frame without any data loss.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.