### PR TITLE
Adding more chk log err's

### DIFF
--- a/src/client/src/Stream.c
+++ b/src/client/src/Stream.c
@@ -300,6 +300,7 @@ STATUS createStream(PKinesisVideoClient pKinesisVideoClient, PStreamInfo pStream
     CHK_STATUS(iterateStreamStateMachine(pKinesisVideoStream));
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     if (clientLocked) {
         pKinesisVideoClient->clientCallbacks.unlockMutexFn(pKinesisVideoClient->clientCallbacks.customData, pKinesisVideoClient->base.lock);
@@ -416,6 +417,7 @@ STATUS freeStream(PKinesisVideoStream pKinesisVideoStream)
     MEMFREE(pKinesisVideoStream);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -447,6 +449,7 @@ STATUS freeStackQueue(PStackQueue pStackQueue, BOOL freeItself)
     }
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -549,6 +552,7 @@ STATUS stopStream(PKinesisVideoStream pKinesisVideoStream)
     streamLocked = FALSE;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     if (clientLocked) {
         pKinesisVideoClient->clientCallbacks.unlockMutexFn(pKinesisVideoClient->clientCallbacks.customData, pKinesisVideoClient->base.lock);
@@ -606,6 +610,7 @@ STATUS stopStreamSync(PKinesisVideoStream pKinesisVideoStream)
     } while (TRUE);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     if (retStatus == STATUS_OPERATION_TIMED_OUT) {
         DLOGE("[%s] Failed to stop Kinesis Video Stream - timed out.", pKinesisVideoStream->streamInfo.name);
@@ -667,6 +672,7 @@ STATUS shutdownStream(PKinesisVideoStream pKinesisVideoStream, BOOL resetStream)
     semaphoreWaitUntilClear(pKinesisVideoStream->base.shutdownSemaphore, STREAM_SHUTDOWN_SEMAPHORE_TIMEOUT);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -736,6 +742,7 @@ STATUS logStreamMetric(PKinesisVideoStream pKinesisVideoStream)
     // V2 client information
     DLOGD("\tAverage API call retry count for client: %lf", clientMetrics.clientAvgApiCallRetryCount);
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     return retStatus;
 }
@@ -1132,6 +1139,7 @@ STATUS putFrame(PKinesisVideoStream pKinesisVideoStream, PFrame pFrame)
     streamLocked = FALSE;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     // We need to see whether we need to remove the allocation on error. Otherwise, we will leak
     if (STATUS_FAILED(retStatus) && IS_VALID_ALLOCATION_HANDLE(allocHandle) && freeOnError) {
@@ -1464,6 +1472,7 @@ STATUS getStreamData(PKinesisVideoStream pKinesisVideoStream, UPLOAD_HANDLE uplo
     } while (remainingSize != 0);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     // Run staleness detection if we have ACKs enabled and if we have retrieved any data
     if (pFillSize != NULL && *pFillSize != 0) {
@@ -1668,6 +1677,7 @@ STATUS getStreamMetrics(PKinesisVideoStream pKinesisVideoStream, PStreamMetrics 
     }
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     if (streamLocked) {
         pKinesisVideoClient->clientCallbacks.unlockMutexFn(pKinesisVideoClient->clientCallbacks.customData, pKinesisVideoStream->base.lock);
@@ -1726,6 +1736,7 @@ STATUS handleAvailability(PKinesisVideoStream pKinesisVideoStream, UINT32 alloca
     }
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -1788,6 +1799,7 @@ STATUS checkForAvailability(PKinesisVideoStream pKinesisVideoStream, UINT32 allo
     pKinesisVideoClient->clientCallbacks.unlockMutexFn(pKinesisVideoClient->clientCallbacks.customData, pKinesisVideoClient->base.lock);
     clientLocked = FALSE;
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     // Unlock the client if locked.
     if (clientLocked) {
@@ -1827,6 +1839,7 @@ STATUS streamFormatChanged(PKinesisVideoStream pKinesisVideoStream, UINT32 codec
     streamLocked = FALSE;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     if (streamLocked) {
         pKinesisVideoClient->clientCallbacks.unlockMutexFn(pKinesisVideoClient->clientCallbacks.customData, pKinesisVideoStream->base.lock);
@@ -1870,6 +1883,7 @@ STATUS setNalAdaptationFlags(PKinesisVideoStream pKinesisVideoStream, UINT32 nal
     streamLocked = FALSE;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     if (streamLocked) {
         pKinesisVideoClient->clientCallbacks.unlockMutexFn(pKinesisVideoClient->clientCallbacks.customData, pKinesisVideoStream->base.lock);
@@ -2004,6 +2018,7 @@ STATUS putEventMetadata(PKinesisVideoStream pKinesisVideoStream, UINT32 event, P
     streamLocked = FALSE;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     // in the event we failed when creating the nodes, free the rest.
     if (creatingNodes) {
@@ -2101,6 +2116,7 @@ STATUS putFragmentMetadata(PKinesisVideoStream pKinesisVideoStream, PCHAR name, 
     streamLocked = FALSE;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     if (streamLocked) {
         pKinesisVideoClient->clientCallbacks.unlockMutexFn(pKinesisVideoClient->clientCallbacks.customData, pKinesisVideoStream->base.lock);
@@ -2205,6 +2221,7 @@ STATUS streamStartFixupOnReconnect(PKinesisVideoStream pKinesisVideoStream)
     pAlloc = NULL;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     // Unmap the old mapping
     if (pFrame != NULL) {
@@ -2307,6 +2324,7 @@ STATUS resetCurrentViewItemStreamStart(PKinesisVideoStream pKinesisVideoStream)
     clientLocked = FALSE;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     /* fix up retStatus if contentViewGetItemAt could not find curViewItem */
     if (retStatus == STATUS_CONTENT_VIEW_INVALID_INDEX) {
@@ -2367,6 +2385,7 @@ STATUS getNextBoundaryViewItem(PKinesisVideoStream pKinesisVideoStream, PViewIte
     *ppViewItem = pViewItem;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -2399,6 +2418,7 @@ STATUS getNextViewItem(PKinesisVideoStream pKinesisVideoStream, PViewItem* ppVie
     *ppViewItem = pViewItem;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -2409,6 +2429,7 @@ CleanUp:
  */
 PUploadHandleInfo getStreamUploadInfo(PKinesisVideoStream pKinesisVideoStream, UPLOAD_HANDLE uploadHandle)
 {
+    ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     StackQueueIterator iterator;
     PUploadHandleInfo pUploadHandleInfo = NULL, pCurHandleInfo;
@@ -2432,6 +2453,9 @@ PUploadHandleInfo getStreamUploadInfo(PKinesisVideoStream pKinesisVideoStream, U
     }
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
+
+    LEAVES();
     return pUploadHandleInfo;
 }
 
@@ -2440,6 +2464,7 @@ CleanUp:
  */
 PUploadHandleInfo getStreamUploadInfoWithState(PKinesisVideoStream pKinesisVideoStream, UINT32 handleState)
 {
+    ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     StackQueueIterator iterator;
     PUploadHandleInfo pUploadHandleInfo = NULL, pCurHandleInfo;
@@ -2463,7 +2488,9 @@ PUploadHandleInfo getStreamUploadInfoWithState(PKinesisVideoStream pKinesisVideo
     }
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
+    LEAVES();
     return pUploadHandleInfo;
 }
 
@@ -2490,6 +2517,7 @@ PUploadHandleInfo getAckReceivedStreamUploadInfo(PKinesisVideoStream pKinesisVid
  */
 VOID deleteStreamUploadInfo(PKinesisVideoStream pKinesisVideoStream, PUploadHandleInfo pUploadHandleInfo)
 {
+    ENTERS();
     if (NULL != pUploadHandleInfo) {
         stackQueueRemoveItem(pKinesisVideoStream->pUploadInfoQueue, (UINT64) pUploadHandleInfo);
 
@@ -2505,6 +2533,7 @@ VOID deleteStreamUploadInfo(PKinesisVideoStream pKinesisVideoStream, PUploadHand
 
         MEMFREE(pUploadHandleInfo);
     }
+    LEAVES();
 }
 
 /**
@@ -2550,6 +2579,7 @@ VOID freeMetadataTracker(PMetadataTracker pMetadataTracker)
 
 STATUS createPackager(PKinesisVideoStream pKinesisVideoStream, PMkvGenerator* ppGenerator)
 {
+    ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     UINT32 mkvGenFlags = MKV_GEN_FLAG_NONE |
         (pKinesisVideoStream->streamInfo.streamCaps.keyFrameFragmentation ? MKV_GEN_KEY_FRAME_PROCESSING : MKV_GEN_FLAG_NONE) |
@@ -2571,6 +2601,7 @@ STATUS createPackager(PKinesisVideoStream pKinesisVideoStream, PMkvGenerator* pp
                                   pKinesisVideoClient->clientCallbacks.customData, ppGenerator));
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -2596,6 +2627,7 @@ STATUS streamFragmentBufferingAck(PKinesisVideoStream pKinesisVideoStream, UINT6
     pKinesisVideoStream->diagnostics.bufferedAcks++;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -2621,6 +2653,7 @@ STATUS streamFragmentReceivedAck(PKinesisVideoStream pKinesisVideoStream, UINT64
     pKinesisVideoStream->diagnostics.receivedAcks++;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -2732,6 +2765,7 @@ STATUS streamFragmentPersistedAck(PKinesisVideoStream pKinesisVideoStream, UINT6
                                                                           pKinesisVideoStream->bufferAvailabilityCondition);
     }
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     // Set the current back if we had modified it
     if (setCurrentBack && STATUS_FAILED((setViewStatus = contentViewSetCurrentIndex(pKinesisVideoStream->pView, curItemIndex)))) {
@@ -2848,6 +2882,7 @@ STATUS streamFragmentErrorAck(PKinesisVideoStream pKinesisVideoStream, UINT64 st
     }
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -2897,6 +2932,8 @@ CleanUp:
         // Fix-up the error code.
         retStatus = STATUS_SUCCESS;
     }
+
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -2948,6 +2985,7 @@ STATUS checkStreamingTokenExpiration(PKinesisVideoStream pKinesisVideoStream)
     }
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -3072,6 +3110,7 @@ STATUS packageStreamMetadata(PKinesisVideoStream pKinesisVideoStream, MKV_STREAM
     }
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     if (STATUS_SUCCEEDED(retStatus)) {
         // Set the size and the state before return
@@ -3166,6 +3205,7 @@ STATUS checkForNotSentMetadata(PKinesisVideoStream pKinesisVideoStream, PBOOL pN
     }
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -3258,6 +3298,7 @@ STATUS packageNotSentMetadata(PKinesisVideoStream pKinesisVideoStream)
     pKinesisVideoStream->metadataTracker.data = pBuffer;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     if (STATUS_FAILED(retStatus) && pBuffer != NULL) {
         MEMFREE(pBuffer);
@@ -3322,6 +3363,7 @@ STATUS createSerializedMetadata(PCHAR name, PCHAR value, BOOL persistent, UINT32
     pSerializedMetadata->persistent = persistent;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     // Free the allocation on error.
     if (STATUS_FAILED(retStatus)) {
@@ -3347,6 +3389,7 @@ STATUS appendValidatedMetadata(PKinesisVideoStream pKinesisVideoStream, PSeriali
     CHK_STATUS(stackQueueEnqueue(pKinesisVideoStream->pMetadataQueue, (UINT64) pSerializedMetadata));
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     // Free the allocation on error.
     if (STATUS_FAILED(retStatus) && pSerializedMetadata != NULL) {
@@ -3384,6 +3427,7 @@ STATUS getAvailableViewSize(PKinesisVideoStream pKinesisVideoStream, PUINT64 pDu
     }
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     *pViewSize = viewByteSize;
     *pDuration = duration;
@@ -3418,6 +3462,7 @@ STATUS notifyStreamClosed(PKinesisVideoStream pKinesisVideoStream, UPLOAD_HANDLE
     CHK(STATUS_SUCCEEDED(savedStatus), savedStatus);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -3558,6 +3603,7 @@ STATUS resetStream(PKinesisVideoStream pKinesisVideoStream)
     streamLocked = FALSE;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     if (streamLocked) {
         pKinesisVideoClient->clientCallbacks.unlockMutexFn(pKinesisVideoClient->clientCallbacks.customData, pKinesisVideoStream->base.lock);

--- a/src/client/src/StreamEvent.c
+++ b/src/client/src/StreamEvent.c
@@ -289,6 +289,7 @@ STATUS describeStreamResult(PKinesisVideoStream pKinesisVideoStream, SERVICE_CAL
     CHK_STATUS(iterateStreamStateMachine(pKinesisVideoStream));
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     // Unlock the stream
     if (locked) {
@@ -350,6 +351,7 @@ STATUS createStreamResult(PKinesisVideoStream pKinesisVideoStream, SERVICE_CALL_
     CHK_STATUS(iterateStreamStateMachine(pKinesisVideoStream));
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     // Unlock the stream
     if (locked) {
@@ -435,6 +437,7 @@ STATUS getStreamingTokenResult(PKinesisVideoStream pKinesisVideoStream, SERVICE_
     CHK_STATUS(iterateStreamStateMachine(pKinesisVideoStream));
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     // Unlock the stream
     if (locked) {
@@ -496,6 +499,7 @@ STATUS getStreamingEndpointResult(PKinesisVideoStream pKinesisVideoStream, SERVI
     CHK_STATUS(iterateStreamStateMachine(pKinesisVideoStream));
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     // Unlock the stream
     if (locked) {
@@ -571,6 +575,7 @@ STATUS putStreamResult(PKinesisVideoStream pKinesisVideoStream, SERVICE_CALL_RES
     CHK_STATUS(iterateStreamStateMachine(pKinesisVideoStream));
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     if (STATUS_FAILED(retStatus) && (NULL != pUploadHandleInfo)) {
         MEMFREE(pUploadHandleInfo);
@@ -641,6 +646,7 @@ STATUS tagStreamResult(PKinesisVideoStream pKinesisVideoStream, SERVICE_CALL_RES
     }
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     // Unlock the stream
     if (locked) {
@@ -787,6 +793,7 @@ STATUS streamTerminatedEvent(PKinesisVideoStream pKinesisVideoStream, UPLOAD_HAN
     }
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     // Unlock the stream
     if (locked) {
@@ -914,6 +921,7 @@ STATUS streamFragmentAckEvent(PKinesisVideoStream pKinesisVideoStream, UPLOAD_HA
     CHK(inView, STATUS_ACK_TIMESTAMP_NOT_IN_VIEW_WINDOW);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     if (pKinesisVideoClient != NULL) {
         // We will notify the fragment ACK received callback even if the processing failed
@@ -958,6 +966,7 @@ STATUS calculateCallLatency(PKinesisVideoStream pKinesisVideoStream, BOOL cplApi
     }
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     return retStatus;
 }

--- a/src/client/src/StreamState.c
+++ b/src/client/src/StreamState.c
@@ -59,6 +59,7 @@ STATUS iterateStreamStateMachine(PKinesisVideoStream pKinesisVideoStream)
     } while (pKinesisVideoStream->keepIteratingStateMachine);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -112,6 +113,7 @@ STATUS defaultStreamStateTransitionHook(UINT64 customData /* customData should b
     *stateTransitionWaitTime = retryWaitTime;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -136,6 +138,7 @@ STATUS fromNewStreamState(UINT64 customData, PUINT64 pState)
     *pState = state;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -154,6 +157,7 @@ STATUS executeNewStreamState(UINT64 customData, UINT64 time)
     pKinesisVideoStream->keepIteratingStateMachine = TRUE;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -189,6 +193,7 @@ STATUS executeDescribeStreamState(UINT64 customData, UINT64 time)
         pKinesisVideoClient->clientCallbacks.customData, pKinesisVideoStream->streamInfo.name, &pKinesisVideoStream->base.serviceCallContext));
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -243,6 +248,7 @@ STATUS fromDescribeStreamState(UINT64 customData, PUINT64 pState)
     *pState = state;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -271,6 +277,7 @@ STATUS fromCreateStreamState(UINT64 customData, PUINT64 pState)
     *pState = state;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -295,6 +302,7 @@ STATUS fromTagStreamState(UINT64 customData, PUINT64 pState)
     *pState = state;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -319,6 +327,7 @@ STATUS fromGetEndpointStreamState(UINT64 customData, PUINT64 pState)
     *pState = state;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -343,6 +352,7 @@ STATUS fromGetTokenStreamState(UINT64 customData, PUINT64 pState)
     *pState = state;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -424,6 +434,7 @@ STATUS fromPutStreamState(UINT64 customData, PUINT64 pState)
     *pState = state;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -447,6 +458,7 @@ STATUS fromStreamingStreamState(UINT64 customData, PUINT64 pState)
     *pState = state;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -521,6 +533,7 @@ STATUS fromStoppedStreamState(UINT64 customData, PUINT64 pState)
     }
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     if (pState != NULL) {
         *pState = state;
@@ -549,6 +562,7 @@ STATUS fromReadyStreamState(UINT64 customData, PUINT64 pState)
     *pState = state;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -601,6 +615,7 @@ STATUS executeGetEndpointStreamState(UINT64 customData, UINT64 time)
         &pKinesisVideoStream->base.serviceCallContext));
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -637,6 +652,7 @@ STATUS executeGetTokenStreamState(UINT64 customData, UINT64 time)
                                                                         &pKinesisVideoStream->base.serviceCallContext));
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -674,6 +690,7 @@ STATUS executeCreateStreamState(UINT64 customData, UINT64 time)
         &pKinesisVideoStream->base.serviceCallContext));
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -711,6 +728,7 @@ STATUS executeTagStreamState(UINT64 customData, UINT64 time)
                                                                   &pKinesisVideoStream->base.serviceCallContext));
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -749,6 +767,7 @@ STATUS executeReadyStreamState(UINT64 customData, UINT64 time)
     }
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -793,6 +812,7 @@ STATUS executePutStreamState(UINT64 customData, UINT64 time)
     }
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -813,6 +833,7 @@ STATUS executeStreamingStreamState(UINT64 customData, UINT64 time)
     // Nothing to do
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -853,6 +874,7 @@ STATUS executeStoppedStreamState(UINT64 customData, UINT64 time)
     pKinesisVideoStream->keepIteratingStateMachine = TRUE;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;

--- a/src/mkvgen/src/MkvGenerator.c
+++ b/src/mkvgen/src/MkvGenerator.c
@@ -141,6 +141,7 @@ STATUS createMkvGenerator(PCHAR contentType, UINT32 behaviorFlags, UINT64 timeco
     *ppMkvGenerator = (PMkvGenerator) pMkvGenerator;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     if (STATUS_FAILED(retStatus)) {
         freeMkvGenerator((PMkvGenerator) pMkvGenerator);
@@ -175,6 +176,7 @@ STATUS freeMkvGenerator(PMkvGenerator pMkvGenerator)
     MEMFREE(pMkvGenerator);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -203,6 +205,7 @@ STATUS mkvgenResetGenerator(PMkvGenerator pMkvGenerator)
     pStreamMkvGenerator->streamStartTimestampStored = FALSE;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -368,6 +371,7 @@ STATUS mkvgenPackageFrame(PMkvGenerator pMkvGenerator, PFrame pFrame, PTrackInfo
     CHK(packagedSize == (UINT32) (pCurrentPnt - pBuffer), STATUS_INTERNAL_ERROR);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     if (STATUS_SUCCEEDED(retStatus)) {
         // Set the size and the state before return
@@ -423,6 +427,7 @@ STATUS mkvgenSetCodecPrivateData(PMkvGenerator pMkvGenerator, UINT64 trackId, UI
                                            &pTrackInfo->codecPrivateDataSize, &pTrackInfo->codecPrivateData, &pTrackInfo->trackCustomData));
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -479,6 +484,7 @@ STATUS mkvgenGenerateHeader(PMkvGenerator pMkvGenerator, PBYTE pBuffer, PUINT32 
     CHK(packagedSize == (UINT32) (pCurrentPnt - pBuffer), STATUS_INTERNAL_ERROR);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     if (STATUS_SUCCEEDED(retStatus)) {
         // Set the size and the state before return
@@ -510,6 +516,7 @@ STATUS mkvgenGetCurrentTimestamps(PMkvGenerator pMkvGenerator, PUINT64 pStreamSt
     *pClusterStartDts = MKV_TIMECODE_TO_TIMESTAMP(pStreamMkvGenerator->lastClusterDts, pStreamMkvGenerator->timecodeScale);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -610,6 +617,7 @@ STATUS mkvgenGenerateTag(PMkvGenerator pMkvGenerator, PBYTE pBuffer, PCHAR tagNa
     CHK(packagedSize == (UINT32) (pCurrentPnt - pBuffer), STATUS_INTERNAL_ERROR);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     if (STATUS_SUCCEEDED(retStatus)) {
         // Set the size and the state before return
@@ -777,6 +785,7 @@ STATUS mkvgenGenerateTagsChain(PBYTE pBuffer, PCHAR tagName, PCHAR tagValue, PUI
     CHK(packagedSize == (UINT32) (pCurrentPnt - pBuffer), STATUS_INTERNAL_ERROR);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     if (STATUS_SUCCEEDED(retStatus)) {
         // Set the size and the state before return
@@ -804,6 +813,7 @@ STATUS mkvgenIncreaseTagsTagSize(PBYTE pBuffer, UINT32 sizeIncrease)
     PUT_UNALIGNED_BIG_ENDIAN((PINT64) (pBuffer + MKV_TAG_ELEMENT_SIZE_OFFSET), encodedElementLength);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -826,6 +836,7 @@ STATUS mkvgenGetMkvOverheadSize(PMkvGenerator pMkvGenerator, MKV_STREAM_STATE mk
     *pOverhead = mkvgenGetFrameOverhead(pStreamMkvGenerator, mkvStreamState);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -848,6 +859,7 @@ STATUS mkvgenTimecodeToTimestamp(PMkvGenerator pMkvGenerator, UINT64 timecode, P
     *pTimestamp = MKV_TIMECODE_TO_TIMESTAMP(timecode, pStreamMkvGenerator->timecodeScale);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -903,6 +915,8 @@ STATUS mkvgenValidateFrame(PStreamMkvGenerator pStreamMkvGenerator, PFrame pFram
     *pDuration = duration;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
+
     return retStatus;
 }
 
@@ -921,6 +935,7 @@ STATUS mkvgenHasStreamStarted(PMkvGenerator pMkvGenerator, PBOOL pBool)
         *pBool = TRUE;
     }
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     return retStatus;
 }
@@ -1115,6 +1130,7 @@ STATUS mkvgenEbmlEncodeNumber(UINT64 number, PBYTE pBuffer, UINT32 bufferSize, P
     }
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     return retStatus;
 }
@@ -1160,6 +1176,7 @@ STATUS mkvgenBigEndianNumber(UINT64 number, PBYTE pBuffer, UINT32 bufferSize, PU
     MEMCPY(pBuffer, storage, byteLen);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     return retStatus;
 }
@@ -1184,6 +1201,7 @@ STATUS mkvgenEbmlEncodeHeader(PBYTE pBuffer, UINT32 bufferSize, PUINT32 pEncoded
     MEMCPY(pBuffer, MKV_HEADER_BITS, MKV_HEADER_BITS_SIZE);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     return retStatus;
 }
@@ -1208,6 +1226,7 @@ STATUS mkvgenEbmlEncodeSegmentHeader(PBYTE pBuffer, UINT32 bufferSize, PUINT32 p
     MEMCPY(pBuffer, MKV_SEGMENT_HEADER_BITS, MKV_SEGMENT_HEADER_BITS_SIZE);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     return retStatus;
 }
@@ -1298,6 +1317,7 @@ STATUS mkvgenEbmlEncodeSegmentInfo(PStreamMkvGenerator pStreamMkvGenerator, PBYT
     PUT_UNALIGNED_BIG_ENDIAN((PINT16) (pBuffer + MKV_SEGMENT_INFO_SIZE_OFFSET), (UINT16) encodedLen);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     if (pEncodedLen != NULL) {
         *pEncodedLen = size;
@@ -1469,6 +1489,7 @@ STATUS mkvgenEbmlEncodeTrackInfo(PBYTE pBuffer, UINT32 bufferSize, PStreamMkvGen
     PUT_UNALIGNED_BIG_ENDIAN((PINT32) (pBuffer + MKV_TRACK_HEADER_SIZE_OFFSET), encodedLen);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     return retStatus;
 }
@@ -1496,6 +1517,7 @@ STATUS mkvgenEbmlEncodeClusterInfo(PBYTE pBuffer, UINT32 bufferSize, UINT64 time
     PUT_UNALIGNED_BIG_ENDIAN((PINT64) (pBuffer + MKV_CLUSTER_TIMECODE_OFFSET), timestamp);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     return retStatus;
 }
@@ -1575,6 +1597,7 @@ STATUS mkvgenEbmlEncodeSimpleBlock(PBYTE pBuffer, UINT32 bufferSize, INT16 times
     *(pBuffer + MKV_SIMPLE_BLOCK_FLAGS_OFFSET) = flags;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     return retStatus;
 }
@@ -1604,6 +1627,7 @@ STATUS getAdaptedFrameSize(PFrame pFrame, MKV_NALS_ADAPTATION nalsAdaptation, PU
     *pAdaptedFrameSize = adaptedFrameSize;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     return retStatus;
 }
@@ -1731,6 +1755,8 @@ STATUS getSamplingFreqAndChannelFromAacCpd(PBYTE pCpd, UINT32 cpdSize, PDOUBLE p
     *pSamplingFrequency = gMkvAACSamplingFrequencies[samplingRateIdx];
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
+
     return retStatus;
 }
 
@@ -1820,6 +1846,8 @@ STATUS getAudioConfigFromAmsAcmCpd(PBYTE pCpd, UINT32 cpdSize, PDOUBLE pSampling
     *pBitDepth = bitDepth;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
+
     return retStatus;
 }
 
@@ -1859,8 +1887,8 @@ STATUS mkvgenGeneratePcmCpd(KVS_PCM_FORMAT_CODE format, UINT32 samplingRate, UIN
     // leave remaining bits as 0
 
 CleanUp:
-
     CHK_LOG_ERR(retStatus);
+
     return retStatus;
 }
 
@@ -1966,6 +1994,7 @@ STATUS mkvgenAdaptCodecPrivateData(PStreamMkvGenerator pMkvGenerator, MKV_TRACK_
     }
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     *ppCpd = pCpd;
     *pCpdSize = adaptedCodecPrivateDataSize;
@@ -1993,6 +2022,7 @@ STATUS mkvgenGetTrackInfo(PTrackInfo pTrackInfos, UINT32 trackInfoCount, UINT64 
     CHK(pTrackInfo != NULL, STATUS_MKV_TRACK_INFO_NOT_FOUND);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     if (ppTrackInfo != NULL) {
         *ppTrackInfo = pTrackInfo;
@@ -2056,6 +2086,7 @@ STATUS mkvgenExtractCpdFromAnnexBFrame(PStreamMkvGenerator pStreamMkvGenerator, 
     CHK_STATUS(mkvgenSetCodecPrivateData((PMkvGenerator) pStreamMkvGenerator, pFrame->trackId, parsedSize, pCpd));
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     if (pCpd != NULL) {
         MEMFREE(pCpd);

--- a/src/utils/src/Semaphore.c
+++ b/src/utils/src/Semaphore.c
@@ -16,6 +16,7 @@ STATUS semaphoreCreate(UINT32 maxPermits, PSEMAPHORE_HANDLE pHandle)
     *pHandle = TO_SEMAPHORE_HANDLE(pSemaphore);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     if (STATUS_FAILED(retStatus)) {
         semaphoreFreeInternal(&pSemaphore);
@@ -41,6 +42,7 @@ STATUS semaphoreEmptyCreate(UINT32 maxPermits, PSEMAPHORE_HANDLE pHandle)
     *pHandle = TO_SEMAPHORE_HANDLE(pSemaphore);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     if (STATUS_FAILED(retStatus)) {
         semaphoreFreeInternal(&pSemaphore);
@@ -70,6 +72,7 @@ STATUS semaphoreFree(PSEMAPHORE_HANDLE pHandle)
     *pHandle = INVALID_SEMAPHORE_HANDLE_VALUE;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     LEAVES();
     return retStatus;
@@ -266,6 +269,7 @@ STATUS semaphoreAcquireInternal(PSemaphore pSemaphore, UINT64 timeout)
     locked = FALSE;
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
 
     if (acquireFailed) {
         ATOMIC_INCREMENT(&pSemaphore->permitCount);
@@ -385,6 +389,8 @@ STATUS semaphoreGetCountInternal(PSemaphore pSemaphore, PINT32 pCount)
     *pCount = (INT32) ATOMIC_LOAD(&pSemaphore->permitCount);
 
 CleanUp:
+    CHK_LOG_ERR(retStatus);
+
     LEAVES();
     return retStatus;
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*What was changed?*
- Adding more CHK_LOG_ERR.

*Why was it changed?*
- C has errors returned by value. This should make debugging easier to pinpoint error locations, especially in environments where gdb isn't available to generate a stacktrace.

*How was it changed?*
- Added chk_log_err in the cleanup label of functions related to the Streams state machine, semaphores, and mkvgenerator.

*What testing was done for the changes?*
- Ci should pass for these changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.