### PR TITLE
Fix clang version to 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
             cmake_flags: "-DBUILD_TEST=TRUE -DALIGNED_MEMORY_MODEL=TRUE -DFIXUP_ANNEX_B_TRAILING_NALU_ZERO=TRUE"
       fail-fast: false
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     env:
       CC: clang
@@ -119,7 +119,12 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get -y install clang
+          sudo apt-get -y install cmake build-essential automake git clang
+
+      - name: Check installed clang versions
+        run: |
+          ls /usr/bin/clang*
+
       - name: Build repository - ${{ matrix.config.name }}
         run: |
           mkdir -p build


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- The clang version of the sanitizers jobs.

*Why was it changed?*
- A recent GitHub actions runner update changed the default from 14 to Clang 18, which broke the builds: https://github.com/awslabs/amazon-kinesis-video-streams-pic/actions/runs/13003102484/job/36265268270
- This build warning, which was treated as a warning for Clang-14, is now treated as a build error in Clang 18.
```
/__w/amazon-kinesis-video-streams-pic/amazon-kinesis-video-streams-pic/src/utils/src/Thread.c:155:16: warning: implicit declaration of function 'pthread_getname_np' is invalid in C99 [-Wimplicit-function-declaration]
    retValue = pthread_getname_np((pthread_t) thread, name, len);
               ^
[ 53%] Building C object CMakeFiles/kvspic.dir/src/utils/src/Time.c.o
1 warning generated.
```

*How was it changed?*
- Use GitHub actions' Ubuntu-22 for now, which has 14 installed. The ECR Ubuntu 22 docker image is giving some (480+) unexpected thread sanitizer failures.

*What testing was done for the changes?*
- The CI, which previously failed, should pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.