### PR TITLE
Add logs for struct versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,9 @@ jobs:
             runner: macos-13
           - name: Mac Apple Silicon
             runner: macos-15
-        compiler: [ gcc, clang ]
+        compiler:
+          # - gcc # Fragile builds due to homebrew GCC being compiled using different MacOSX SDK version
+          - clang
         config:
           - name: Default Build
             cmake_flags: "-DBUILD_TEST=TRUE"

--- a/src/client/src/InputValidator.c
+++ b/src/client/src/InputValidator.c
@@ -18,6 +18,7 @@ STATUS validateClientCallbacks(PDeviceInfo pDeviceInfo, PClientCallbacks pClient
     STATUS retStatus = STATUS_SUCCESS;
 
     CHK(pClientCallbacks != NULL && pDeviceInfo != NULL, STATUS_NULL_ARG);
+    DLOGD("ClientCallbacks version: %d", pClientCallbacks->version);
     CHK(pClientCallbacks->version <= CALLBACKS_CURRENT_VERSION, STATUS_INVALID_CALLBACKS_VERSION);
 
     // Most of the callbacks are optional
@@ -124,6 +125,7 @@ STATUS validateDeviceInfo(PDeviceInfo pDeviceInfo)
     STATUS retStatus = STATUS_SUCCESS;
 
     CHK(pDeviceInfo != NULL, STATUS_NULL_ARG);
+    DLOGD("DeviceInfo version: %d", pDeviceInfo->version);
     CHK(pDeviceInfo->version <= DEVICE_INFO_CURRENT_VERSION, STATUS_INVALID_DEVICE_INFO_VERSION);
     CHK(pDeviceInfo->streamCount <= MAX_STREAM_COUNT, STATUS_MAX_STREAM_COUNT);
     CHK(pDeviceInfo->streamCount > 0, STATUS_MIN_STREAM_COUNT);
@@ -159,6 +161,7 @@ STATUS validateClientInfo(PClientInfo pClientInfo)
     STATUS retStatus = STATUS_SUCCESS;
 
     CHK(pClientInfo != NULL, STATUS_NULL_ARG);
+    DLOGD("ClientInfo version: %d", pClientInfo->version);
     CHK(pClientInfo->version <= CLIENT_INFO_CURRENT_VERSION, STATUS_INVALID_CLIENT_INFO_VERSION);
 
 CleanUp:
@@ -218,6 +221,7 @@ STATUS validateStreamInfo(PStreamInfo pStreamInfo, PClientCallbacks pClientCallb
 
     // Validate the stream info struct
     CHK(pStreamInfo != NULL, STATUS_NULL_ARG);
+    DLOGD("StreamInfo version: %d", pStreamInfo->version);
     CHK(pStreamInfo->version <= STREAM_INFO_CURRENT_VERSION, STATUS_INVALID_STREAM_INFO_VERSION);
     CHK(STRNLEN(pStreamInfo->name, MAX_STREAM_NAME_LEN + 1) <= MAX_STREAM_NAME_LEN, STATUS_INVALID_STREAM_NAME_LENGTH);
 


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Added logs for struct versions

*Why was it changed?*
- For debugging. If a user specified a recent struct version but do not provide valid values for the newly-added fields, there will be undefined behavior.

*How was it changed?*
- Log the values of the struct versions being input to the SDK.

*What testing was done for the changes?*
- CI should be sufficient.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.