### PR TITLE
Add size_t size check test

### DIFF
--- a/tst/common/CommonDefsTest.cpp
+++ b/tst/common/CommonDefsTest.cpp
@@ -1,0 +1,8 @@
+#include "gtest/gtest.h"
+
+#include "src/common/include/com/amazonaws/kinesis/video/common/CommonDefs.h"
+
+TEST(CommonDefsTest, SizeTMatches)
+{
+    EXPECT_EQ(SIZEOF(size_t), SIZEOF(SIZE_T));
+}


### PR DESCRIPTION
*Issue #, if available:*
* https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/pull/2097
* https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-c/issues/2065

*What was changed?*
* Introduced a unit test to validate that the SIZE_T macro is correctly defined and matches size_t across different platforms.

*Why was it changed?*
* This change aims to prevent potential issues arising from size mismatches that could lead to undefined behavior or compilation errors.

*How was it changed?*
* Implemented a gtest unit test CommonDefsTest.SizeTMatches to assert the equality of SIZEOF(size_t) and SIZEOF(SIZE_T).

*What testing was done for the changes?*
* Checked locally that the code will compile and that the test is built and ran with the standard procedure.
* The CI will executed the newly added unit test on multiple platforms to verify the consistency of the `size_t` macro definition.
* SDK code was not modified, so no regressions are introduced.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.