### PR TITLE
Correct missing defined in include file

### DIFF
--- a/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
+++ b/src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h
@@ -74,7 +74,7 @@ extern "C" {
 // 64/32 bit check on GCC
 //
 #if defined __GNUC__ || defined __GNUG__
-#if defined __x86_64__ || defined __ppc64__ || __aarch64__
+#if defined __x86_64__ || defined __ppc64__ || defined __aarch64__
 #define SIZE_64
 #if defined __APPLE__
 #define __LLP64__


### PR DESCRIPTION
*Issue #, if available:* NA, related to old PR #257

*What was changed?* 
Correct to use "defined" for preprocessor check.

*Why was it changed?* 
Receive a compiler warning with it as is.
`warning: "__aarch64__" is not defined [-Wundef] #if defined __x86_64__ || defined __ppc64__ || __aarch64__
`

*How was it changed?* 
Add the keyword "defined" to the line above.

*What testing was done for the changes?*
CI is passing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.