### PR TITLE
Updated pr-desc-lint to bind github.event.pull_request.number via env

### DIFF
--- a/.github/workflows/pr-desc-lint.yml
+++ b/.github/workflows/pr-desc-lint.yml
@@ -22,8 +22,9 @@ jobs:
       - name: Check PR Description
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          pr_link="https://github.com/${GITHUB_REPOSITORY}/pull/${{ github.event.pull_request.number }}"
+          pr_link="https://github.com/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}"
           
           echo "$pr_link"
           


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- PR description workflow

*Why was it changed?*
- To follow GitHub Secure Use practices: https://docs.github.com/en/actions/reference/security/secure-use#good-practices-for-mitigating-script-injection-attacks

*How was it changed?*
- Made PR Number a environment variable

*What testing was done for the changes?*
- PR Description Workflow should run properly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
