### PR TITLE
Add AL2 to the CI, migrate to docker, address compile warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v1
 
       - name: Install deps
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,6 @@ jobs:
           timeout --signal=SIGABRT 40m ./tst/kvspic_test --gtest_filter="${{ env.TEST_FILTER }}"
 
   linux-gcc-4_4:
-    runs-on: ubuntu-20.04
     strategy:
       matrix:
         config:
@@ -154,30 +153,85 @@ jobs:
           - name: Aligned Memory Model Build
             cmake_flags: "-DBUILD_TEST=TRUE -DALIGNED_MEMORY_MODEL=TRUE -DFIXUP_ANNEX_B_TRAILING_NALU_ZERO=TRUE"
       fail-fast: false
+
+    runs-on: ubuntu-latest
+    container: public.ecr.aws/ubuntu/ubuntu:20.04
+
     env:
+      DEBIAN_FRONTEND: noninteractive
       CC: gcc-4.4
+
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
+
       - name: Install deps
         run: |
-          sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6'
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty main'
-          sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty universe'
-          sudo apt-get -q update
-          sudo apt-get -y install gcc-4.4
-          sudo apt-get -y install gdb
+          apt-get -q update
+          apt-get install -y software-properties-common build-essential cmake git
+          add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty main'
+          add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ trusty universe'
+          apt-get -q update
+          apt-get -y install gcc-4.4
+
       - name: Build repository
         run: |
           mkdir build && cd build
           cmake .. ${{ matrix.config.cmake_flags }}
-          make
+          make -j
+
       - name: Run tests
+        working-directory: ./build
         run: |
-          cd build
-          ulimit -c unlimited -S
           timeout --signal=SIGABRT 40m ./tst/kvspic_test --gtest_filter="${{ env.TEST_FILTER }}"
+
+  al2:
+    strategy:
+      matrix:
+        config:
+          - name: Default Build
+            cmake_flags: "-DBUILD_TEST=TRUE"
+          - name: Aligned Memory Model Build
+            cmake_flags: "-DBUILD_TEST=TRUE -DALIGNED_MEMORY_MODEL=TRUE -DFIXUP_ANNEX_B_TRAILING_NALU_ZERO=TRUE"
+      fail-fast: false
+
+    runs-on: ubuntu-latest
+    container: public.ecr.aws/sam/build-provided.al2:1.137.1-x86_64
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      - name: Install deps
+        run: |
+          yum update -y
+          yum install -y cmake3 which
+          ln -s /usr/bin/cmake3 /usr/local/bin/cmake
+
+      - name: Check GCC version
+        run: |
+          gcc --version
+          which gcc
+          gcc -v
+
+      - name: Check CMake version
+        run: |
+          cmake --version
+          which cmake
+
+      - name: Build repository
+        run: |
+          mkdir build
+          cd build
+          cmake .. ${{ matrix.config.cmake_flags }}
+          make -j
+
+      - name: Run tests
+        working-directory: ./build
+        run: |
+          # 2400s = 40m
+          timeout 2400 ./tst/kvspic_test --gtest_filter="${{ env.TEST_FILTER }}"
 
   arm-cross-compilation:
     runs-on: ubuntu-latest

--- a/tst/utils/Directory.cpp
+++ b/tst/utils/Directory.cpp
@@ -111,10 +111,13 @@ STATUS createDirStruct()
     removeDirectory((PCHAR) TEMP_TEST_DIRECTORY_PATH);
 
 #if defined __WINDOWS_BUILD__
-    system((PCHAR) "del /q /s " TEMP_TEST_DIRECTORY_PATH);
+     const char* command = "del /q /s ";
 #else
-    system((PCHAR) "rm -rf " TEMP_TEST_DIRECTORY_PATH);
+     const char* command = "rm -rf ";
 #endif
+
+    const int result = system((PCHAR) (std::string(command) + TEMP_TEST_DIRECTORY_PATH).c_str());
+    EXPECT_EQ(result, 0) << "Failed to delete directory: " << TEMP_TEST_DIRECTORY_PATH;
 
     // Start creating
     FMKDIR(TEMP_TEST_DIRECTORY_PATH, 0777);


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*
- **linux-gcc-4_4** - Updated to run inside the official Ubuntu 20.04 ECR Docker container on the ubuntu-latest runner, replacing the deprecated GitHub-hosted Ubuntu 20.04 runner.
- **al2** - Added a new CI job to build and run tests on Amazon Linux 2 (AL2) using the `public.ecr.aws/sam/build-provided.al2` container.
- **Directory.cpp** test - Updated the test to capture and assert the return value of the system() call when deleting test directories.

*Why was it changed?*
- **linux-gcc-4_4** - GitHub Actions deprecated the native Ubuntu 20.04 runner as of January 2025, requiring a container-based alternative for legacy builds. [Reference](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/)
- **al2** - In preparation for adding AL2 for the JNI builds for https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-java.
- **Directory.cpp** test - Addressed the following compiler warning for ignoring the return value of system() marked with warn_unused_result.

```
[ 98%] Built target kvsVideoOnlyOfflineStreamingSample
/__w/amazon-kinesis-video-streams-producer-c/amazon-kinesis-video-streams-producer-c/dependency/libkvspic/kvspic-src/tst/utils/Directory.cpp: In function 'UINT32 createDirStruct()':
/__w/amazon-kinesis-video-streams-producer-c/amazon-kinesis-video-streams-producer-c/dependency/libkvspic/kvspic-src/tst/utils/Directory.cpp:116:11: warning: ignoring return value of 'int system(const char*)' declared with attribute 'warn_unused_result' [-Wunused-result]
  116 |     system((PCHAR) "rm -rf " TEMP_TEST_DIRECTORY_PATH);
      |     ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
[ 98%] Built target kvsVideoOnlyRealtimeStreamingSample
```

*How was it changed?*
- **linux-gcc-4_4** - Switched the job’s runner to ubuntu-latest and added a container directive to use `public.ecr.aws/ubuntu/ubuntu:20.04`. Updated dependency installation to run inside the container since the ecr image and GitHub actions image have different things pre-installed.
- **al2** - Introduced a new job definition using the AL2 container image to match the rest of the jobs we have in the CI. It runs both the memory-aligned build and the non-memory-aligned build.
- **Directory.cpp** test - Capture the `system()` call result and added a EXPECT_EQ(result, 0) assertion to validate successful execution.

*What testing was done for the changes?*
- Verified via CI runs in my fork for both the updated and new jobs. All tests completed successfully.
- Manually checked that the runner output that the compiler warning no longer shows up

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.