### PR TITLE
Log for submitting auto-eofr for intermittent producer mode

### DIFF
--- a/src/client/src/Client.c
+++ b/src/client/src/Client.c
@@ -75,6 +75,8 @@ STATUS checkIntermittentProducerCallback(UINT32 timerId, UINT64 currentTime, UIN
                     (currentTime - pCurrStream->lastPutFrameTimestamp) > INTERMITTENT_PRODUCER_MAX_TIMEOUT) {
                     if (!STATUS_SUCCEEDED(retStatus = putKinesisVideoFrame(TO_STREAM_HANDLE(pCurrStream), &eofr))) {
                         DLOGW("Failed to submit auto eofr with 0x%08x, for stream: %s", retStatus, pCurrStream->streamInfo.name);
+                    } else {
+                        DLOGI("Submitted auto eofr for stream %s", pCurrStream->streamInfo.name);
                     }
                 }
 


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Add a log line when the EOFR is submitted for the intermittent producer mode

*Why was it changed?*
- For debug purposes

*How was it changed?*
- Added a log line for the success case.

*What testing was done for the changes?*
- Tested in conjunction with [Java #235](https://github.com/awslabs/amazon-kinesis-video-streams-producer-sdk-java/pull/235)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.