### PR TITLE
Getenv Test

### DIFF
--- a/tst/common/CommonDefsTest.cpp
+++ b/tst/common/CommonDefsTest.cpp
@@ -6,3 +6,8 @@ TEST(CommonDefsTest, SizeTMatches)
 {
     EXPECT_EQ(SIZEOF(size_t), SIZEOF(SIZE_T));
 }
+
+TEST(CommonDefsTest, GetEnvWorks)
+{
+    EXPECT_NE(nullptr, GETENV("PATH")) << "PATH environment variable is unexpectedly unset, or GETENV doesn't work";
+}

--- a/tst/common/CommonDefsTest.cpp
+++ b/tst/common/CommonDefsTest.cpp
@@ -11,3 +11,62 @@ TEST(CommonDefsTest, GetEnvWorks)
 {
     EXPECT_NE(nullptr, GETENV("PATH")) << "PATH environment variable is unexpectedly unset, or GETENV doesn't work";
 }
+
+
+// On Windows, getenv() doesn't work with SetEnvironmentVariable().
+// We'll need to use SetEnvironmentVariable() and GetEnvironmentVariable() together for runtime changes.
+// However, getenv does work in Windows (above test: GetEnvWorks) when the variable is set before program execution.
+// Note: SetEnvironmentVariable and GetEnvironmentVariable have different APIs to getenv and setenv.
+#ifndef __WINDOWS_BUILD__
+TEST(CommonDefsTest, SetEnvWorks)
+{
+    const char* test_var = "MY_TEST_VAR";
+    const char* test_value = "test_value";
+
+    // Save the original value of the environment variable, if it exists
+    const char* original_value = GETENV(test_var);
+
+    // Set the environment variable to a new value
+    setenv(test_var, test_value, 1);
+
+    // Verify if the environment variable was set correctly
+    EXPECT_STREQ(test_value, GETENV(test_var)) << "Failed to set environment variable " << test_var;
+
+    // Restore the original environment variable value (if any)
+    if (original_value) {
+        setenv(test_var, original_value, 1);
+    } else {
+        // If it was not set, unset the variable
+        unsetenv(test_var);
+    }
+}
+
+TEST(CommonDefsTest, UnsetEnvWorks)
+{
+    const char* test_var = "MY_TEST_VAR";
+    const char* test_value = "test_value";
+
+    // Save the original value of the environment variable, if it exists
+    const char* original_value = GETENV(test_var);
+
+    // Set the environment variable to a new value
+    setenv(test_var, test_value, 1);
+
+    // Verify if the environment variable was set correctly
+    EXPECT_STREQ(test_value, GETENV(test_var)) << "Failed to set environment variable " << test_var;
+
+    // Unset the environment variable
+    unsetenv(test_var);
+
+    // Verify if the environment variable is properly unset
+    EXPECT_EQ(nullptr, GETENV(test_var)) << "Failed to unset environment variable " << test_var;
+
+    // Restore the original environment variable value (if any)
+    if (original_value) {
+        setenv(test_var, original_value, 1);
+    } else {
+        // If it was not set, unset the variable
+        unsetenv(test_var);
+    }
+}
+#endif


### PR DESCRIPTION
*Issue #, if available:*
N/A

*What was changed?*
* Adding a new unit test to check GETENV macro.

*Why was it changed?*
* To verify portability of this macro.

*How was it changed?*
* The new unit test checks that the `PATH` variable exists.

*What testing was done for the changes?*
- Ran the test locally with PATH set and unset.

```
~/Downloads/amazon-kinesis-video-streams-pic/build > unset PATH                                                                                                                                                                           
~/Downloads/amazon-kinesis-video-streams-pic/build > ./tst/kvspic_test --gtest_filter="*CommonDefs*"
Note: Google Test filter = *CommonDefs*
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from CommonDefsTest
[ RUN      ] CommonDefsTest.SizeTMatches
[       OK ] CommonDefsTest.SizeTMatches (0 ms)
[ RUN      ] CommonDefsTest.GetEnvWorks
/Users/me/Downloads/amazon-kinesis-video-streams-pic/tst/common/CommonDefsTest.cpp:12: Failure
Expected: (nullptr) != (getenv("PATH")), actual: (nullptr) vs NULL
PATH environment variable is unexpectedly unset, or GETENV doesn't work

[  FAILED  ] CommonDefsTest.GetEnvWorks (0 ms)
[----------] 2 tests from CommonDefsTest (0 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] CommonDefsTest.GetEnvWorks

 1 FAILED TEST
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.