### PR TITLE
Enhance Crash Recovery for File-Based Offline Caching in KVS

### DIFF
--- a/src/client/include/com/amazonaws/kinesis/video/client/Include.h
+++ b/src/client/include/com/amazonaws/kinesis/video/client/Include.h
@@ -1134,6 +1134,9 @@ struct __StorageInfo {
     // Spillover ratio for the hybrid heaps in 0 - 100%
     UINT32 spillRatio;
 
+    // starting file index for hybrid file heap  
+    UINT32 fileHeapStartingFileIndex;
+
     // File location in case of the file based storage
     CHAR rootDirectory[MAX_PATH_LEN + 1];
 };

--- a/src/client/src/Client.c
+++ b/src/client/src/Client.c
@@ -254,7 +254,8 @@ STATUS createKinesisVideoClient(PDeviceInfo pDeviceInfo, PClientCallbacks pClien
         ? MEMORY_BASED_HEAP_FLAGS
         : FILE_BASED_HEAP_FLAGS;
     CHK_STATUS(heapInitialize(pKinesisVideoClient->deviceInfo.storageInfo.storageSize, pKinesisVideoClient->deviceInfo.storageInfo.spillRatio,
-                              heapFlags, pKinesisVideoClient->deviceInfo.storageInfo.rootDirectory, &pKinesisVideoClient->pHeap));
+                              heapFlags, pKinesisVideoClient->deviceInfo.storageInfo.rootDirectory, 
+                              pKinesisVideoClient->deviceInfo.storageInfo.fileHeapStartingFileIndex, &pKinesisVideoClient->pHeap));
 
     // Using content store allocator if needed
     // IMPORTANT! This will not be multi-client-safe

--- a/src/heap/include/com/amazonaws/kinesis/video/heap/Include.h
+++ b/src/heap/include/com/amazonaws/kinesis/video/heap/Include.h
@@ -147,7 +147,7 @@ typedef struct {
 /**
  * Creates and initializes the heap
  */
-PUBLIC_API STATUS heapInitialize(UINT64, UINT32, UINT32, PCHAR, PHeap*);
+PUBLIC_API STATUS heapInitialize(UINT64, UINT32, UINT32, PCHAR, UINT32, PHeap*);
 
 /**
  * Releases the entire heap.

--- a/src/heap/src/Heap.c
+++ b/src/heap/src/Heap.c
@@ -34,9 +34,10 @@ CleanUp:
  *      @spillRatio - Spill ratio in percentage of direct allocation RAM vs. vRAM in the hybrid heap scenario
  *      @behaviorFlags - Flags controlling the behavior/type of the heap
  *      @pRootDirectoru - Optional path to the root directory in case of the file-based heap
+ *      @fileHeapStartingFileIndex - Starting file index for file-based heaps
  *      @ppHeap - The returned pointer to the Heap object
  */
-STATUS heapInitialize(UINT64 heapLimit, UINT32 spillRatio, UINT32 behaviorFlags, PCHAR pRootDirectory, PHeap* ppHeap)
+STATUS heapInitialize(UINT64 heapLimit, UINT32 spillRatio, UINT32 behaviorFlags, PCHAR pRootDirectory, UINT32 fileHeapStartingFileIndex, PHeap* ppHeap)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
@@ -76,7 +77,7 @@ STATUS heapInitialize(UINT64 heapLimit, UINT32 spillRatio, UINT32 behaviorFlags,
         pHeap = (PHeap) pHybridHeap;
     } else if ((behaviorFlags & FLAGS_USE_HYBRID_FILE_HEAP) != HEAP_FLAGS_NONE) {
         DLOGI("Creating hybrid file heap with flags: 0x%08x", behaviorFlags);
-        CHK_STATUS(hybridFileCreateHeap(pHeap, spillRatio, pRootDirectory, &pFileHeap));
+        CHK_STATUS(hybridFileCreateHeap(pHeap, spillRatio, pRootDirectory, fileHeapStartingFileIndex, &pFileHeap));
 
         // Store the file hybrid heap as the returned heap object
         pHeap = (PHeap) pFileHeap;

--- a/src/heap/src/HybridFileHeap.c
+++ b/src/heap/src/HybridFileHeap.c
@@ -17,7 +17,7 @@ ALLOCATION_FOOTER gFileFooter = {0};
 
 #define FILE_ALLOCATION_HEADER_SIZE SIZEOF(gFileHeader)
 
-STATUS hybridFileCreateHeap(PHeap pHeap, UINT32 spillRatio, PCHAR pRootDirectory, PHybridFileHeap* ppHybridHeap)
+STATUS hybridFileCreateHeap(PHeap pHeap, UINT32 spillRatio, PCHAR pRootDirectory, UINT32 fileHeapStartingFileIndex, PHybridFileHeap* ppHybridHeap)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
@@ -37,7 +37,8 @@ STATUS hybridFileCreateHeap(PHeap pHeap, UINT32 spillRatio, PCHAR pRootDirectory
     pHybridHeap->spillRatio = (DOUBLE) spillRatio / 100;
 
     // IMPORTANT: We should start from a non-zero handle num to avoid a collision with the invalid handle value
-    pHybridHeap->handleNum = FILE_HEAP_STARTING_FILE_INDEX;
+    // Set the handleNum to the provided fileHeapStartingFileIndex if valid, otherwise use default
+    pHybridHeap->handleNum = (fileHeapStartingFileIndex > 0) ? fileHeapStartingFileIndex : FILE_HEAP_STARTING_FILE_INDEX;
 
     // Set the root path. Use default if not specified
     if (pRootDirectory == NULL || pRootDirectory[0] == '\0') {

--- a/src/heap/src/HybridFileHeap.h
+++ b/src/heap/src/HybridFileHeap.h
@@ -62,7 +62,7 @@ typedef struct {
 /**
  * Hybrid heap internal functions
  */
-STATUS hybridFileCreateHeap(PHeap, UINT32, PCHAR, PHybridFileHeap*);
+STATUS hybridFileCreateHeap(PHeap, UINT32, PCHAR, UINT32, PHybridFileHeap*);
 
 /**
  * Allocate a buffer from the heap


### PR DESCRIPTION
Description of Changes:
This PR introduces enhancements to support crash recovery when using file-based content storage for offline caching. The primary goal is to maintain the integrity of cached data during unexpected interruptions, such as application crashes, allowing seamless recovery without data loss. Specifically, the changes include:

Starting File Index in StorageInfo:
Added fileHeapStartingFileIndex to the StorageInfo structure, which sets a custom starting index for the file-based heap. This addition is crucial for crash recovery, enabling the system to resume from the correct file index.

Heap Initialization:
Updated the heapInitialize and hybridFileCreateHeap functions to accept fileHeapStartingFileIndex. This allows the heap to start from a specified file index when recovering from an interruption, preventing collisions with invalid handle values.
Added logic to set the file handle number to fileHeapStartingFileIndex if it’s greater than zero; otherwise, it defaults to FILE_HEAP_STARTING_FILE_INDEX. This ensures that the file heap can recover and start from the correct index after a crash, maintaining data consistency.

Testing:
Verified these changes by simulating application crashes and unexpected interruptions. Confirmed that the KVS offline cache resumes from the correct file index after recovery, ensuring no data loss in the caching session.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of your choice.