### PR TITLE
Add environment variable check utility function

### DIFF
--- a/src/utils/include/com/amazonaws/kinesis/video/utils/Include.h
+++ b/src/utils/include/com/amazonaws/kinesis/video/utils/Include.h
@@ -2005,6 +2005,15 @@ PUBLIC_API STATUS threadpoolTryAdd(PThreadpool, startRoutine, PVOID);
  */
 PUBLIC_API STATUS threadpoolPush(PThreadpool, startRoutine, PVOID);
 
+/**
+ * @brief Checks if an environment variable is enabled.
+ *
+ * @param - PCHAR - IN - The label of the environment variable to check for.
+ *
+ * @return - BOOL - TRUE if the environment variable is enabled, FALSE otherwise.
+ */
+PUBLIC_API BOOL isEnvVarEnabled(PCHAR);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/utils/src/Environment.c
+++ b/src/utils/src/Environment.c
@@ -15,7 +15,7 @@ BOOL isEnvVarEnabled(PCHAR envVarName)
     retBool = envVarVal != NULL && (STRCMPI(envVarVal, "1") == 0 || STRCMPI(envVarVal, "true") == 0 || STRCMPI(envVarVal, "on") == 0);
 
 CleanUp:
-    UNUSED_PARAM(retStatus);
+    CHK_LOG_ERR(retStatus);
     LEAVES();
     return retBool;
 }

--- a/src/utils/src/Environment.c
+++ b/src/utils/src/Environment.c
@@ -1,0 +1,21 @@
+#include "Include_i.h"
+
+BOOL isEnvVarEnabled(PCHAR envVarName)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    BOOL retBool = FALSE;
+
+    // Null or empty envVarName to GETENV is undefined behavior.
+    CHK_ERR(envVarName != NULL && envVarName[0] != '\0', STATUS_NULL_ARG, "Environment variable name is NULL or empty.");
+
+    PCHAR envVarVal = GETENV(envVarName);
+
+    // Case-insensitive comparisons.
+    retBool = envVarVal != NULL && (STRCMPI(envVarVal, "1") == 0 || STRCMPI(envVarVal, "true") == 0 || STRCMPI(envVarVal, "on") == 0);
+
+CleanUp:
+    UNUSED_PARAM(retStatus);
+    LEAVES();
+    return retBool;
+}

--- a/src/utils/src/FileIo.c
+++ b/src/utils/src/FileIo.c
@@ -19,7 +19,7 @@ STATUS readFile(PCHAR filePath, BOOL binMode, PBYTE pBuffer, PUINT64 pSize)
 
     CHK(filePath != NULL && pSize != NULL, STATUS_NULL_ARG);
 
-    DLOGD("Opening file: %s", filePath);
+    DLOGV("Opening file: %s", filePath);
     fp = FOPEN(filePath, binMode ? "rb" : "r");
 
     CHK(fp != NULL, STATUS_OPEN_FILE_FAILED);
@@ -87,7 +87,7 @@ STATUS readFileSegment(PCHAR filePath, BOOL binMode, PBYTE pBuffer, UINT64 offse
 
     CHK(filePath != NULL && pBuffer != NULL && readSize != 0, STATUS_NULL_ARG);
 
-    DLOGD("Opening file: %s", filePath);
+    DLOGV("Opening file: %s", filePath);
     fp = FOPEN(filePath, binMode ? "rb" : "r");
 
     CHK(fp != NULL, STATUS_OPEN_FILE_FAILED);
@@ -148,7 +148,7 @@ STATUS writeFileWithLogging(PCHAR filePath, BOOL binMode, BOOL append, PBYTE pBu
 
     CHK(filePath != NULL && pBuffer != NULL, STATUS_NULL_ARG);
 
-    DLOGD("Opening file: %s", filePath);
+    DLOGV("Opening file: %s", filePath);
     fp = FOPEN(filePath, binMode ? (append ? "ab" : "wb") : (append ? "a" : "w"));
 
     CHK(fp != NULL, STATUS_OPEN_FILE_FAILED);
@@ -222,7 +222,7 @@ STATUS updateFile(PCHAR filePath, BOOL binMode, PBYTE pBuffer, UINT64 offset, UI
 
     CHK(filePath != NULL && pBuffer != NULL, STATUS_NULL_ARG);
 
-    DLOGD("Opening file: %s", filePath);
+    DLOGV("Opening file: %s", filePath);
     fp = FOPEN(filePath, binMode ? "rb+" : "r+");
 
     CHK(fp != NULL, STATUS_OPEN_FILE_FAILED);

--- a/tst/utils/Environment.cpp
+++ b/tst/utils/Environment.cpp
@@ -1,0 +1,99 @@
+#include "UtilTestFixture.h"
+
+class EnvironmentFunctionalityTest : public UtilTestBase {};
+
+TEST_F(EnvironmentFunctionalityTest, CheckTrueCases)
+{
+    std::string envVar = "KVS_TEST_ENV_VAR_TRUE";
+
+#ifdef _WIN32
+    CHAR envBuf[256];
+#endif
+
+    // Common potential true values to test.
+    std::vector<std::string> trueValues = {
+        "1", "true", "True", "TRUE", "on", "On", "ON",
+    };
+
+    for (std::string val : trueValues) {
+// Unset env var first.
+#ifdef _WIN32
+        SNPRINTF(envBuf, sizeof(envBuf), "%s=", envVar.c_str());
+        _putenv(envBuf);
+#else
+        unsetenv(envVar.c_str());
+#endif
+
+        // Check unset case.
+        EXPECT_FALSE(isEnvVarEnabled((PCHAR) envVar.c_str()));
+
+// Set to the TRUE value.
+#ifdef _WIN32
+        SNPRINTF(envBuf, sizeof(envBuf), "%s=%s", envVar.c_str(), val.c_str());
+        _putenv(envBuf);
+#else
+        setenv(envVar.c_str(), val.c_str(), 1);
+#endif
+
+        EXPECT_TRUE(isEnvVarEnabled((PCHAR) envVar.c_str()));
+    }
+
+// Cleanup the test environment variable.
+#ifdef _WIN32
+    SNPRINTF(envBuf, sizeof(envBuf), "%s=", envVar.c_str());
+    _putenv(envBuf);
+#else
+    unsetenv(envVar.c_str());
+#endif
+}
+
+TEST_F(EnvironmentFunctionalityTest, CheckFalseCases)
+{
+    std::string envVar = "KVS_TEST_ENV_VAR_FALSE";
+
+#ifdef _WIN32
+    CHAR envBuf[256];
+#endif
+
+    // Common potential false values to test, including near-true ones.
+    std::vector<std::string> falseValues = {
+        "0", "false", "off", "random_string", "", " ", "tru", "rue", "onn", "yes", "no", "2", "-1",
+    };
+
+    for (std::string val : falseValues) {
+// Unset env var first.
+#ifdef _WIN32
+        SNPRINTF(envBuf, sizeof(envBuf), "%s=", envVar.c_str());
+        _putenv(envBuf);
+#else
+        unsetenv(envVar.c_str());
+#endif
+
+        // Check unset case.
+        EXPECT_FALSE(isEnvVarEnabled((PCHAR) envVar.c_str()));
+
+// Set to the false value
+#ifdef _WIN32
+        SNPRINTF(envBuf, sizeof(envBuf), "%s=%s", envVar.c_str(), val.c_str());
+        _putenv(envBuf);
+#else
+        setenv(envVar.c_str(), val.c_str(), 1);
+#endif
+
+        EXPECT_FALSE(isEnvVarEnabled((PCHAR) envVar.c_str()));
+    }
+
+    // Null variable name check.
+    EXPECT_FALSE(isEnvVarEnabled((PCHAR) NULL));
+
+    // Empty variable name check.
+    EXPECT_FALSE(isEnvVarEnabled((PCHAR) ""));
+
+// Cleanup the test environment variable.
+#ifdef _WIN32
+    SNPRINTF(envBuf, sizeof(envBuf), "%s=", envVar.c_str());
+    _putenv(envBuf);
+#else
+    unsetenv(envVar.c_str());
+#endif
+}


### PR DESCRIPTION
*Issue #, if available:*
N/A

*What was changed?*
- Added a new utility function to check whether an environment variable is enabled. Checks like this are made throughout consuming SDKs, so adding a utility function to centralize it and keep logic consistent.
- Changed verbosity of "Opening file" logs to VERBOSE to reduce log clutter in DEBUG mode.

The function returns TRUE if the passed in env var is set to 1, "ON", or "OFF" (case insensitive), else returns FALSE.

*Why was it changed?*
To provide a helper function for all down-stream libraries to be able to use.

*How was it changed?*
Created a new _Environment.c_ source file and added the definition there.

*What testing was done for the changes?*
- Added new unit tests to cover various cases.
- CI to pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.