### PR TITLE
notify streamErrorReportFn calbacks when call result is permission error

### DIFF
--- a/src/client/src/StreamEvent.c
+++ b/src/client/src/StreamEvent.c
@@ -655,6 +655,17 @@ STATUS streamTerminatedEvent(PKinesisVideoStream pKinesisVideoStream, UPLOAD_HAN
     CHK(pKinesisVideoStream != NULL && pKinesisVideoStream->pKinesisVideoClient != NULL, STATUS_NULL_ARG);
     pKinesisVideoClient = pKinesisVideoStream->pKinesisVideoClient;
 
+    // Report permission errors to the registered stream error handlers
+    // PIC state machine will still retry but application must be informed to handle the error appropriately.
+    if (callResult == SERVICE_CALL_FORBIDDEN || callResult == SERVICE_CALL_NOT_AUTHORIZED) {
+        DLOGE("[%s] Stream terminated with authorization error (result=%u). Notifying application.", pKinesisVideoStream->streamInfo.name, callResult);
+        if (pKinesisVideoClient->clientCallbacks.streamErrorReportFn != NULL) {
+            pKinesisVideoClient->clientCallbacks.streamErrorReportFn(pKinesisVideoClient->clientCallbacks.customData,
+                                                                     TO_STREAM_HANDLE(pKinesisVideoStream), uploadHandle, 0,
+                                                                     STATUS_SERVICE_CALL_NOT_AUTHORIZED_ERROR);
+        }
+    }
+
     // Lock the state
     pKinesisVideoClient->clientCallbacks.lockMutexFn(pKinesisVideoClient->clientCallbacks.customData, pKinesisVideoStream->base.lock);
     locked = TRUE;

--- a/src/client/src/StreamEvent.c
+++ b/src/client/src/StreamEvent.c
@@ -658,7 +658,8 @@ STATUS streamTerminatedEvent(PKinesisVideoStream pKinesisVideoStream, UPLOAD_HAN
     // Report permission errors to the registered stream error handlers
     // PIC state machine will still retry but application must be informed to handle the error appropriately.
     if (callResult == SERVICE_CALL_FORBIDDEN || callResult == SERVICE_CALL_NOT_AUTHORIZED) {
-        DLOGE("[%s] Stream terminated with authorization error (result=%u). Notifying application.", pKinesisVideoStream->streamInfo.name, callResult);
+        DLOGE("[%s] Stream terminated with authorization error (result=%u). Notifying application.", pKinesisVideoStream->streamInfo.name,
+              callResult);
         if (pKinesisVideoClient->clientCallbacks.streamErrorReportFn != NULL) {
             pKinesisVideoClient->clientCallbacks.streamErrorReportFn(pKinesisVideoClient->clientCallbacks.customData,
                                                                      TO_STREAM_HANDLE(pKinesisVideoStream), uploadHandle, 0,

--- a/tst/client/StreamApiFunctionalityTest.cpp
+++ b/tst/client/StreamApiFunctionalityTest.cpp
@@ -1175,6 +1175,146 @@ TEST_F(StreamApiFunctionalityTest, putFrame_PutGetRestartUnauthorizedResult)
     EXPECT_EQ(2, ATOMIC_LOAD(&mGetStreamingTokenFuncCount));
 }
 
+TEST_F(StreamApiFunctionalityTest, streamTerminated_ForbiddenReportsErrorToApplication)
+{
+    UINT32 i, filledSize;
+    BYTE tempBuffer[10000];
+    BYTE getDataBuffer[20000];
+    UINT64 timestamp;
+    Frame frame;
+
+    mStreamInfo.streamCaps.recoverOnError = TRUE;
+
+    // Create and ready a stream
+    ReadyStream();
+
+    frame.duration = TEST_LONG_FRAME_DURATION;
+    frame.size = SIZEOF(tempBuffer);
+    frame.frameData = tempBuffer;
+    frame.trackId = TEST_TRACKID;
+    for (i = 0, timestamp = 0; timestamp < TEST_BUFFER_DURATION; timestamp += TEST_LONG_FRAME_DURATION, i++) {
+        frame.index = i;
+        frame.decodingTs = timestamp;
+        frame.presentationTs = timestamp;
+
+        frame.flags = i % 10 == 0 ? FRAME_FLAG_KEY_FRAME : FRAME_FLAG_NONE;
+        EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(mStreamHandle, &frame));
+
+        EXPECT_EQ(1, ATOMIC_LOAD(&mPutStreamFuncCount));
+
+        if (i == 50) {
+            EXPECT_EQ(STATUS_SUCCESS, putStreamResultEvent(mCallContext.customData, SERVICE_CALL_RESULT_OK, TEST_UPLOAD_HANDLE));
+        }
+    }
+
+    for (timestamp = 0; timestamp < TEST_BUFFER_DURATION / 2; timestamp += TEST_LONG_FRAME_DURATION) {
+        EXPECT_EQ(STATUS_SUCCESS, getKinesisVideoStreamData(mStreamHandle, TEST_UPLOAD_HANDLE, getDataBuffer, SIZEOF(getDataBuffer), &filledSize));
+        EXPECT_EQ(SIZEOF(getDataBuffer), filledSize);
+    }
+
+    // Verify streamErrorReportFn not called yet
+    EXPECT_EQ(0, ATOMIC_LOAD(&mStreamErrorReportFuncCount));
+
+    // Simulate PutMedia returning 403 Forbidden
+    EXPECT_EQ(STATUS_SUCCESS, kinesisVideoStreamTerminated(mCallContext.customData, TEST_UPLOAD_HANDLE, SERVICE_CALL_FORBIDDEN));
+
+    // Verify streamErrorReportFn was called with the correct status
+    EXPECT_EQ(1, ATOMIC_LOAD(&mStreamErrorReportFuncCount));
+    EXPECT_EQ(STATUS_SERVICE_CALL_NOT_AUTHORIZED_ERROR, mStatus);
+}
+
+TEST_F(StreamApiFunctionalityTest, streamTerminated_NotAuthorizedReportsErrorToApplication)
+{
+    UINT32 i, filledSize;
+    BYTE tempBuffer[10000];
+    BYTE getDataBuffer[20000];
+    UINT64 timestamp;
+    Frame frame;
+
+    mStreamInfo.streamCaps.recoverOnError = TRUE;
+
+    // Create and ready a stream
+    ReadyStream();
+
+    frame.duration = TEST_LONG_FRAME_DURATION;
+    frame.size = SIZEOF(tempBuffer);
+    frame.frameData = tempBuffer;
+    frame.trackId = TEST_TRACKID;
+    for (i = 0, timestamp = 0; timestamp < TEST_BUFFER_DURATION; timestamp += TEST_LONG_FRAME_DURATION, i++) {
+        frame.index = i;
+        frame.decodingTs = timestamp;
+        frame.presentationTs = timestamp;
+
+        frame.flags = i % 10 == 0 ? FRAME_FLAG_KEY_FRAME : FRAME_FLAG_NONE;
+        EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(mStreamHandle, &frame));
+
+        EXPECT_EQ(1, ATOMIC_LOAD(&mPutStreamFuncCount));
+
+        if (i == 50) {
+            EXPECT_EQ(STATUS_SUCCESS, putStreamResultEvent(mCallContext.customData, SERVICE_CALL_RESULT_OK, TEST_UPLOAD_HANDLE));
+        }
+    }
+
+    for (timestamp = 0; timestamp < TEST_BUFFER_DURATION / 2; timestamp += TEST_LONG_FRAME_DURATION) {
+        EXPECT_EQ(STATUS_SUCCESS, getKinesisVideoStreamData(mStreamHandle, TEST_UPLOAD_HANDLE, getDataBuffer, SIZEOF(getDataBuffer), &filledSize));
+        EXPECT_EQ(SIZEOF(getDataBuffer), filledSize);
+    }
+
+    // Verify streamErrorReportFn not called yet
+    EXPECT_EQ(0, ATOMIC_LOAD(&mStreamErrorReportFuncCount));
+
+    // Simulate PutMedia returning 401 Not Authorized
+    EXPECT_EQ(STATUS_SUCCESS, kinesisVideoStreamTerminated(mCallContext.customData, TEST_UPLOAD_HANDLE, SERVICE_CALL_NOT_AUTHORIZED));
+
+    // Verify streamErrorReportFn was called with the correct status
+    EXPECT_EQ(1, ATOMIC_LOAD(&mStreamErrorReportFuncCount));
+    EXPECT_EQ(STATUS_SERVICE_CALL_NOT_AUTHORIZED_ERROR, mStatus);
+}
+
+TEST_F(StreamApiFunctionalityTest, streamTerminated_OtherErrorDoesNotReportToApplication)
+{
+    UINT32 i, filledSize;
+    BYTE tempBuffer[10000];
+    BYTE getDataBuffer[20000];
+    UINT64 timestamp;
+    Frame frame;
+
+    mStreamInfo.streamCaps.recoverOnError = TRUE;
+
+    // Create and ready a stream
+    ReadyStream();
+
+    frame.duration = TEST_LONG_FRAME_DURATION;
+    frame.size = SIZEOF(tempBuffer);
+    frame.frameData = tempBuffer;
+    frame.trackId = TEST_TRACKID;
+    for (i = 0, timestamp = 0; timestamp < TEST_BUFFER_DURATION; timestamp += TEST_LONG_FRAME_DURATION, i++) {
+        frame.index = i;
+        frame.decodingTs = timestamp;
+        frame.presentationTs = timestamp;
+
+        frame.flags = i % 10 == 0 ? FRAME_FLAG_KEY_FRAME : FRAME_FLAG_NONE;
+        EXPECT_EQ(STATUS_SUCCESS, putKinesisVideoFrame(mStreamHandle, &frame));
+
+        EXPECT_EQ(1, ATOMIC_LOAD(&mPutStreamFuncCount));
+
+        if (i == 50) {
+            EXPECT_EQ(STATUS_SUCCESS, putStreamResultEvent(mCallContext.customData, SERVICE_CALL_RESULT_OK, TEST_UPLOAD_HANDLE));
+        }
+    }
+
+    for (timestamp = 0; timestamp < TEST_BUFFER_DURATION / 2; timestamp += TEST_LONG_FRAME_DURATION) {
+        EXPECT_EQ(STATUS_SUCCESS, getKinesisVideoStreamData(mStreamHandle, TEST_UPLOAD_HANDLE, getDataBuffer, SIZEOF(getDataBuffer), &filledSize));
+        EXPECT_EQ(SIZEOF(getDataBuffer), filledSize);
+    }
+
+    // Simulate a different error (e.g., 500 Internal Server Error) — should NOT call streamErrorReportFn
+    EXPECT_EQ(STATUS_SUCCESS, kinesisVideoStreamTerminated(mCallContext.customData, TEST_UPLOAD_HANDLE, SERVICE_CALL_INTERNAL_ERROR));
+
+    // Verify streamErrorReportFn was NOT called for non-auth errors
+    EXPECT_EQ(0, ATOMIC_LOAD(&mStreamErrorReportFuncCount));
+}
+
 TEST_F(StreamApiFunctionalityTest, putFrame_PutGetRestartOtherResult)
 {
     UINT32 i, filledSize;


### PR DESCRIPTION
*Issue #, if available:*

- N/A

*What was changed?*

- In `streamTerminatedEvent()`, added a call to `streamErrorReportFn` when the call result is `SERVICE_CALL_FORBIDDEN` (403) or `SERVICE_CALL_NOT_AUTHORIZED` (401).

*Why was it changed?*

- When PutMedia returns HTTP 403 (e.g., IAM role lacks `kinesisvideo:PutMedia` permission), the error was never reported to the application. `streamTerminatedEvent` only drove the state machine retry cycle — it never invoked `streamErrorReportFn`. This meant:
  - The application's error handler (e.g., kvssink's `streamErrorReportHandler`) was never called
  - The application had no way to detect or react to a permanent permission failure
  - The state machine retried infinitely without the caller knowing why
- We still keep the PIC behavior of retrying indefinitely on this error unchanged, while providing a way to registered handlers to do something about the permission error (reset stream, stop pipeline etc).
*How was it changed?*

- Added a check at the top of `streamTerminatedEvent()` (before the state lock is acquired) that detects 403/401 call results and invokes `streamErrorReportFn` with `STATUS_SERVICE_CALL_NOT_AUTHORIZED_ERROR`.
- The state machine continues to retry (with backoff). This change only adds notification, it does not alter the retry behavior. The application can choose to stop the stream or log the error based on its own policy.
- The notification is placed before the lock intentionally as callbacks must not block while holding the stream mutex.

*What testing was done for the changes?*

- Unit tests pass (existing `StreamApiFunctionalityTest` suite)
- End to end manual test: removed PutMedia permission from IAM role, verified `streamErrorReportFn` is called with `STATUS_SERVICE_CALL_NOT_AUTHORIZED_ERROR` on first 403
- Verified the callback chain: ContinuousRetryHandler passes through (returns SUCCESS), application handler receives the error
- Verified no behavior change for other error types (500, timeouts still retry normally)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.