### PR TITLE
Fix unit test when log level env variable is not set

### DIFF
--- a/tst/client/ClientTestFixture.h
+++ b/tst/client/ClientTestFixture.h
@@ -371,7 +371,7 @@ class ClientTestBase : public ::testing::Test {
 
     void initTestMembers()
     {
-        UINT32 logLevel = 0;
+        UINT32 logLevel = LOG_LEVEL_WARN;
         STATUS retStatus = STATUS_SUCCESS;
         auto logLevelStr = GETENV("AWS_KVS_LOG_LEVEL");
         if (logLevelStr != NULL) {


### PR DESCRIPTION
*Issue #, if available:*
N/A

*What was changed?*
- Unit test. Specifically, "ClientApiTest.client_info_version_test".

*Why was it changed?*
- It was failing with the a similar output to this when I cloned it onto my system:

```
[ RUN      ] ClientApiTest.client_info_version_test

[0x00007ff84935e800] [level 4] InputValidator fixupClientInfo(): Connection timeout is invalid...setting to default
[0x00007ff84935e800] [level 4] InputValidator fixupClientInfo(): Completion timeout is invalid...setting to default
[0x00007ff84935e800] [level 4] InputValidator fixupClientInfo(): Invalid ClientInfo version/Users/runner/work/amazon-kinesis-video-streams-pic/amazon-kinesis-video-streams-pic/tst/client/ClientApiTest.cpp:300: Failure
Expected equality of these values:
  mDeviceInfo.clientInfo.loggerLogLevel
    Which is: 0
  pKinesisVideoClient->deviceInfo.clientInfo.loggerLogLevel
    Which is: 4
/Users/runner/work/amazon-kinesis-video-streams-pic/amazon-kinesis-video-streams-pic/tst/client/ClientApiTest.cpp:317: Failure
Expected equality of these values:
  mDeviceInfo.clientInfo.loggerLogLevel
    Which is: 0
  pKinesisVideoClient->deviceInfo.clientInfo.loggerLogLevel
    Which is: 4
/Users/runner/work/amazon-kinesis-video-streams-pic/amazon-kinesis-video-streams-pic/tst/client/ClientApiTest.cpp:335: Failure
Expected equality of these values:
  mDeviceInfo.clientInfo.loggerLogLevel
    Which is: 0
  pKinesisVideoClient->deviceInfo.clientInfo.loggerLogLevel
    Which is: 4

[0x00007ff84935e800] [level 4] InputValidator fixupClientInfo(): Connection timeout is invalid...setting to default/Users/runner/work/amazon-kinesis-video-streams-pic/amazon-kinesis-video-streams-pic/tst/client/ClientApiTest.cpp:353: Failure
Expected equality of these values:
  mDeviceInfo.clientInfo.loggerLogLevel
    Which is: 0
  pKinesisVideoClient->deviceInfo.clientInfo.loggerLogLevel
    Which is: 4

[0x00007ff84935e800] [level 4] InputValidator fixupClientInfo(): Completion timeout should be more than connection timeout...setting to defaults/Users/runner/work/amazon-kinesis-video-streams-pic/amazon-kinesis-video-streams-pic/tst/client/ClientApiTest.cpp:371: Failure
Expected equality of these values:
  mDeviceInfo.clientInfo.loggerLogLevel
    Which is: 0
  pKinesisVideoClient->deviceInfo.clientInfo.loggerLogLevel
    Which is: 4
/Users/runner/work/amazon-kinesis-video-streams-pic/amazon-kinesis-video-streams-pic/tst/client/ClientApiTest.cpp:389: Failure
Expected equality of these values:
  mDeviceInfo.clientInfo.loggerLogLevel
    Which is: 0
  pKinesisVideoClient->deviceInfo.clientInfo.loggerLogLevel
    Which is: 4
[  FAILED  ] ClientApiTest.client_info_version_test (1 ms)
```

*How was it changed?*
- Adjusted the log level that the test is checking for. By default, the SDK will default to `LOG_LEVEL_WARN` (4) if the environment variable "AWS_KVS_LOG_LEVEL" is not present. The test is checking that it's 0 if `AWS_KVS_LOG_LEVEL` is not present. 0 is not a valid log level. This change fixes the test to not check for 0.
- This unit test failure only occurs if the `AWS_KVS_LOG_LEVEL` environment variable is not present. The CI always runs the unit tests with `AWS_KVS_LOG_LEVEL=2`, that's likely why this issue was not caught previously.

*What testing was done for the changes?*
- Changes were validated on a forked repository with passing CI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.