### PR TITLE
Set the log level first so initialization logs are shown

### DIFF
--- a/src/client/src/Client.c
+++ b/src/client/src/Client.c
@@ -171,10 +171,18 @@ STATUS createKinesisVideoClient(PDeviceInfo pDeviceInfo, PClientCallbacks pClien
     PKinesisVideoClient pKinesisVideoClient = NULL;
     PStateMachine pStateMachine = NULL;
     BOOL tearDownOnError = TRUE;
-    UINT32 allocationSize, heapFlags, tagsSize;
+    UINT32 allocationSize, heapFlags, tagsSize, logLevel;
 
     // Check the input params
     CHK(pDeviceInfo != NULL && pClientHandle != NULL, STATUS_NULL_ARG);
+
+    // Set the log level immediately so that initialization logs are shown
+    logLevel = pDeviceInfo->clientInfo.loggerLogLevel;
+    if (logLevel == 0 || logLevel > LOG_LEVEL_PROFILE) {
+        logLevel = LOG_LEVEL_WARN;
+    }
+    SET_LOGGER_LOG_LEVEL(pDeviceInfo->clientInfo.loggerLogLevel);
+    DLOGI("Creating Kinesis Video Client");
 
     // Set the return client handle first
     *pClientHandle = INVALID_CLIENT_HANDLE_VALUE;
@@ -184,9 +192,6 @@ STATUS createKinesisVideoClient(PDeviceInfo pDeviceInfo, PClientCallbacks pClien
 
     // Validate the callbacks. Set default callbacks.
     CHK_STATUS(validateClientCallbacks(pDeviceInfo, pClientCallbacks));
-
-    // Report the creation after the validation as we might have the overwritten logger.
-    DLOGI("Creating Kinesis Video Client");
 
     // Get the max tags structure size
     CHK_STATUS(packageTags(pDeviceInfo->tagCount, pDeviceInfo->tags, 0, NULL, &tagsSize));
@@ -238,9 +243,6 @@ STATUS createKinesisVideoClient(PDeviceInfo pDeviceInfo, PClientCallbacks pClien
         createRandomName(pKinesisVideoClient->deviceInfo.name, DEFAULT_DEVICE_NAME_LEN, pKinesisVideoClient->clientCallbacks.getRandomNumberFn,
                          pKinesisVideoClient->clientCallbacks.customData);
     }
-
-    // Set logger log level
-    SET_LOGGER_LOG_LEVEL(pKinesisVideoClient->deviceInfo.clientInfo.loggerLogLevel);
 
 #ifndef ALIGNED_MEMORY_MODEL
     // In case of in-content-store memory allocation, we need to ensure the heap is aligned

--- a/src/client/src/Client.c
+++ b/src/client/src/Client.c
@@ -171,17 +171,15 @@ STATUS createKinesisVideoClient(PDeviceInfo pDeviceInfo, PClientCallbacks pClien
     PKinesisVideoClient pKinesisVideoClient = NULL;
     PStateMachine pStateMachine = NULL;
     BOOL tearDownOnError = TRUE;
-    UINT32 allocationSize, heapFlags, tagsSize, logLevel;
+    UINT32 allocationSize, heapFlags, tagsSize, logLevel = DEFAULT_LOGGER_LOG_LEVEL;
 
     // Check the input params
     CHK(pDeviceInfo != NULL && pClientHandle != NULL, STATUS_NULL_ARG);
 
     // Set the log level immediately so that initialization logs are shown
-    logLevel = pDeviceInfo->clientInfo.loggerLogLevel;
-    if (logLevel == 0 || logLevel > LOG_LEVEL_PROFILE) {
-        logLevel = LOG_LEVEL_WARN;
+    if (pDeviceInfo->version >= 1 && 0 < pDeviceInfo->clientInfo.loggerLogLevel && pDeviceInfo->clientInfo.loggerLogLevel <= LOG_LEVEL_PROFILE) {
+        logLevel = pDeviceInfo->clientInfo.loggerLogLevel;
     }
-    SET_LOGGER_LOG_LEVEL(pDeviceInfo->clientInfo.loggerLogLevel);
     DLOGI("Creating Kinesis Video Client");
 
     // Set the return client handle first


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- KinesisVideoClient constructor: Set the log level as the first thing. This is to make sure logs inside of validateDeviceInfo and validateClientInfo get printed.

*Why was it changed?*
- Verbose logs inside those function calls would not get printed otherwise.

*How was it changed?*
- Moved setting the log level up.

*What testing was done for the changes?*
- CI/CD should pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.