### PR TITLE
Add line to properly set log level

### DIFF
--- a/src/client/src/Client.c
+++ b/src/client/src/Client.c
@@ -182,6 +182,8 @@ STATUS createKinesisVideoClient(PDeviceInfo pDeviceInfo, PClientCallbacks pClien
     if (pDeviceInfo->version >= 1 && 0 < pDeviceInfo->clientInfo.loggerLogLevel && pDeviceInfo->clientInfo.loggerLogLevel <= LOG_LEVEL_PROFILE) {
         logLevel = pDeviceInfo->clientInfo.loggerLogLevel;
     }
+    SET_LOGGER_LOG_LEVEL(logLevel);
+
     DLOGI("Creating Kinesis Video Client");
 
     // Set the return client handle first


### PR DESCRIPTION
*Issue #, if available:*

*What was changed?*

Added a line to set the log level.

*Why was it changed?*

Prior to #282, the log level was set at the end of `createKinesisVideoClient`. This line was supposed to be moved up to after getting the log level from `clientInfo`, but was it was removed and never added back.

*How was it changed?*

Added `SET_LOGGER_LOG_LEVEL(logLevel);` after updating log level from `clientInfo`

*What testing was done for the changes?*

Compiled and ran it locally confirming log levels were updated properly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.