### PR TITLE
Upgrade from MacOS13 to 15-intel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os:
           - name: Mac Intel
-            runner: macos-13
+            runner: macos-15-intel
           - name: Mac Apple Silicon
             runner: macos-15
         compiler:


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- CI: Runner type used

*Why was it changed?*
- MacOS 13 (x86_64) is being deprecated and being replaced with `macos-15-intel`
- https://github.com/actions/runner-images/issues/13045

*How was it changed?*
- Updated the matrix parameter that determines the runner type

*What testing was done for the changes?*
- If the CI passes, the migration completed successfully

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
