### PR TITLE
Add isEnvEnabled function with default when env is unset

### DIFF
--- a/src/utils/include/com/amazonaws/kinesis/video/utils/Include.h
+++ b/src/utils/include/com/amazonaws/kinesis/video/utils/Include.h
@@ -2006,9 +2006,23 @@ PUBLIC_API STATUS threadpoolTryAdd(PThreadpool, startRoutine, PVOID);
 PUBLIC_API STATUS threadpoolPush(PThreadpool, startRoutine, PVOID);
 
 /**
- * @brief Checks if an environment variable is enabled.
+ * @brief Checks if an environment variable is set to an enabled or disabled value, with a default if unset.
  *
- * @param - PCHAR - IN - The label of the environment variable to check for.
+ * Recognized enabled values: "1", "true", "on" (case-insensitive).
+ * Recognized disabled values: "0", "false", "off" (case-insensitive).
+ * Unset or unrecognized values return the provided default.
+ *
+ * @param - PCHAR - IN - The name of the environment variable to check for.
+ * @param - BOOL - IN - The default value to return if the variable is unset.
+ *
+ * @return - BOOL - TRUE/FALSE based on the variable value, or defaultVal if unset.
+ */
+PUBLIC_API BOOL isEnvVarEnabledWithDefault(PCHAR, BOOL);
+
+/**
+ * @brief Checks if an environment variable is enabled (default=OFF). Equivalent to isEnvVarEnabledWithDefault(envVarName, FALSE).
+ *
+ * @param - PCHAR - IN - The name of the environment variable to check for.
  *
  * @return - BOOL - TRUE if the environment variable is enabled, FALSE otherwise.
  */

--- a/src/utils/src/Environment.c
+++ b/src/utils/src/Environment.c
@@ -1,21 +1,32 @@
 #include "Include_i.h"
 
-BOOL isEnvVarEnabled(PCHAR envVarName)
+BOOL isEnvVarEnabledWithDefault(PCHAR envVarName, BOOL defaultVal)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
-    BOOL retBool = FALSE;
+    BOOL retBool = defaultVal;
 
     // Null or empty envVarName to GETENV is undefined behavior.
     CHK_ERR(envVarName != NULL && envVarName[0] != '\0', STATUS_NULL_ARG, "Environment variable name is NULL or empty.");
 
-    PCHAR envVarVal = GETENV(envVarName);
+    PCHAR envVarVal = (PCHAR) GETENV(envVarName);
+    CHK(envVarVal != NULL, retStatus);
 
-    // Case-insensitive comparisons.
-    retBool = envVarVal != NULL && (STRCMPI(envVarVal, "1") == 0 || STRCMPI(envVarVal, "true") == 0 || STRCMPI(envVarVal, "on") == 0);
+    if (STRCMPI(envVarVal, "1") == 0 || STRCMPI(envVarVal, "true") == 0 || STRCMPI(envVarVal, "on") == 0) {
+        retBool = TRUE;
+    } else if (STRCMPI(envVarVal, "0") == 0 || STRCMPI(envVarVal, "false") == 0 || STRCMPI(envVarVal, "off") == 0) {
+        retBool = FALSE;
+    } else {
+        DLOGW("Unrecognized value for %s, using default: %d", envVarName, defaultVal);
+    }
 
 CleanUp:
     CHK_LOG_ERR(retStatus);
     LEAVES();
     return retBool;
+}
+
+BOOL isEnvVarEnabled(PCHAR envVarName)
+{
+    return isEnvVarEnabledWithDefault(envVarName, FALSE);
 }

--- a/tst/utils/Environment.cpp
+++ b/tst/utils/Environment.cpp
@@ -18,7 +18,7 @@ TEST_F(EnvironmentFunctionalityTest, CheckTrueCases)
     for (std::string val : trueValues) {
 // Unset env var first.
 #ifdef _WIN32
-        SNPRINTF(envBuf, sizeof(envBuf), "%s=", envVar.c_str());
+        SNPRINTF(envBuf, SIZEOF(envBuf), "%s=", envVar.c_str());
         _putenv(envBuf);
 #else
         unsetenv(envVar.c_str());
@@ -29,7 +29,7 @@ TEST_F(EnvironmentFunctionalityTest, CheckTrueCases)
 
 // Set to the TRUE value.
 #ifdef _WIN32
-        SNPRINTF(envBuf, sizeof(envBuf), "%s=%s", envVar.c_str(), val.c_str());
+        SNPRINTF(envBuf, SIZEOF(envBuf), "%s=%s", envVar.c_str(), val.c_str());
         _putenv(envBuf);
 #else
         setenv(envVar.c_str(), val.c_str(), 1);
@@ -40,7 +40,7 @@ TEST_F(EnvironmentFunctionalityTest, CheckTrueCases)
 
 // Cleanup the test environment variable.
 #ifdef _WIN32
-    SNPRINTF(envBuf, sizeof(envBuf), "%s=", envVar.c_str());
+    SNPRINTF(envBuf, SIZEOF(envBuf), "%s=", envVar.c_str());
     _putenv(envBuf);
 #else
     unsetenv(envVar.c_str());
@@ -63,7 +63,7 @@ TEST_F(EnvironmentFunctionalityTest, CheckFalseCases)
     for (std::string val : falseValues) {
 // Unset env var first.
 #ifdef _WIN32
-        SNPRINTF(envBuf, sizeof(envBuf), "%s=", envVar.c_str());
+        SNPRINTF(envBuf, SIZEOF(envBuf), "%s=", envVar.c_str());
         _putenv(envBuf);
 #else
         unsetenv(envVar.c_str());
@@ -74,7 +74,7 @@ TEST_F(EnvironmentFunctionalityTest, CheckFalseCases)
 
 // Set to the false value
 #ifdef _WIN32
-        SNPRINTF(envBuf, sizeof(envBuf), "%s=%s", envVar.c_str(), val.c_str());
+        SNPRINTF(envBuf, SIZEOF(envBuf), "%s=%s", envVar.c_str(), val.c_str());
         _putenv(envBuf);
 #else
         setenv(envVar.c_str(), val.c_str(), 1);
@@ -91,9 +91,127 @@ TEST_F(EnvironmentFunctionalityTest, CheckFalseCases)
 
 // Cleanup the test environment variable.
 #ifdef _WIN32
-    SNPRINTF(envBuf, sizeof(envBuf), "%s=", envVar.c_str());
+    SNPRINTF(envBuf, SIZEOF(envBuf), "%s=", envVar.c_str());
     _putenv(envBuf);
 #else
     unsetenv(envVar.c_str());
 #endif
+}
+
+TEST_F(EnvironmentFunctionalityTest, isEnvVarEnabledWithDefaultDefaultTrueUnsetReturnsTrue)
+{
+    std::string envVar = "KVS_TEST_ENV_VAR_SET";
+
+#ifdef _WIN32
+    CHAR envBuf[256];
+    SNPRINTF(envBuf, SIZEOF(envBuf), "%s=", envVar.c_str());
+    _putenv(envBuf);
+#else
+    unsetenv(envVar.c_str());
+#endif
+
+    // Unset var with default=TRUE should return TRUE.
+    EXPECT_TRUE(isEnvVarEnabledWithDefault((PCHAR) envVar.c_str(), TRUE));
+
+    // Unset var with default=FALSE should return FALSE.
+    EXPECT_FALSE(isEnvVarEnabledWithDefault((PCHAR) envVar.c_str(), FALSE));
+}
+
+TEST_F(EnvironmentFunctionalityTest, isEnvVarEnabledWithDefaultExplicitDisable)
+{
+    std::string envVar = "KVS_TEST_ENV_VAR_SET";
+
+#ifdef _WIN32
+    CHAR envBuf[256];
+#endif
+
+    std::vector<std::string> disabledValues = {"0", "false", "False", "FALSE", "off", "Off", "OFF"};
+
+    for (std::string val : disabledValues) {
+#ifdef _WIN32
+        SNPRINTF(envBuf, SIZEOF(envBuf), "%s=%s", envVar.c_str(), val.c_str());
+        _putenv(envBuf);
+#else
+        setenv(envVar.c_str(), val.c_str(), 1);
+#endif
+
+        // Even with default=TRUE, explicit disable should return FALSE.
+        EXPECT_FALSE(isEnvVarEnabledWithDefault((PCHAR) envVar.c_str(), TRUE));
+    }
+
+#ifdef _WIN32
+    SNPRINTF(envBuf, SIZEOF(envBuf), "%s=", envVar.c_str());
+    _putenv(envBuf);
+#else
+    unsetenv(envVar.c_str());
+#endif
+}
+
+TEST_F(EnvironmentFunctionalityTest, isEnvVarEnabledWithDefaultExplicitEnable)
+{
+    std::string envVar = "KVS_TEST_ENV_VAR_SET";
+
+#ifdef _WIN32
+    CHAR envBuf[256];
+#endif
+
+    std::vector<std::string> enabledValues = {"1", "true", "True", "TRUE", "on", "On", "ON"};
+
+    for (std::string val : enabledValues) {
+#ifdef _WIN32
+        SNPRINTF(envBuf, SIZEOF(envBuf), "%s=%s", envVar.c_str(), val.c_str());
+        _putenv(envBuf);
+#else
+        setenv(envVar.c_str(), val.c_str(), 1);
+#endif
+
+        // Even with default=FALSE, explicit enable should return TRUE.
+        EXPECT_TRUE(isEnvVarEnabledWithDefault((PCHAR) envVar.c_str(), FALSE));
+    }
+
+#ifdef _WIN32
+    SNPRINTF(envBuf, SIZEOF(envBuf), "%s=", envVar.c_str());
+    _putenv(envBuf);
+#else
+    unsetenv(envVar.c_str());
+#endif
+}
+
+TEST_F(EnvironmentFunctionalityTest, isEnvVarEnabledWithDefaultUnrecognizedValueReturnsDefault)
+{
+    std::string envVar = "KVS_TEST_ENV_VAR_SET";
+
+#ifdef _WIN32
+    CHAR envBuf[256];
+#endif
+
+    std::vector<std::string> garbageValues = {"random_string", " ", "tru", "yes", "no", "2", "-1"};
+
+    for (std::string val : garbageValues) {
+#ifdef _WIN32
+        SNPRINTF(envBuf, SIZEOF(envBuf), "%s=%s", envVar.c_str(), val.c_str());
+        _putenv(envBuf);
+#else
+        setenv(envVar.c_str(), val.c_str(), 1);
+#endif
+
+        // Unrecognized values should return the default.
+        EXPECT_TRUE(isEnvVarEnabledWithDefault((PCHAR) envVar.c_str(), TRUE));
+        EXPECT_FALSE(isEnvVarEnabledWithDefault((PCHAR) envVar.c_str(), FALSE));
+    }
+
+#ifdef _WIN32
+    SNPRINTF(envBuf, SIZEOF(envBuf), "%s=", envVar.c_str());
+    _putenv(envBuf);
+#else
+    unsetenv(envVar.c_str());
+#endif
+}
+
+TEST_F(EnvironmentFunctionalityTest, isEnvVarEnabledWithDefaultNullAndEmpty)
+{
+    EXPECT_TRUE(isEnvVarEnabledWithDefault((PCHAR) NULL, TRUE));
+    EXPECT_FALSE(isEnvVarEnabledWithDefault((PCHAR) NULL, FALSE));
+    EXPECT_TRUE(isEnvVarEnabledWithDefault((PCHAR) "", TRUE));
+    EXPECT_FALSE(isEnvVarEnabledWithDefault((PCHAR) "", FALSE));
 }


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*

Added `isEnvVarEnabledWithDefault(PCHAR, BOOL)` utility function alongside the existing `isEnvVarEnabled`.

*Why was it changed?*

`isEnvVarEnabled` supports default-OFF semantics. Default-ON environment variables were not supported. There was no clean way to check if a user explicitly disabled a feature that is enabled by default.

<details><summary><strong>Detailed explanation</strong></summary>

For example, given a feature that is ON by default, and the user decided to set it to on anyway:
```bash
export USE_FEATURE=ON
```

```c
// Incorrect: disabled even though the user explicitly enabled it
if (!isEnvVarEnabled("USE_FEATURE")) { ... }
```

Before `!isEnvVarEnabled()`:

| USE_FEATURE | Result | Correct? |
|---|---|---|
| ON | FALSE | ❌ Feature disabled despite user enabling it |
| OFF | TRUE | ❌ Feature enabled despite user disabling it |
| unset | TRUE | ✅ |

After `isEnvVarEnabledWithDefault(env, TRUE)`:

| USE_FEATURE | Result | Correct? |
|---|---|---|
| ON | TRUE | ✅ |
| OFF | FALSE | ✅ |
| unset | TRUE | ✅ Default preserved |

</details>

*How was it changed?*

- Introduced `isEnvVarEnabledWithDefault(PCHAR envVarName, BOOL defaultVal)` to return the `defaultVal` when the env var is unset.
  - Note: In C, there is no method overloading, so the new function needed a different name.
- Reimplemented `isEnvVarEnabled` as a thin wrapper: `isEnvVarSet(envVarName, FALSE)` for backward compatibility.

*What testing was done for the changes?*

- Added new unit tests to check the new functionality
- Existing tests for `isEnvVarEnabled` continue to pass (backwards compatibility)

```bash
 ./tst/kvspic_test --gtest_filter="*EnvironmentFunctionalityTest*"
...
[       OK ] EnvironmentFunctionalityTest.isEnvVarEnabledWithDefaultNullAndEmpty (0 ms)
[----------] 7 tests from EnvironmentFunctionalityTest (2 ms total)

[----------] Global test environment tear-down
[==========] 7 tests from 1 test suite ran. (3 ms total)
[  PASSED  ] 7 tests.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.