### PR TITLE
Fix bug in uploadHandle rotation with persisted ACKs causing timeout

### DIFF
--- a/src/client/src/Stream.c
+++ b/src/client/src/Stream.c
@@ -1528,13 +1528,15 @@ CleanUp:
         }
     }
 
-    // when pUploadHandleInfo is in UPLOAD_HANDLE_STATE_TERMINATED or UPLOAD_HANDLE_STATE_AWAITING_ACK, it means current handle
-    // has sent all the data. So it's safe to unblock the next one if any. If WAIT_FOR_PERSISTED_ACK is enabled, no need
-    // to execute data available again when UPLOAD_HANDLE_STATE_TERMINATED because we did it already when upload handle
-    // was in UPLOAD_HANDLE_STATE_AWAITING_ACK state.
+     // when pUploadHandleInfo is in UPLOAD_HANDLE_STATE_TERMINATED or UPLOAD_HANDLE_STATE_AWAITING_ACK it means current handle
+     // has sent all the data, so it's safe to unblock the next one if any.
+     // If WAIT_FOR_PERSISTED_ACK is not enabled, we will not enter UPLOAD_HANDLE_STATE_AWAITING_ACK and instead will immediately poke
+     // the next handle.
+     // If pUploadHandleInfo is in UPLOAD_HANDLE_STATE_TERMINATED but pUploadHandleInfo->nextHandlePoked is false, we likely skipped
+     // UPLOAD_HANDLE_STATE_AWAITING_ACK states as all fragment ACKs were received prior to handle transition.
     if (NULL != pUploadHandleInfo &&
         (pUploadHandleInfo->state == UPLOAD_HANDLE_STATE_AWAITING_ACK ||
-         (!WAIT_FOR_PERSISTED_ACK(pKinesisVideoStream) && pUploadHandleInfo->state == UPLOAD_HANDLE_STATE_TERMINATED))) {
+        (pUploadHandleInfo->state == UPLOAD_HANDLE_STATE_TERMINATED && (!WAIT_FOR_PERSISTED_ACK(pKinesisVideoStream) || !pUploadHandleInfo->nextHandlePoked)))) {
         // Special handling for the case:
         // When the stream has been stopped so no more putFrame calls that drive the data availability
         // When the current upload handle is in EoS
@@ -1563,6 +1565,7 @@ CleanUp:
             CHK_STATUS(pKinesisVideoClient->clientCallbacks.streamDataAvailableFn(
                 pKinesisVideoClient->clientCallbacks.customData, TO_STREAM_HANDLE(pKinesisVideoStream), pKinesisVideoStream->streamInfo.name,
                 pNextUploadHandleInfo->handle, duration, viewByteSize));
+            pUploadHandleInfo->nextHandlePoked = TRUE;
         }
     }
 

--- a/src/client/src/Stream.h
+++ b/src/client/src/Stream.h
@@ -325,6 +325,9 @@ struct __UploadHandleInfo {
 
     // Handle state
     UPLOAD_HANDLE_STATE state;
+
+    // Whether or not the next upload handle has been poked to start
+    BOOL nextHandlePoked;
 };
 typedef struct __UploadHandleInfo* PUploadHandleInfo;
 

--- a/src/client/src/StreamEvent.c
+++ b/src/client/src/StreamEvent.c
@@ -554,6 +554,7 @@ STATUS putStreamResult(PKinesisVideoStream pKinesisVideoStream, SERVICE_CALL_RES
         pUploadHandleInfo->timestamp = INVALID_TIMESTAMP_VALUE;
         pUploadHandleInfo->lastPersistedAckTs = INVALID_TIMESTAMP_VALUE;
         pUploadHandleInfo->state = UPLOAD_HANDLE_STATE_NEW;
+        pUploadHandleInfo->nextHandlePoked = FALSE;
 
         pUploadHandleInfo->createTime = pKinesisVideoClient->clientCallbacks.getCurrentTimeFn(pKinesisVideoClient->clientCallbacks.customData);
 

--- a/tst/client/StreamTokenRotationTest.cpp
+++ b/tst/client/StreamTokenRotationTest.cpp
@@ -4,6 +4,7 @@ class StreamTokenRotationTest : public ClientTestBase {};
 
 UINT64 gPresetTimeValue = 0;
 UINT32 gPutStreamFuncCount = 0;
+UINT32 uh1_gStreamDataAvailableFuncCount = 0;
 CHAR gStreamingToken[100];
 
 #define UPDATE_TEST_STREAMING_TOKEN(x) (SNPRINTF(gStreamingToken, 100, "%s%d", "StreamingToken_", (x)))
@@ -36,6 +37,23 @@ STATUS testPutStream(UINT64 customData, PCHAR streamName, PCHAR containerType, U
         if (pCallbackContext->pAuthInfo->type == AUTH_INFO_TYPE_STS) {
             EXPECT_EQ(0, STRCMP(gStreamingToken, (PCHAR) pCallbackContext->pAuthInfo->data));
         }
+    }
+
+    return STATUS_SUCCESS;
+}
+
+STATUS testStreamDataAvailableFn(UINT64 customData, STREAM_HANDLE streamHandle, PCHAR streamName, UPLOAD_HANDLE uploadHandle,
+                                                    UINT64 duration, UINT64 size)
+{
+    UNUSED_PARAM(customData);
+    UNUSED_PARAM(streamHandle);
+    UNUSED_PARAM(streamName);
+    UNUSED_PARAM(uploadHandle);
+    UNUSED_PARAM(duration);
+    UNUSED_PARAM(size);
+
+    if (uploadHandle == TEST_UPLOAD_HANDLE +1 ) {
+        uh1_gStreamDataAvailableFuncCount++;
     }
 
     return STATUS_SUCCESS;
@@ -332,6 +350,174 @@ TEST_F(StreamTokenRotationTest, rotationWithAwaitingCheck)
 
     EXPECT_EQ(0, ATOMIC_LOAD(&mStreamErrorReportFuncCount));
     EXPECT_TRUE(uploadHandle > TEST_UPLOAD_HANDLE); // upload handle rotated at least once.
+
+    if (IS_VALID_CLIENT_HANDLE(clientHandle)) {
+        freeKinesisVideoClient(&clientHandle);
+    }
+    MEMFREE(emptyTagValue);
+}
+
+// Test rotation case in which active uploadHandle has received all fragment ACKs prior to rotation initiation.
+TEST_F(StreamTokenRotationTest, grantar_test_two)
+{
+    UINT32 i, filledSize, rotation, lastRotation;
+    BYTE tempBuffer[1000];
+    BYTE getDataBuffer[5000];
+    PBYTE emptyTagValue = (PBYTE) MEMALLOC(MKV_TAG_STRING_BITS_SIZE);
+    UINT64 timestamp, uploadHandle = TEST_UPLOAD_HANDLE, newUploadHandle = TEST_UPLOAD_HANDLE;
+    Frame frame;
+    STATUS status;
+    UINT64 runDuration = 3 * MIN_STREAMING_TOKEN_EXPIRATION_DURATION + TEST_LONG_FRAME_DURATION;
+    CLIENT_HANDLE clientHandle = INVALID_CLIENT_HANDLE_VALUE;
+    STREAM_HANDLE streamHandle = INVALID_STREAM_HANDLE_VALUE;
+    BOOL sendAck = FALSE;
+    FragmentAck fragmentAck;
+    PUploadHandleInfo pUploadHandleInfo = NULL;
+    BOOL iterate;
+    BOOL completed;
+
+    // Reset the values for repeated playback of the tests
+    gPresetTimeValue = 0;
+    gPutStreamFuncCount = 0;
+    completed = FALSE;
+
+    mStreamInfo.streamCaps.recoverOnError = TRUE;
+
+    // Set the ACK values
+    fragmentAck.version = FRAGMENT_ACK_CURRENT_VERSION;
+    fragmentAck.ackType = FRAGMENT_ACK_TYPE_PERSISTED;
+    fragmentAck.result = SERVICE_CALL_RESULT_OK;
+    STRCPY(fragmentAck.sequenceNumber, "SequenceNumber");
+    fragmentAck.timestamp = 0;
+
+    // Set the specialized callback functions
+    mClientCallbacks.getCurrentTimeFn = getCurrentTimePreset;
+    mClientCallbacks.putStreamFn = testPutStream;
+    mClientCallbacks.streamDataAvailableFn = testStreamDataAvailableFn;
+
+    // Set the retention period to enforce the awaiting for last persist ACK
+    mStreamInfo.retention = 10 * HUNDREDS_OF_NANOS_IN_AN_HOUR;
+
+    // Set to absolute timestamps to ensure deterministic ACKs
+    mStreamInfo.streamCaps.absoluteFragmentTimes = TRUE;
+
+    // Set the frame buffer to a pattern
+    MEMSET(tempBuffer, 0x55, SIZEOF(tempBuffer));
+
+    // Copy over empty MkvTagStringBits and fix up ebml size for empty tag string
+    MEMCPY(emptyTagValue, gMkvTagStringBits, gMkvTagStringBitsSize);
+    emptyTagValue[2] = 0x01;
+
+    // Create and ready a stream
+    EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoClient(&mDeviceInfo, &mClientCallbacks, &clientHandle));
+    EXPECT_EQ(STATUS_SUCCESS, createDeviceResultEvent(mCallContext.customData, SERVICE_CALL_RESULT_OK, TEST_DEVICE_ARN));
+    EXPECT_EQ(STATUS_SUCCESS, createKinesisVideoStream(clientHandle, &mStreamInfo, &streamHandle));
+
+    // Move to ready state
+    mStreamDescription.version = STREAM_DESCRIPTION_CURRENT_VERSION;
+    STRCPY(mStreamDescription.deviceName, TEST_DEVICE_NAME);
+    STRCPY(mStreamDescription.streamName, TEST_STREAM_NAME);
+    STRCPY(mStreamDescription.contentType, TEST_CONTENT_TYPE);
+    STRCPY(mStreamDescription.streamArn, TEST_STREAM_ARN);
+    STRCPY(mStreamDescription.updateVersion, TEST_UPDATE_VERSION);
+    mStreamDescription.streamStatus = STREAM_STATUS_ACTIVE;
+    mStreamDescription.creationTime = GETTIME();
+
+    lastRotation = 0;
+    rotation = 1;
+
+    UPDATE_TEST_STREAMING_TOKEN(rotation);
+    EXPECT_EQ(STATUS_SUCCESS, describeStreamResultEvent(mCallContext.customData, SERVICE_CALL_RESULT_OK, &mStreamDescription));
+    EXPECT_EQ(STATUS_SUCCESS, getStreamingEndpointResultEvent(mCallContext.customData, SERVICE_CALL_RESULT_OK, TEST_STREAMING_ENDPOINT));
+    EXPECT_EQ(STATUS_INVALID_TOKEN_EXPIRATION,
+              getStreamingTokenResultEvent(mCallContext.customData, SERVICE_CALL_RESULT_OK, (PBYTE) gStreamingToken, SIZEOF(gStreamingToken),
+                                           MIN_STREAMING_TOKEN_EXPIRATION_DURATION - 1));
+    EXPECT_EQ(STATUS_SUCCESS,
+              getStreamingTokenResultEvent(mCallContext.customData, SERVICE_CALL_RESULT_OK, (PBYTE) gStreamingToken, SIZEOF(gStreamingToken),
+                                           MIN_STREAMING_TOKEN_EXPIRATION_DURATION));
+    EXPECT_EQ(STATUS_SUCCESS, putStreamResultEvent(mCallContext.customData, SERVICE_CALL_RESULT_OK, uploadHandle));
+
+    // Produce Buffers Up Until MIN_STREAMING_TOKEN_EXPIRATION_DURATION Final Fragment KeyFrame With I Frames After
+    for (i = 0, timestamp = 0; timestamp <= runDuration; timestamp += TEST_LONG_FRAME_DURATION, i++) {
+        if (timestamp < (MIN_STREAMING_TOKEN_EXPIRATION_DURATION + (6*TEST_LONG_FRAME_DURATION))) {
+            frame.index = i;
+            frame.decodingTs = timestamp;
+            frame.presentationTs = timestamp;
+            frame.duration = TEST_LONG_FRAME_DURATION;
+            frame.size = SIZEOF(tempBuffer);
+            frame.frameData = tempBuffer;
+            frame.trackId = TEST_TRACKID;
+
+            // Update the timer
+            gPresetTimeValue = timestamp;
+
+            // Key frame every 5th
+            frame.flags = i % 5 == 0 ? FRAME_FLAG_KEY_FRAME : FRAME_FLAG_NONE;
+            EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(streamHandle, &frame));
+
+            // Check for rotation
+            if ((INT64) timestamp >
+                rotation * MIN_STREAMING_TOKEN_EXPIRATION_DURATION - STREAMING_TOKEN_EXPIRATION_GRACE_PERIOD + TEST_LONG_FRAME_DURATION) {
+                
+                EXPECT_EQ(rotation + 1, ATOMIC_LOAD(&mGetStreamingEndpointFuncCount));
+                EXPECT_EQ(rotation, ATOMIC_LOAD(&mGetStreamingTokenFuncCount));
+                EXPECT_EQ(rotation, gPutStreamFuncCount);
+
+                EXPECT_EQ(STATUS_SUCCESS, getStreamingEndpointResultEvent(mCallContext.customData, SERVICE_CALL_RESULT_OK, TEST_STREAMING_ENDPOINT));
+                EXPECT_EQ(rotation + 1, ATOMIC_LOAD(&mGetStreamingEndpointFuncCount));
+                EXPECT_EQ(rotation + 1, ATOMIC_LOAD(&mGetStreamingTokenFuncCount));
+                EXPECT_EQ(rotation, gPutStreamFuncCount);
+                EXPECT_EQ(STATUS_SUCCESS,
+                        getStreamingTokenResultEvent(mCallContext.customData, SERVICE_CALL_RESULT_OK, (PBYTE) gStreamingToken, SIZEOF(gStreamingToken),
+                                                    (rotation + 1) * MIN_STREAMING_TOKEN_EXPIRATION_DURATION));
+
+                // Validate the put stream count
+                EXPECT_EQ(rotation + 1, gPutStreamFuncCount);
+
+                rotation++;
+                UPDATE_TEST_STREAMING_TOKEN(rotation);
+
+                EXPECT_EQ(STATUS_SUCCESS, putStreamResultEvent(mCallContext.customData, SERVICE_CALL_RESULT_OK, (uploadHandle+1)));
+            }
+
+            // Send final ACK after we have sent the last fragment
+            if ((timestamp + TEST_LONG_FRAME_DURATION) >= (MIN_STREAMING_TOKEN_EXPIRATION_DURATION + (6*TEST_LONG_FRAME_DURATION))) {
+                pUploadHandleInfo = getStreamUploadInfo(FROM_STREAM_HANDLE(streamHandle), uploadHandle);
+                fragmentAck.timestamp = pUploadHandleInfo->lastFragmentTs / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+                EXPECT_EQ(STATUS_SUCCESS, kinesisVideoStreamFragmentAck(streamHandle, uploadHandle, &fragmentAck));
+            }
+        }
+
+        // Consume every 10th, until uploadHandle terminated
+        if (i != 0 && (i % 10 == 0) && !completed) {
+            iterate = TRUE;
+            while (iterate) {
+                status = getKinesisVideoStreamData(streamHandle, uploadHandle, getDataBuffer, SIZEOF(getDataBuffer), &filledSize);
+
+                EXPECT_TRUE(status == STATUS_SUCCESS || status == STATUS_END_OF_STREAM || status == STATUS_NO_MORE_DATA_AVAILABLE);
+
+                switch (status) {
+                    case STATUS_SUCCESS:
+                        break;
+                    case STATUS_END_OF_STREAM:
+                        completed = TRUE;
+                        iterate = FALSE;
+                        break;
+                    case STATUS_NO_MORE_DATA_AVAILABLE:
+                        iterate = FALSE;
+                        break;
+                    default:
+                        iterate = FALSE;
+                        break;
+                }
+            }
+        }
+    }
+
+    EXPECT_EQ(0, ATOMIC_LOAD(&mStreamErrorReportFuncCount));
+
+    // StreamDataAvailable should have been fired after uploadHanlde termination
+    EXPECT_EQ(1, uh1_gStreamDataAvailableFuncCount);
 
     if (IS_VALID_CLIENT_HANDLE(clientHandle)) {
         freeKinesisVideoClient(&clientHandle);

--- a/tst/client/StreamTokenRotationTest.cpp
+++ b/tst/client/StreamTokenRotationTest.cpp
@@ -358,7 +358,7 @@ TEST_F(StreamTokenRotationTest, rotationWithAwaitingCheck)
 }
 
 // Test rotation case in which active uploadHandle has received all fragment ACKs prior to rotation initiation.
-TEST_F(StreamTokenRotationTest, grantar_test_two)
+TEST_F(StreamTokenRotationTest, rotationWithAllFragmentsAlreadyAcked)
 {
     UINT32 i, filledSize, rotation, lastRotation;
     BYTE tempBuffer[1000];


### PR DESCRIPTION
*Issue*
Our application utilizes the Gstreamer plugin kvssink from the Kinesis producer-c library. Our higher level application (Java) sends MKV containers into the gstreamer pipeline as available. They currently are available once every 10 seconds. We wait for the persisted ACK signal from kvssink before allowing the next fragment to be sent, as we have a use case for knowing 100% for sure that each fragment is persisted.

In aid of this, we send an EoFr frame at the end of each MKV cluster.

Recent behavior in regard to this was discovered frequently failing pipelines due to kvssink. On investigation it was discovered the root cause of this was uploadHandles timing out on stream token rotation. (Application uses IoT Credential Provider). 

```
[java] 31 Jan 2025 15:46:49,125 [INFO] [] (MkvFileReaderSrc-worker) com.package.ClassX: Container Loaded - stream [id1-archive] - 1: [1738338403619] - 2: [1738338405619] - target ACK: [1738338407618]
[java] [kvssink] [INFO ] [31-01-2025 15:46:49:125.719 GMT] getStreamingEndpointResultEvent(): Get streaming endpoint result event.
[java] [kvssink] [INFO ] [31-01-2025 15:46:49:125.750 GMT] getStreamingTokenResultEvent(): Get streaming token result event.
[java] [kvssink] [INFO ] [31-01-2025 15:46:49:125.953 GMT] putStreamResultEvent(): Put stream result event. New upload handle 10
[java] [kvssink] [INFO ] [31-01-2025 15:46:49:185.257 GMT] writeHeaderCallback(): RequestId: f0890943-5703-6b32-909f-fbeae1fd6f62
[java] [kvssink] [INFO ] [31-01-2025 15:46:49:829.444 GMT] postReadCallback(): Reported end-of-stream for stream id1-archive. Upload handle: 9
[java] [kvssink] [WARN ] [31-01-2025 15:47:19:154.901 GMT] curlCompleteSync(): [id1-archive] curl perform failed for url https://s-x.kinesisvideo.us-east-1.amazonaws.com/putMedia with result Timeout was reached: Operation too slow. Less than 30 bytes/sec transferred the last 30 seconds
[java] [kvssink] [WARN ] [31-01-2025 15:47:19:154.977 GMT] curlCompleteSync(): [id1-archive] HTTP Error 0 : Response: (null)
[java] Request URL: https://s-x.kinesisvideo.us-east-1.amazonaws.com/putMedia
[java] Request Headers:
[java]     Authorization: AWS4-HMAC-SHA256 Credential=X/20250131/us-east-1/kinesisvideo/aws4_request, SignedHeaders=connection;host;transfer-encoding;user-agent;x-amz-date;x-amzn-fragment-acknowledgment-required;x-amzn-fragment-timecode-type;x-amzn-producer-start-timestamp;x-amzn-stream-name, Signature=X
[java] [kvssink] [WARN ] [31-01-2025 15:47:19:156.406 GMT] putStreamCurlHandler(): [id1-archive] Stream with streamHandle 140321213454512 uploadHandle 10 has exited without triggering end-of-stream. Service call result: 599
[java] [kvssink] [INFO ] [31-01-2025 15:47:19:156.414 GMT] kinesisVideoStreamTerminated(): Stream 0x7f9f141518b0 terminated upload handle 10 with service call result 599.
[java] [kvssink] [INFO ] [31-01-2025 15:47:19:156.572 GMT] putStreamResultEvent(): Put stream result event. New upload handle 11
[java] [kvssink] [WARN ] [31-01-2025 15:47:19:166.666 GMT] notifyDataAvailable(): [id1-archive] Failed to un-pause curl with error: 43. Curl object 0x7f9f9c0ab670
[java] [kvssink] [INFO ] [31-01-2025 15:47:21:703.700 GMT] writeHeaderCallback(): RequestId: fcf7467c-fb07-98b6-9ce1-b4b54df99879
```

Root cause was discovered in PIC code on token rotation, if all Persisted ACKs have been received and processed for the fragments that were handled by uploadHandle(N), it would enter state UPLOAD_HANDLE_STATE_TERMINATED and never pass through UPLOAD_HANDLE_STATE_AWAITING_ACK (appropriately). Though on getStreamData:CleanUp that would cause PIC to not hit the code path that pokes the subsequent handle uploadHandle(N+1). uploadHandle(N+1) will be stuck in UPLOAD_HANDLE_STATE_READY until it times out due to inactivity, and uploadHandle(N+2) starts up and successfully picks up data.

```
// when pUploadHandleInfo is in UPLOAD_HANDLE_STATE_TERMINATED or UPLOAD_HANDLE_STATE_AWAITING_ACK, it means current handle
// has sent all the data. So it's safe to unblock the next one if any. If WAIT_FOR_PERSISTED_ACK is enabled, no need
// to execute data available again when UPLOAD_HANDLE_STATE_TERMINATED because we did it already when upload handle
// was in UPLOAD_HANDLE_STATE_AWAITING_ACK state.
if (NULL != pUploadHandleInfo &&
    (pUploadHandleInfo->state == UPLOAD_HANDLE_STATE_AWAITING_ACK ||
    (!WAIT_FOR_PERSISTED_ACK(pKinesisVideoStr && pUploadHandleInfo->state == UPLOAD_HANDLE_STATE_TERMINATED))) {
    <poke next handle to pick up stream>
```
https://github.com/grantralston/amazon-kinesis-video-streams-pic/blob/c98c2a256a7bb3dfc4db41ae26d45e28ac7eec56/src/client/src/Stream.c#L1535

*What was changed?*
getStreamData:CleanUp path adjusted condition to trigger next upload handle poke when uploadHandle reaches UPLOAD_HANDLE_STATE_TERMINATED and has not poked the subsequent handle yet. This condition is tracked as a BOOL on the __UploadHandleInfo struct.

*Why was it changed?*
Fix was implemented so that edge case on stream token transition does not causes intermittent failures to pipeline and disruptions to streaming operations.

*How was it changed?*
getStreamData:CleanUp path adjusted condition to trigger next upload handle poke when uploadHandle reaches UPLOAD_HANDLE_STATE_TERMINATED and has not poked the subsequent handle yet. This condition is tracked as a BOOL on the __UploadHandleInfo struct.

*What testing was done for the changes?*
- Commit was compiled into test version of our full application and deployed to lab environment with over 500 streams active. Failure mode was observed to be successfully fixed and no additional issues were uncovered.
- PIC compiled with unit tests and run with `./tst/kvspic_test`
- Unit test implemented to cover scenario in question.

```
[==========] 2436 tests from 71 test suites ran. (1849852 ms total)
[  PASSED  ] 2435 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] TimerQueueFunctionalityTest.kickTimerQueueTest
```
| TimerQueueFunctionalityTest.kickTimerQueueTest was failing prior to change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.